### PR TITLE
feat(backup): implement AddJob with 5-job limit and duplicate name check

### DIFF
--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -47,8 +47,9 @@ public class BackupManager
         if (_jobs.Any(j => j.Name == job.Name))
             throw new InvalidOperationException($"Job '{job.Name}' already exists.");
 
+        var updated = new List<BackupJob>(_jobs) { job };
+        _jobRepository.Save(updated);
         _jobs.Add(job);
-        _jobRepository.Save(_jobs);
     }
 
     public void RemoveJob(string name) => throw new NotImplementedException();

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -7,11 +7,14 @@ namespace EasySave.Services;
 // Manages backup jobs: CRUD + execution with logging and state tracking.
 public class BackupManager
 {
+    private const int MaxJobs = 5;
+
     private readonly IDailyLogger _logger;
     private readonly IBackupStrategy _fullStrategy;
     private readonly IBackupStrategy _diffStrategy;
     private readonly StateTracker _stateTracker;
     private readonly JobRepository _jobRepository;
+    private readonly List<BackupJob> _jobs;
 
     public BackupManager(
         IDailyLogger logger,
@@ -31,18 +34,30 @@ public class BackupManager
         _diffStrategy = diffStrategy;
         _stateTracker = stateTracker;
         _jobRepository = jobRepository;
+        _jobs = new List<BackupJob>(_jobRepository.Load());
     }
 
-    public void AddJob(BackupJob job) => throw new NotImplementedException();
+    public void AddJob(BackupJob job)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+
+        if (_jobs.Count >= MaxJobs)
+            throw new InvalidOperationException($"Maximum {MaxJobs} jobs allowed.");
+
+        if (_jobs.Any(j => j.Name == job.Name))
+            throw new InvalidOperationException($"Job '{job.Name}' already exists.");
+
+        _jobs.Add(job);
+        _jobRepository.Save(_jobs);
+    }
 
     public void RemoveJob(string name) => throw new NotImplementedException();
 
-    public IReadOnlyList<BackupJob> ListJobs() => throw new NotImplementedException();
+    public IReadOnlyList<BackupJob> ListJobs() => _jobs.AsReadOnly();
 
     public void ExecuteJob(string name)
     {
-        var jobs = _jobRepository.Load();
-        var job = jobs.FirstOrDefault(j => j.Name == name)
+        var job = _jobs.FirstOrDefault(j => j.Name == name)
             ?? throw new InvalidOperationException($"Job '{name}' not found.");
 
         var strategy = job.Type == BackupType.Full ? _fullStrategy : _diffStrategy;

--- a/tests/EasySave.Tests/BackupManagerAddJobTests.cs
+++ b/tests/EasySave.Tests/BackupManagerAddJobTests.cs
@@ -4,6 +4,7 @@ using EasySave.Services;
 
 namespace EasySave.Tests;
 
+[Collection("StateCollection")]
 public class BackupManagerAddJobTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/EasySave.Tests/BackupManagerAddJobTests.cs
+++ b/tests/EasySave.Tests/BackupManagerAddJobTests.cs
@@ -84,6 +84,9 @@ public class BackupManagerAddJobTests : IDisposable
     [Fact]
     public void AddJob_PersistsAcrossInstances()
     {
+        // Clear any leftover jobs from other tests
+        JobRepository.Instance.Save(new List<BackupJob>());
+
         var manager = CreateManager();
         manager.AddJob(MakeJob("persisted-job"));
 

--- a/tests/EasySave.Tests/BackupManagerAddJobTests.cs
+++ b/tests/EasySave.Tests/BackupManagerAddJobTests.cs
@@ -1,0 +1,83 @@
+using EasyLog;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+public class BackupManagerAddJobTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public BackupManagerAddJobTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "bm-addjob-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        File.WriteAllText(configPath, System.Text.Json.JsonSerializer.Serialize(new
+        {
+            LogDirectory = Path.Combine(_tempDir, "logs"),
+            StateFilePath = Path.Combine(_tempDir, "state.json"),
+            JobsFilePath = Path.Combine(_tempDir, "jobs.json"),
+        }));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private BackupManager CreateManager()
+    {
+        var logger = new JsonDailyLogger(Path.Combine(_tempDir, "logs"));
+        return new BackupManager(
+            logger,
+            new FullBackupStrategy(),
+            new DifferentialBackupStrategy(),
+            StateTracker.Instance,
+            JobRepository.Instance);
+    }
+
+    private static BackupJob MakeJob(string name) => new()
+    {
+        Name = name,
+        SourcePath = "/tmp/src",
+        TargetPath = "/tmp/dst",
+        Type = BackupType.Full,
+    };
+
+    [Fact]
+    public void AddJob_WhenLessThan5_Succeeds()
+    {
+        var manager = CreateManager();
+
+        for (int i = 1; i <= 5; i++)
+            manager.AddJob(MakeJob($"job-{i}"));
+
+        Assert.Equal(5, manager.ListJobs().Count);
+    }
+
+    [Fact]
+    public void AddJob_When5Already_Throws()
+    {
+        var manager = CreateManager();
+
+        for (int i = 1; i <= 5; i++)
+            manager.AddJob(MakeJob($"job-{i}"));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.AddJob(MakeJob("job-6")));
+        Assert.Contains("5", ex.Message);
+    }
+
+    [Fact]
+    public void AddJob_DuplicateName_Throws()
+    {
+        var manager = CreateManager();
+        manager.AddJob(MakeJob("backup-daily"));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.AddJob(MakeJob("backup-daily")));
+        Assert.Contains("backup-daily", ex.Message);
+    }
+}

--- a/tests/EasySave.Tests/BackupManagerAddJobTests.cs
+++ b/tests/EasySave.Tests/BackupManagerAddJobTests.cs
@@ -80,4 +80,17 @@ public class BackupManagerAddJobTests : IDisposable
         var ex = Assert.Throws<InvalidOperationException>(() => manager.AddJob(MakeJob("backup-daily")));
         Assert.Contains("backup-daily", ex.Message);
     }
+
+    [Fact]
+    public void AddJob_PersistsAcrossInstances()
+    {
+        var manager = CreateManager();
+        manager.AddJob(MakeJob("persisted-job"));
+
+        var freshManager = CreateManager();
+        var jobs = freshManager.ListJobs();
+
+        Assert.Single(jobs);
+        Assert.Equal("persisted-job", jobs[0].Name);
+    }
 }

--- a/tests/EasySave.Tests/BackupManagerExecuteTests.cs
+++ b/tests/EasySave.Tests/BackupManagerExecuteTests.cs
@@ -4,6 +4,7 @@ using EasySave.Services;
 
 namespace EasySave.Tests;
 
+[Collection("StateCollection")]
 public class BackupManagerExecuteTests : IDisposable
 {
     private readonly string _tempDir;


### PR DESCRIPTION
## Summary
- Implement `AddJob` with max 5 jobs limit (cahier v1.0)
- Reject duplicate job names with `InvalidOperationException`
- Persist jobs via `JobRepository.Save` after each add
- Load existing jobs in constructor from `JobRepository`
- Implement `ListJobs` returning in-memory list
- 3 unit tests: success, limit exceeded, duplicate name

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — all 3 new tests pass
- [ ] 6th job throws InvalidOperationException
- [ ] Duplicate name throws InvalidOperationException