### PR TITLE
feat(config): add AppConfig singleton and appsettings.json

### DIFF
--- a/src/EasySave/EasySave.csproj
+++ b/src/EasySave/EasySave.csproj
@@ -11,4 +11,10 @@
     <ProjectReference Include="..\EasyLog\EasyLog.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -1,1 +1,5 @@
+using EasySave.Services;
+
+AppConfig.Load();
+
 Console.WriteLine("Hello EasySave");

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+
+namespace EasySave.Services;
+
+// Singleton holding the application configuration loaded from appsettings.json.
+// Any service that needs a file path or a user-facing setting reads from AppConfig.Instance.
+public sealed class AppConfig
+{
+    // Current configuration. Replaced once at startup by Load().
+    public static AppConfig Instance { get; private set; } = new AppConfig();
+
+    // Directory where daily log files are written.
+    public string LogDirectory { get; set; } = "data/logs";
+
+    // Full path of the real-time state file.
+    public string StateFilePath { get; set; } = "data/state.json";
+
+    // Full path of the backup jobs definitions file.
+    public string JobsFilePath { get; set; } = "data/jobs.json";
+
+    // UI language code (ISO 639-1), e.g. "en" or "fr".
+    public string Language { get; set; } = "en";
+
+    // Loads the configuration from the given JSON file, or keeps the defaults if the file is missing or invalid.
+    public static void Load(string path = "appsettings.json")
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (!File.Exists(path))
+        {
+            Instance = new AppConfig();
+            return;
+        }
+
+        var json = File.ReadAllText(path);
+        Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+    }
+}

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace EasySave.Services;
 
@@ -9,17 +10,20 @@ public sealed class AppConfig
     // Current configuration. Replaced once at startup by Load().
     public static AppConfig Instance { get; private set; } = new AppConfig();
 
-    // Directory where daily log files are written.
-    public string LogDirectory { get; set; } = "data/logs";
+    // Directory where daily log files are written. Anchored to the executable directory.
+    public string LogDirectory { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "logs");
 
-    // Full path of the real-time state file.
-    public string StateFilePath { get; set; } = "data/state.json";
+    // Full path of the real-time state file. Anchored to the executable directory.
+    public string StateFilePath { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "state.json");
 
-    // Full path of the backup jobs definitions file.
-    public string JobsFilePath { get; set; } = "data/jobs.json";
+    // Full path of the backup jobs definitions file. Anchored to the executable directory.
+    public string JobsFilePath { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "jobs.json");
 
     // UI language code (ISO 639-1), e.g. "en" or "fr".
-    public string Language { get; set; } = "en";
+    public string Language { get; init; } = "en";
+
+    [JsonConstructor]
+    private AppConfig() { }
 
     // Loads the configuration from the given JSON file, or keeps the defaults if the file is missing or invalid.
     public static void Load(string path = "appsettings.json")
@@ -32,7 +36,14 @@ public sealed class AppConfig
             return;
         }
 
-        var json = File.ReadAllText(path);
-        Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+        try
+        {
+            var json = File.ReadAllText(path);
+            Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+        }
+        catch (JsonException)
+        {
+            Instance = new AppConfig();
+        }
     }
 }

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -26,9 +26,10 @@ public sealed class AppConfig
     private AppConfig() { }
 
     // Loads the configuration from the given JSON file, or keeps the defaults if the file is missing or invalid.
-    public static void Load(string path = "appsettings.json")
+    // When path is null, appsettings.json is read from the executable directory.
+    public static void Load(string? path = null)
     {
-        ArgumentNullException.ThrowIfNull(path);
+        path ??= Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
 
         if (!File.Exists(path))
         {

--- a/src/EasySave/appsettings.json
+++ b/src/EasySave/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "LogDirectory": "data/logs",
+  "StateFilePath": "data/state.json",
+  "JobsFilePath": "data/jobs.json",
+  "Language": "en"
+}

--- a/src/EasySave/appsettings.json
+++ b/src/EasySave/appsettings.json
@@ -1,6 +1,3 @@
 {
-  "LogDirectory": "data/logs",
-  "StateFilePath": "data/state.json",
-  "JobsFilePath": "data/jobs.json",
   "Language": "en"
 }


### PR DESCRIPTION
Implements the configurable file locations required by the v1.0 spec (no more `C:\temp`).

- `src/EasySave/Services/AppConfig.cs` — singleton holding the 3 file paths (`LogDirectory`, `StateFilePath`, `JobsFilePath`) and the UI `Language`. Defaults live under `data/` relative to the exe.
- `src/EasySave/appsettings.json` — ships with the defaults; clients override without recompiling.
- `EasySave.csproj` — `appsettings.json` copied to the output directory (`PreserveNewest`).
- `Program.cs` — `AppConfig.Load()` runs at startup.

Consumers (StateTracker, JobRepository, EasyLog) will pick up `AppConfig.Instance.*` in later tasks.