### PR TITLE
docs: add user manual and customer support guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Console application providing the user interface for managing backup jobs.
 Reusable library that writes daily JSON log files (`yyyy-MM-dd.json`).
 Thread-safe, atomic writes, designed to be shared across ProSoft applications.
 
+## Documentation
+
+- [User manual](docs/user-manual.md) — end-user guide (1 page)
+- [Customer support guide](docs/support-client.md) — deployment, configuration, and support contacts
+
 ## Contributing
 
 - Follow [commit conventions](docs/COMMIT_CONVENTION.md)

--- a/docs/support-client.md
+++ b/docs/support-client.md
@@ -1,0 +1,78 @@
+# EasySave — Customer Support Guide
+
+This document is intended for ProSoft support technicians and system administrators deploying EasySave on client machines.
+
+## System requirements
+
+| Item | Requirement |
+| --- | --- |
+| Operating system | Windows 10/11, Linux (x64), macOS 12+ |
+| Runtime | .NET 8.0 Runtime |
+| Disk space | 50 MB for the application, plus space for backups |
+| Network access | Required only if sources or targets live on network shares |
+
+The runtime can be downloaded from <https://dotnet.microsoft.com/download/dotnet/8.0>.
+
+## Installation layout
+
+After installation, the application directory contains:
+
+```
+<install-dir>/
+├── EasySave(.exe)           # Entry point
+├── EasyLog.dll              # Logger library
+├── appsettings.json         # Configuration file (editable)
+└── data/
+    ├── logs/                # Daily log files (yyyy-MM-dd.json)
+    ├── state.json           # Real-time state of the 5 jobs
+    └── jobs.json            # Persisted job definitions
+```
+
+The `<install-dir>` depends on the deployment method (MSI, ZIP extraction, or `dotnet publish` output). On a typical Windows install, it is `C:\Program Files\ProSoft\EasySave\`.
+
+## Configurable locations
+
+All paths below can be overridden by editing `appsettings.json`:
+
+```json
+{
+  "LogDirectory": "\\\\fileserver\\ProSoft\\logs",
+  "StateFilePath": "C:\\ProgramData\\ProSoft\\EasySave\\state.json",
+  "JobsFilePath": "C:\\ProgramData\\ProSoft\\EasySave\\jobs.json",
+  "Language": "en"
+}
+```
+
+| Key | Purpose | Default |
+| --- | --- | --- |
+| `LogDirectory` | Folder where daily JSON logs are written | `./data/logs/` |
+| `StateFilePath` | Full path of the single `state.json` | `./data/state.json` |
+| `JobsFilePath` | Full path of the job definitions file | `./data/jobs.json` |
+| `Language` | UI language (`en` or `fr`) | `en` |
+
+Network shares must be given in **UNC format** (`\\server\share\folder`). Changes take effect on the next application startup.
+
+## Change the configuration
+
+1. Stop any running EasySave instance.
+2. Open `appsettings.json` with a text editor.
+3. Update the relevant keys. Leave unused keys unchanged.
+4. Save the file and restart EasySave.
+
+Invalid JSON falls back to the defaults without crashing the application; verify changes with a dry run (`EasySave list`) before scheduling production backups.
+
+## Logs and troubleshooting
+
+- Daily logs: `<LogDirectory>/yyyy-MM-dd.json`, one file per calendar day (local time).
+- State file: `<StateFilePath>`, updated in real time while jobs run.
+- A negative `FileTransferTimeMs` in a log entry indicates a copy failure on that file — the job continues with the next file.
+
+## Support contact
+
+ProSoft support is included under the following terms:
+
+- **Annual fee:** 12% of the purchase price, billed yearly.
+- **Availability:** 5 days a week, 08:00–17:00 local time.
+- **Channels:** dedicated email and ticketing portal provided with the purchase contract.
+
+Full pricing and service-level terms are defined in the *ProSoft Pricing Policy* document delivered with the contract.

--- a/docs/support-client.md
+++ b/docs/support-client.md
@@ -28,17 +28,34 @@ After installation, the application directory contains:
     └── jobs.json            # Persisted job definitions
 ```
 
