### PR TITLE
feat(backup): implement ExecuteJob with recursive copy, logging and state tracking

### DIFF
--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -1,9 +1,10 @@
+using System.Diagnostics;
 using EasyLog;
 using EasySave.Models;
 
 namespace EasySave.Services;
 
-// Manages backup jobs. Stubs only — implementation in Phase 3.
+// Manages backup jobs: CRUD + execution with logging and state tracking.
 public class BackupManager
 {
     private readonly IDailyLogger _logger;
@@ -38,7 +39,107 @@ public class BackupManager
 
     public IReadOnlyList<BackupJob> ListJobs() => throw new NotImplementedException();
 
-    public void ExecuteJob(string name) => throw new NotImplementedException();
+    public void ExecuteJob(string name)
+    {
+        var jobs = _jobRepository.Load();
+        var job = jobs.FirstOrDefault(j => j.Name == name)
+            ?? throw new InvalidOperationException($"Job '{name}' not found.");
+
+        var strategy = job.Type == BackupType.Full ? _fullStrategy : _diffStrategy;
+        var sourceDir = new DirectoryInfo(job.SourcePath);
+
+        if (!sourceDir.Exists)
+            throw new DirectoryNotFoundException($"Source directory not found: {job.SourcePath}");
+
+        var allFiles = sourceDir.EnumerateFiles("*", SearchOption.AllDirectories).ToList();
+        var filesToCopy = allFiles
+            .Where(f => strategy.ShouldCopy(f, BuildTargetPath(f, sourceDir, job.TargetPath)))
+            .ToList();
+
+        int totalFiles = filesToCopy.Count;
+        long totalSize = filesToCopy.Sum(f => f.Length);
+
+        _stateTracker.Update(new StateEntry
+        {
+            Name = job.Name,
+            LastActionTime = DateTimeOffset.Now,
+            State = JobState.Active,
+            TotalFilesEligible = totalFiles,
+            TotalSize = totalSize,
+            FilesRemaining = totalFiles,
+            SizeRemaining = totalSize,
+        });
+
+        int filesProcessed = 0;
+        long sizeProcessed = 0;
+
+        foreach (var file in filesToCopy)
+        {
+            string targetPath = BuildTargetPath(file, sourceDir, job.TargetPath);
+
+            _stateTracker.Update(new StateEntry
+            {
+                Name = job.Name,
+                LastActionTime = DateTimeOffset.Now,
+                State = JobState.Active,
+                TotalFilesEligible = totalFiles,
+                TotalSize = totalSize,
+                FilesRemaining = totalFiles - filesProcessed,
+                SizeRemaining = totalSize - sizeProcessed,
+                CurrentSource = file.FullName,
+                CurrentTarget = targetPath,
+            });
+
+            long transferTimeMs;
+            var sw = Stopwatch.StartNew();
+
+            try
+            {
+                string? targetDir = Path.GetDirectoryName(targetPath);
+                if (!string.IsNullOrEmpty(targetDir))
+                    Directory.CreateDirectory(targetDir);
+
+                File.Copy(file.FullName, targetPath, overwrite: true);
+                sw.Stop();
+                transferTimeMs = sw.ElapsedMilliseconds;
+            }
+            catch
+            {
+                sw.Stop();
+                transferTimeMs = -1;
+            }
+
+            _logger.Append(new LogEntry
+            {
+                Timestamp = DateTimeOffset.Now.ToString("o"),
+                JobName = job.Name,
+                SourceFile = file.FullName,
+                TargetFile = targetPath,
+                FileSize = file.Length,
+                FileTransferTimeMs = transferTimeMs,
+            });
+
+            filesProcessed++;
+            sizeProcessed += file.Length;
+        }
+
+        _stateTracker.Update(new StateEntry
+        {
+            Name = job.Name,
+            LastActionTime = DateTimeOffset.Now,
+            State = JobState.Inactive,
+            TotalFilesEligible = totalFiles,
+            TotalSize = totalSize,
+            FilesRemaining = 0,
+            SizeRemaining = 0,
+        });
+    }
 
     public void ExecuteAll() => throw new NotImplementedException();
+
+    private static string BuildTargetPath(FileInfo file, DirectoryInfo sourceDir, string targetRoot)
+    {
+        string relativePath = Path.GetRelativePath(sourceDir.FullName, file.FullName);
+        return Path.Combine(targetRoot, relativePath);
+    }
 }

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -53,11 +53,12 @@ public class BackupManager
 
         var allFiles = sourceDir.EnumerateFiles("*", SearchOption.AllDirectories).ToList();
         var filesToCopy = allFiles
