### PR TITLE
style(easylog): fix catch indentation

### DIFF
--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -69,7 +69,7 @@ public sealed class JsonDailyLogger : IDailyLogger
             File.WriteAllText(tmpPath, JsonSerializer.Serialize(entries, SerializerOptions));
             File.Move(tmpPath, filePath, overwrite: true);
         }
-    catch (Exception)
+        catch (Exception)
         {
             try { File.Delete(tmpPath); } catch { }
             throw;


### PR DESCRIPTION
## Why
The CI `Format check` job on staging is red because the squash merge of #27 landed with the `catch (Exception)` line indented at 4 spaces instead of 8.

## Fix
Single-line indentation correction produced by `dotnet format`.

## Local checks
- `dotnet format EasySave.sln --verify-no-changes --severity warn` → passes
- `dotnet build EasySave.sln --warnaserror` → 0 warning, 0 error