-The `<install-dir>` depends on the deployment method (MSI, ZIP extraction, or `dotnet publish` output). On a typical Windows install, it is `C:\Program Files\ProSoft\EasySave\`.
+The `<install-dir>` depends on the deployment method (MSI, ZIP extraction, or `dotnet publish` output). Typical locations per platform:
+
+- Windows: `C:\Program Files\ProSoft\EasySave\`
+- Linux: `/opt/prosoft/easysave/`
+- macOS: `/Applications/EasySave.app/Contents/MacOS/` or `/usr/local/prosoft/easysave/`
 
 ## Configurable locations
 
-All paths below can be overridden by editing `appsettings.json`:
+All paths below can be overridden by editing `appsettings.json`. Use the path syntax native to the target platform.
+
+Windows example:
 
 ```json
 {
   "LogDirectory": "\\\\fileserver\\ProSoft\\logs",
   "StateFilePath": "C:\\ProgramData\\ProSoft\\EasySave\\state.json",
   "JobsFilePath": "C:\\ProgramData\\ProSoft\\EasySave\\jobs.json",
+  "Language": "en"
+}
+```
+
+Linux / macOS example:
+
+```json
+{
+  "LogDirectory": "/var/log/prosoft/easysave",
+  "StateFilePath": "/var/lib/prosoft/easysave/state.json",
+  "JobsFilePath": "/var/lib/prosoft/easysave/jobs.json",
   "Language": "en"
 }
 ```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,0 +1,46 @@
+# EasySave — User Manual
+
+EasySave is a console backup tool for ProSoft. It manages up to **5 backup jobs** and runs them on demand (full or differential).
+
+## Launch
+
+Two modes are available once the application is installed:
+
+- **Interactive menu:** `EasySave`
+- **Command-line:** `EasySave <command> [arguments]`
+
+## Manage jobs
+
+| Action | Command | Notes |
+| --- | --- | --- |
+| List jobs | `EasySave list` | Shows name, type, source, target. |
+| Create a job | `EasySave create <name> <source> <target> <full\|diff>` | Max 5 jobs; names are unique. |
+| Delete a job | `EasySave delete <name>` | Removes the job definition only. |
+
+Sources and targets accept local disks, external drives, and network shares (UNC paths such as `\\server\share\folder`).
+
+## Run jobs
+
+Jobs are addressed by their position (1 to 5) in the list returned by `list`.
+
+| Syntax | Effect |
+| --- | --- |
+| `1` | Run job 1 only. |
+| `1-3` | Run jobs 1, 2, 3 (range). |
+| `1;3` | Run jobs 1 and 3 (selection). |
+| `1-3;5` | Run jobs 1, 2, 3 and 5 (combined). |
+
+From the CLI: `EasySave run 1-3;5`. From the menu: choose **Run**, then enter the same expression.
+
+## Change the language
+
+The UI supports **English** and **French**.
+
+- From the menu: **Settings → Language**.
+- From the configuration file: set `"Language": "en"` or `"Language": "fr"` in `appsettings.json`, then restart.
+
+## Where are the logs?
+
+Daily logs are written in real time as JSON files named `yyyy-MM-dd.json` inside the log directory. The default location is `data/logs/` next to the executable, and it is configurable from `appsettings.json` (see the support guide). Each entry records the job name, source, target, size, and transfer time.
+
+A failed file copy is recorded with a **negative transfer time** (`FileTransferTimeMs < 0`).

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,6 +1,6 @@
 # EasySave — User Manual
 
-EasySave is a console backup tool for ProSoft. It manages up to **5 backup jobs** and runs them on demand (full or differential).
+EasySave is a console backup tool for ProSoft. It manages up to **5 backup jobs** and runs them on demand (full or differential). This manual describes the **v1.0 interface** as defined in the specification; command names and options are final for the v1.0 release.
 
 ## Launch
 


### PR DESCRIPTION
## Summary

- `docs/user-manual.md` — 1-page end-user guide (cahier v1.0 hard constraint).
- `docs/support-client.md` — deployment layout, configurable paths, system requirements, support terms.
- `README.md` — links both documents under a new *Documentation* section.

Closes ClickUp task 869cycq3z.

## Scope

- Manual covers: launch modes (menu + CLI), job CRUD, run syntaxes (`1`, `1-3`, `1;3`, `1-3;5`), language switch, log location.
- Support guide covers: system requirements, install layout, configurable paths via `appsettings.json`, troubleshooting signals (negative `FileTransferTimeMs`), support contact terms (12%/year, 5/7 08:00–17:00).
- Both in English per project convention; user-facing strings reference keys, not hardcoded French.

## Test plan

- [ ] `docs/user-manual.md` fits on one page when printed (A4, 11pt).
- [ ] All paths mentioned match `AppConfig` defaults (`data/logs`, `data/state.json`, `data/jobs.json`).
- [ ] README links resolve on GitHub.