### PR TITLE
feat(easylog): implement JsonDailyLogger

### DIFF
--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+
+namespace EasyLog;
+
+/// <summary>
+/// Writes <see cref="LogEntry"/> instances to a daily JSON file
+/// named "yyyy-MM-dd.json" inside a configurable directory.
+/// Each file contains a JSON array of entries appended over the day.
+/// Writes are serialized with a lock to stay safe under concurrent calls.
+/// </summary>
+public sealed class JsonDailyLogger : IDailyLogger
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _logDirectory;
+    private readonly object _writeLock = new();
+
+    /// <summary>
+    /// Initializes a new logger writing to <paramref name="logDirectory"/>.
+    /// The directory is created if it does not exist.
+    /// </summary>
+    /// <param name="logDirectory">Absolute or UNC path where daily files are stored.</param>
+    /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
+    public JsonDailyLogger(string logDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(logDirectory))
+        {
+            throw new ArgumentException("Log directory must be provided.", nameof(logDirectory));
+        }
+
+        _logDirectory = logDirectory;
+        Directory.CreateDirectory(_logDirectory);
+    }
+
+    /// <summary>
+    /// Absolute path of the directory where daily log files are written.
+    /// </summary>
+    public string LogDirectory => _logDirectory;
+
+    /// <inheritdoc />
+    public void Append(LogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        string filePath = Path.Combine(_logDirectory, $"{DateTime.Now:yyyy-MM-dd}.json");
+
+        lock (_writeLock)
+        {
+            List<LogEntry> entries = ReadExisting(filePath);
+            entries.Add(entry);
+            File.WriteAllText(filePath, JsonSerializer.Serialize(entries, SerializerOptions));
+        }
+    }
+
+    private static List<LogEntry> ReadExisting(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return new List<LogEntry>();
+        }
+
+        string raw = File.ReadAllText(filePath);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return new List<LogEntry>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<LogEntry>>(raw) ?? new List<LogEntry>();
+        }
+        catch (JsonException)
+        {
+            // File exists but is corrupted; start a fresh list rather than crashing the backup.
+            return new List<LogEntry>();
+        }
+    }
+}

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 
 namespace EasyLog;
@@ -6,7 +7,10 @@ namespace EasyLog;
 /// Writes <see cref="LogEntry"/> instances to a daily JSON file
 /// named "yyyy-MM-dd.json" inside a configurable directory.
 /// Each file contains a JSON array of entries appended over the day.
-/// Writes are serialized with a lock to stay safe under concurrent calls.
+/// Writes are serialized with a lock to stay safe under concurrent calls
+/// and performed atomically via a temporary file to avoid partial writes.
+/// Note: each append rewrites the whole day file (O(n) on the daily count);
+/// this is acceptable for v1.0 volumes and can be revisited later if needed.
 /// </summary>
 public sealed class JsonDailyLogger : IDailyLogger
 {
@@ -45,14 +49,26 @@ public sealed class JsonDailyLogger : IDailyLogger
     {
         ArgumentNullException.ThrowIfNull(entry);
 
+        // Local date is intentional: daily files must align with the business day
+        // seen by the operator, not UTC.
         string filePath = Path.Combine(_logDirectory, $"{DateTime.Now:yyyy-MM-dd}.json");
 
         lock (_writeLock)
         {
             List<LogEntry> entries = ReadExisting(filePath);
             entries.Add(entry);
-            File.WriteAllText(filePath, JsonSerializer.Serialize(entries, SerializerOptions));
+            WriteAtomic(filePath, entries);
         }
+    }
+
+    private static void WriteAtomic(string filePath, List<LogEntry> entries)
+    {
+        // Write to a side file first, then move it over the target path.
+        // A same-volume File.Move with overwrite is atomic on NTFS and POSIX,
+        // so a process kill mid-write never leaves a half-written log.
+        string tmpPath = filePath + ".tmp";
+        File.WriteAllText(tmpPath, JsonSerializer.Serialize(entries, SerializerOptions));
+        File.Move(tmpPath, filePath, overwrite: true);
     }
 
     private static List<LogEntry> ReadExisting(string filePath)
@@ -72,9 +88,11 @@ public sealed class JsonDailyLogger : IDailyLogger
         {
             return JsonSerializer.Deserialize<List<LogEntry>>(raw) ?? new List<LogEntry>();
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            // File exists but is corrupted; start a fresh list rather than crashing the backup.
+            // Corrupted file: surface a warning so an incident can be diagnosed,
+            // then start fresh rather than crashing the backup job.
+            Trace.TraceWarning($"[EasyLog] Corrupted log file discarded: {filePath} - {ex.Message}");
             return new List<LogEntry>();
         }
     }


### PR DESCRIPTION
Phase 3 implementation for Dev 1 zone (EasyLog DLL).

## Scope
- Implement `JsonDailyLogger.Append` writing to `<logDir>/yyyy-MM-dd.json`
- Configurable log directory passed via constructor (no hardcoded `C:\temp\`)
- Directory created automatically on first use
- JSON output indented with line breaks between entries (cahier requirement)
- Thread-safe via `lock` — safe under concurrent backup jobs
- Tolerant of corrupted existing file (starts fresh instead of crashing)

## Cahier requirements covered
- Real-time append
- Daily file name `YYYY-MM-DD.json`
- Indented JSON
- UNC path format preserved (strings are not transformed)
- Negative `FileTransferTimeMs` flows through for errors

## Smoke test locally
```
2026-04-17.json created, two entries, UNC paths kept, size=0/time=-1 entry round-trips correctly.
```

## Depends on
PR #7 — interface + LogEntry already on staging.

## ClickUp
Covers: [Dev1] JsonDailyLogger.Append écrit Logs/YYYY-MM-DD.json (Phase 3, high)