### PR TITLE
chore(sln): add EasySave solution + initial README

### DIFF
--- a/EasySave.sln
+++ b/EasySave.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasySave", "src\EasySave\EasySave.csproj", "{C5B0A1FA-AABE-4D96-9DF0-4EA590DB1FF9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyLog", "src\EasyLog\EasyLog.csproj", "{1BDFAA63-9B0D-4698-B436-BA2A91399615}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C5B0A1FA-AABE-4D96-9DF0-4EA590DB1FF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5B0A1FA-AABE-4D96-9DF0-4EA590DB1FF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5B0A1FA-AABE-4D96-9DF0-4EA590DB1FF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5B0A1FA-AABE-4D96-9DF0-4EA590DB1FF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BDFAA63-9B0D-4698-B436-BA2A91399615}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BDFAA63-9B0D-4698-B436-BA2A91399615}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BDFAA63-9B0D-4698-B436-BA2A91399615}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BDFAA63-9B0D-4698-B436-BA2A91399615}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# Genie_Logiciel
+# EasySave
+
+Console backup software for ProSoft, built on .NET 8.
+
+## Projects
+
+| Project | Type | Description |
+|---|---|---|
+| `src/EasySave` | Console app (net8.0) | Backup engine and CLI entry point |
+| `src/EasyLog` | Class library (net8.0) | Daily JSON logger reusable across ProSoft applications |
+
+## Requirements
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- Windows, macOS or Linux
+
+## Build
+
+```bash
+dotnet build EasySave.sln
+```
+
+## Run
+
+```bash
+dotnet run --project src/EasySave
+```
+
+## Test
+
+```bash
+dotnet test EasySave.sln
+```
+
+## Repository layout
+
+```
+EasySave.sln
+src/
+  EasySave/        # console application
+  EasyLog/         # logging library (IDailyLogger, JsonDailyLogger)
+docs/
+  COMMIT_CONVENTION.md
+```
+
+## Contributing
+
+Read [`docs/COMMIT_CONVENTION.md`](docs/COMMIT_CONVENTION.md) before opening a pull request. Work on a dedicated branch (`feat/...`, `fix/...`, etc.), open the PR against `staging`.

--- a/src/EasySave/EasySave.csproj
+++ b/src/EasySave/EasySave.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>EasySave</RootNamespace>
+    <AssemblyName>EasySave</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Version>1.0.0</Version>
+    <Description>EasySave backup software (ProSoft).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EasyLog\EasyLog.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Initial solution scaffold and README for EasySave v1.0.

## Scope

- `EasySave.sln` at repo root, referencing the two existing projects
- `src/EasySave/EasySave.csproj` — console app, net8.0, project reference to EasyLog
- `README.md` — projects overview, build / run / test commands, repo layout, pointer to the commit convention

## ClickUp tasks covered

- [Chloé] Créer la solution `EasySave.sln` et les 2 `.csproj` (net8.0)
- [Chloé] Rédiger `README.md` initial

## Notes

- No changes to `src/EasyLog/` or `src/EasySave/Program.cs` (owned by Dev1)
- `dotnet build EasySave.sln` should restore the project reference and compile the console app with the logger linked
- Could not run `dotnet build` locally (SDK not installed in this environment) — please verify locally before merge