### PR TITLE
fix(easylog): prevent tmp file collision and cleanup on error

### DIFF
--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -69,7 +69,7 @@ public sealed class JsonDailyLogger : IDailyLogger
             File.WriteAllText(tmpPath, JsonSerializer.Serialize(entries, SerializerOptions));
             File.Move(tmpPath, filePath, overwrite: true);
         }
-        catch
+    catch (Exception)
         {
             try { File.Delete(tmpPath); } catch { }
             throw;

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -63,12 +63,17 @@ public sealed class JsonDailyLogger : IDailyLogger
 
     private static void WriteAtomic(string filePath, List<LogEntry> entries)
     {
-        // Write to a side file first, then move it over the target path.
-        // A same-volume File.Move with overwrite is atomic on NTFS and POSIX,
-        // so a process kill mid-write never leaves a half-written log.
-        string tmpPath = filePath + ".tmp";
-        File.WriteAllText(tmpPath, JsonSerializer.Serialize(entries, SerializerOptions));
-        File.Move(tmpPath, filePath, overwrite: true);
+        string tmpPath = $"{filePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(tmpPath, JsonSerializer.Serialize(entries, SerializerOptions));
+            File.Move(tmpPath, filePath, overwrite: true);
+        }
+        catch
+        {
+            try { File.Delete(tmpPath); } catch { }
+            throw;
+        }
     }
 
     private static List<LogEntry> ReadExisting(string filePath)


### PR DESCRIPTION
## Summary
Fix for the two issues raised in #24:
- Concurrent writers no longer share the same `.tmp` side file (GUID suffix)
- Failed writes no longer leave orphaned `.tmp` files in the log directory (best-effort cleanup)

## Behavior unchanged
- `File.Move(overwrite: true)` kept — atomicity preserved
- `IDailyLogger` public contract untouched
- File content / format unchanged

## Local checks
- `dotnet build src/EasyLog/EasyLog.csproj --warnaserror` → 0 warning, 0 error
- Smoke test: file written, no `.tmp` residue

Closes #24