### PR TITLE
feat(easylog): add interface and log entry skeleton

### DIFF
--- a/src/EasyLog/EasyLog.csproj
+++ b/src/EasyLog/EasyLog.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>EasyLog</RootNamespace>
+    <AssemblyName>EasyLog</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>1.0.0</Version>
+    <Description>Daily JSON logger reusable across ProSoft applications.</Description>
+  </PropertyGroup>
+
+</Project>

--- a/src/EasyLog/IDailyLogger.cs
+++ b/src/EasyLog/IDailyLogger.cs
@@ -1,0 +1,17 @@
+namespace EasyLog;
+
+/// <summary>
+/// Appends log entries to a daily log file.
+/// Designed to be reusable across multiple ProSoft applications.
+/// Implementations must be thread-safe and must preserve the v1.0
+/// contract for backward compatibility with existing consumers.
+/// </summary>
+public interface IDailyLogger
+{
+    /// <summary>
+    /// Appends a single log entry to the current day log file.
+    /// A new file is created automatically when the date changes.
+    /// </summary>
+    /// <param name="entry">The log entry to append. Must not be null.</param>
+    void Append(LogEntry entry);
+}

--- a/src/EasyLog/LogEntry.cs
+++ b/src/EasyLog/LogEntry.cs
@@ -1,0 +1,40 @@
+namespace EasyLog;
+
+/// <summary>
+/// Represents a single operation recorded during a backup job.
+/// The field set matches the minimum contract required by EasySave v1.0
+/// and must remain backward compatible with future revisions.
+/// </summary>
+public sealed class LogEntry
+{
+    /// <summary>
+    /// ISO-8601 timestamp of the logged action.
+    /// </summary>
+    public string Timestamp { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Name of the backup job that produced this entry.
+    /// </summary>
+    public string JobName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Full source path in UNC format (e.g. \\server\share\file.txt).
+    /// </summary>
+    public string SourceFile { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Full target path in UNC format.
+    /// </summary>
+    public string TargetFile { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Size of the source file in bytes.
+    /// </summary>
+    public long FileSize { get; set; }
+
+    /// <summary>
+    /// File transfer duration in milliseconds.
+    /// A negative value indicates a transfer error.
+    /// </summary>
+    public long FileTransferTimeMs { get; set; }
+}


### PR DESCRIPTION
Phase 2 skeletons for Dev 1 zone (EasyLog DLL).

## Scope
- Add EasyLog class library project (net8.0, nullable enable, XML docs)
- Add IDailyLogger public interface
- Add LogEntry model with all fields required by EasySave v1.0

## Notes
- Only touches src/EasyLog/ — no impact on EasySave.sln or src/EasySave/
- Interface signature is stable for v1.0 backward compatibility
- UNC path format documented on source/target fields
- Negative FileTransferTimeMs documented as the error signal

## ClickUp tasks covered
- [Dev1] Interface IDailyLogger
- [Dev1] POCO LogEntry
- [Dev1] Classe JsonDailyLogger vide (partial: csproj in place)

## Checks
- dotnet build src/EasyLog/EasyLog.csproj -> success, 0 warning, 0 error