### PR TITLE
feat(state): add StateTracker singleton skeleton

### DIFF
--- a/src/EasySave/StateTracker.cs
+++ b/src/EasySave/StateTracker.cs
@@ -1,0 +1,21 @@
+namespace EasySave;
+
+// Singleton that tracks the real-time state of every backup job.
+// Sits in the Model layer, ready to be observed by any View or ViewModel.
+public sealed class StateTracker
+{
+    // Lazy, thread-safe singleton instance.
+    private static readonly Lazy<StateTracker> _instance = new(() => new StateTracker());
+    public static StateTracker Instance => _instance.Value;
+
+    // In-memory store, keyed by job name (unique per workspace).
+    private readonly Dictionary<string, StateEntry> _entries = new();
+
+    private StateTracker() { }
+
+    // Inserts or replaces the snapshot for a job, then persists the full state.
+    public void Update(StateEntry entry)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/EasySave/StateTracker.cs
+++ b/src/EasySave/StateTracker.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace EasySave;
 
 // Singleton that tracks the real-time state of every backup job.
@@ -9,13 +11,15 @@ public sealed class StateTracker
     public static StateTracker Instance => _instance.Value;
 
     // In-memory store, keyed by job name (unique per workspace).
-    private readonly Dictionary<string, StateEntry> _entries = new();
+    // Concurrent so multiple backup managers can update safely in parallel.
+    private readonly ConcurrentDictionary<string, StateEntry> _entries = new();
 
     private StateTracker() { }
 
     // Inserts or replaces the snapshot for a job, then persists the full state.
     public void Update(StateEntry entry)
     {
+        ArgumentNullException.ThrowIfNull(entry);
         throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Introduces the `StateTracker` class, central point for real-time backup job state.

- Singleton (lazy, thread-safe) so every BackupManager shares the same in-memory store.
- Private constructor + sealed class to enforce the pattern.
- Internal `Dictionary<string, StateEntry>` keyed by job name.
- `Update(StateEntry)` skeleton throws `NotImplementedException`; real persistence and observer wiring land in the next task.