### PR TITLE
feat(state): add JobRepository singleton skeleton

### DIFF
--- a/src/EasySave/JobRepository.cs
+++ b/src/EasySave/JobRepository.cs
@@ -12,7 +12,7 @@ public sealed class JobRepository
     private JobRepository() { }
 
     // Loads the persisted list of backup jobs from disk.
-    public List<BackupJob> Load()
+    public IReadOnlyList<BackupJob> Load()
     {
         throw new NotImplementedException();
     }

--- a/src/EasySave/JobRepository.cs
+++ b/src/EasySave/JobRepository.cs
@@ -1,0 +1,26 @@
+using EasySave.Models;
+
+namespace EasySave;
+
+// Singleton repository that persists the list of user-defined backup jobs.
+public sealed class JobRepository
+{
+    // Lazy, thread-safe singleton instance.
+    private static readonly Lazy<JobRepository> _instance = new(() => new JobRepository());
+    public static JobRepository Instance => _instance.Value;
+
+    private JobRepository() { }
+
+    // Loads the persisted list of backup jobs from disk.
+    public List<BackupJob> Load()
+    {
+        throw new NotImplementedException();
+    }
+
+    // Persists the given list of backup jobs to disk.
+    public void Save(IReadOnlyList<BackupJob> jobs)
+    {
+        ArgumentNullException.ThrowIfNull(jobs);
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Introduces the `JobRepository` class responsible for persisting user-defined backup jobs.

- Singleton (lazy, thread-safe) so every consumer shares the same persistence entry point.
- Private constructor + sealed class to enforce the pattern.
- `Load()` skeleton returning a `List<BackupJob>`; throws `NotImplementedException`.
- `Save(IReadOnlyList<BackupJob>)` skeleton with null guard; throws `NotImplementedException`.

Real persistence lands in the next task.