-            .Where(f => strategy.ShouldCopy(f, BuildTargetPath(f, sourceDir, job.TargetPath)))
+            .Select(f => (File: f, Target: BuildTargetPath(f, sourceDir, job.TargetPath)))
+            .Where(pair => strategy.ShouldCopy(pair.File, pair.Target))
             .ToList();
 
         int totalFiles = filesToCopy.Count;
-        long totalSize = filesToCopy.Sum(f => f.Length);
+        long totalSize = filesToCopy.Sum(pair => pair.File.Length);
 
         _stateTracker.Update(new StateEntry
         {
@@ -73,9 +74,8 @@ public class BackupManager
         int filesProcessed = 0;
         long sizeProcessed = 0;
 
-        foreach (var file in filesToCopy)
+        foreach (var (file, targetPath) in filesToCopy)
         {
-            string targetPath = BuildTargetPath(file, sourceDir, job.TargetPath);
 
             _stateTracker.Update(new StateEntry
             {
@@ -103,7 +103,7 @@ public class BackupManager
                 sw.Stop();
                 transferTimeMs = sw.ElapsedMilliseconds;
             }
-            catch
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
                 sw.Stop();
                 transferTimeMs = -1;

--- a/tests/EasySave.Tests/BackupManagerExecuteTests.cs
+++ b/tests/EasySave.Tests/BackupManagerExecuteTests.cs
@@ -143,6 +143,10 @@ public class BackupManagerExecuteTests : IDisposable
         var stateFile = Path.Combine(_dataDir, "state.json");
         Assert.True(File.Exists(stateFile));
         var stateJson = File.ReadAllText(stateFile);
-        Assert.Contains("\"State\":0", stateJson); // Inactive = 0
+        var entries = System.Text.Json.JsonSerializer.Deserialize<List<StateEntry>>(stateJson);
+        Assert.NotNull(entries);
+        var entry = Assert.Single(entries);
+        Assert.Equal(JobState.Inactive, entry.State);
+        Assert.Equal(0, entry.FilesRemaining);
     }
 }

--- a/tests/EasySave.Tests/BackupManagerExecuteTests.cs
+++ b/tests/EasySave.Tests/BackupManagerExecuteTests.cs
@@ -1,0 +1,148 @@
+using EasyLog;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+public class BackupManagerExecuteTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _sourceDir;
+    private readonly string _targetDir;
+    private readonly string _logDir;
+    private readonly string _dataDir;
+
+    public BackupManagerExecuteTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "bm-exec-tests-" + Guid.NewGuid().ToString("N"));
+        _sourceDir = Path.Combine(_tempDir, "source");
+        _targetDir = Path.Combine(_tempDir, "target");
+        _logDir = Path.Combine(_tempDir, "logs");
+        _dataDir = Path.Combine(_tempDir, "data");
+
+        Directory.CreateDirectory(_sourceDir);
+        Directory.CreateDirectory(_targetDir);
+        Directory.CreateDirectory(_logDir);
+        Directory.CreateDirectory(_dataDir);
+
+        // Point AppConfig to our temp directories
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        File.WriteAllText(configPath, System.Text.Json.JsonSerializer.Serialize(new
+        {
+            LogDirectory = _logDir,
+            StateFilePath = Path.Combine(_dataDir, "state.json"),
+            JobsFilePath = Path.Combine(_dataDir, "jobs.json"),
+        }));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private BackupManager CreateManager(IBackupStrategy fullStrategy, IBackupStrategy diffStrategy)
+    {
+        var logger = new JsonDailyLogger(_logDir);
+        return new BackupManager(logger, fullStrategy, diffStrategy, StateTracker.Instance, JobRepository.Instance);
+    }
+
+    private void SeedJob(string name, BackupType type)
+    {
+        var job = new BackupJob
+        {
+            Name = name,
+            SourcePath = _sourceDir,
+            TargetPath = _targetDir,
+            Type = type,
+        };
+        JobRepository.Instance.Save(new List<BackupJob> { job });
+    }
+
+    [Fact]
+    public void ExecuteJob_FullStrategy_CopiesAllFiles_AndLogsEach()
+    {
+        File.WriteAllText(Path.Combine(_sourceDir, "a.txt"), "aaa");
+        Directory.CreateDirectory(Path.Combine(_sourceDir, "sub"));
+        File.WriteAllText(Path.Combine(_sourceDir, "sub", "b.txt"), "bbb");
+
+        SeedJob("full-test", BackupType.Full);
+        var manager = CreateManager(new FullBackupStrategy(), new DifferentialBackupStrategy());
+
+        manager.ExecuteJob("full-test");
+
+        Assert.True(File.Exists(Path.Combine(_targetDir, "a.txt")));
+        Assert.True(File.Exists(Path.Combine(_targetDir, "sub", "b.txt")));
+        Assert.Equal("aaa", File.ReadAllText(Path.Combine(_targetDir, "a.txt")));
+        Assert.Equal("bbb", File.ReadAllText(Path.Combine(_targetDir, "sub", "b.txt")));
+
+        // Check that log entries were created
+        var logFiles = Directory.GetFiles(_logDir, "*.json");
+        Assert.Single(logFiles);
+    }
+
+    [Fact]
+    public void ExecuteJob_DiffStrategy_CopiesOnlyModified()
+    {
+        File.WriteAllText(Path.Combine(_sourceDir, "unchanged.txt"), "same");
+        File.WriteAllText(Path.Combine(_sourceDir, "changed.txt"), "new content");
+
+        // Pre-fill target with identical unchanged file
+        var unchangedTarget = Path.Combine(_targetDir, "unchanged.txt");
+        File.WriteAllText(unchangedTarget, "same");
+        File.SetLastWriteTimeUtc(unchangedTarget,
+            File.GetLastWriteTimeUtc(Path.Combine(_sourceDir, "unchanged.txt")));
+
+        SeedJob("diff-test", BackupType.Differential);
+        var manager = CreateManager(new FullBackupStrategy(), new DifferentialBackupStrategy());
+
+        manager.ExecuteJob("diff-test");
+
+        // changed.txt should be copied
+        Assert.True(File.Exists(Path.Combine(_targetDir, "changed.txt")));
+        Assert.Equal("new content", File.ReadAllText(Path.Combine(_targetDir, "changed.txt")));
+    }
+
+    [Fact]
+    public void ExecuteJob_ErrorOnOneFile_ContinuesAndLogsNegativeTime()
+    {
+        File.WriteAllText(Path.Combine(_sourceDir, "good.txt"), "ok");
+        File.WriteAllText(Path.Combine(_sourceDir, "bad.txt"), "will fail");
+
+        // Lock bad.txt target path by making it a read-only directory (causes copy to fail)
+        var badTargetDir = Path.Combine(_targetDir, "bad.txt");
+        Directory.CreateDirectory(badTargetDir);
+
+        SeedJob("error-test", BackupType.Full);
+        var manager = CreateManager(new FullBackupStrategy(), new DifferentialBackupStrategy());
+
+        manager.ExecuteJob("error-test");
+
+        // good.txt should still be copied
+        Assert.True(File.Exists(Path.Combine(_targetDir, "good.txt")));
+
+        // Check log has a negative transfer time for the failed file
+        var logFiles = Directory.GetFiles(_logDir, "*.json");
+        Assert.Single(logFiles);
+        var logContent = File.ReadAllText(logFiles[0]);
+        Assert.Contains("-1", logContent);
+    }
+
+    [Fact]
+    public void ExecuteJob_UpdatesStateAtStartAndEnd()
+    {
+        File.WriteAllText(Path.Combine(_sourceDir, "file.txt"), "data");
+
+        SeedJob("state-test", BackupType.Full);
+        var manager = CreateManager(new FullBackupStrategy(), new DifferentialBackupStrategy());
+
+        manager.ExecuteJob("state-test");
+
+        // After execution, state should be Inactive (job finished)
+        var stateFile = Path.Combine(_dataDir, "state.json");
+        Assert.True(File.Exists(stateFile));
+        var stateJson = File.ReadAllText(stateFile);
+        Assert.Contains("\"State\":0", stateJson); // Inactive = 0
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `BackupManager.ExecuteJob` with recursive file traversal
- Strategy pattern dispatch (Full vs Differential)
- Log each file copy via `IDailyLogger` with UNC paths
- Update `StateTracker` at start, per-file progress, and end
- Typed exception handling (IOException, UnauthorizedAccessException) with TransferTimeMs = -1 on error
- 4 integration tests

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — all 4 new tests pass
- [ ] Full backup copies all files including subdirectories
- [ ] Diff backup only copies modified files
- [ ] Failed file copy logs negative transfer time and continues