### PR TITLE
fix(backup): validate job name and paths are not empty

### DIFF
--- a/src/EasySave/CLI/ConsoleUI.cs
+++ b/src/EasySave/CLI/ConsoleUI.cs
@@ -78,6 +78,10 @@ public sealed class ConsoleUI
             _backupManager.AddJob(job);
             Console.WriteLine(_lang.T("confirm.job_added"));
         }
+        catch (ArgumentException)
+        {
+            Console.WriteLine(_lang.T("error.empty_field"));
+        }
         catch (InvalidOperationException ex)
         {
             var colon = ex.Message.IndexOf(':');

--- a/src/EasySave/Resources/en.json
+++ b/src/EasySave/Resources/en.json
@@ -14,6 +14,7 @@
   "error.invalid_selection": "Invalid job selection.",
   "error.invalid_backup_type": "Invalid backup type. Use Full or Differential.",
   "error.duplicate_job": "A job with this name already exists.",
+  "error.empty_field": "Name, source path and target path are required.",
   "error.invalid_language": "Invalid language. Supported: en, fr.",
   "error.source_not_found": "Source directory does not exist.",
   "error.execute_failed": "Execution error: {0}",

--- a/src/EasySave/Resources/fr.json
+++ b/src/EasySave/Resources/fr.json
@@ -14,6 +14,7 @@
   "error.invalid_selection": "Sélection invalide.",
   "error.invalid_backup_type": "Type invalide. Utilisez Full ou Differential.",
   "error.duplicate_job": "Un job avec ce nom existe déjà.",
+  "error.empty_field": "Le nom, le chemin source et le chemin cible sont obligatoires.",
   "error.invalid_language": "Langue invalide. Supportées : en, fr.",
   "error.source_not_found": "Le dossier source n'existe pas.",
   "error.execute_failed": "Erreur d'exécution : {0}",

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -38,6 +38,9 @@ public sealed class BackupManager
     public void AddJob(BackupJob job)
     {
         ArgumentNullException.ThrowIfNull(job);
+        ArgumentException.ThrowIfNullOrWhiteSpace(job.Name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(job.SourcePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(job.TargetPath);
 
         var jobs = _jobRepository.Load().ToList();
 

--- a/tests/EasySave.Tests/BackupManagerAddJobTests.cs
+++ b/tests/EasySave.Tests/BackupManagerAddJobTests.cs
@@ -97,4 +97,20 @@ public class BackupManagerAddJobTests : IDisposable
         Assert.Single(jobs);
         Assert.Equal("persisted-job", jobs[0].Name);
     }
+
+    [Theory]
+    [InlineData("", "/src", "/dst")]
+    [InlineData("   ", "/src", "/dst")]
+    [InlineData("job", "", "/dst")]
+    [InlineData("job", "/src", "")]
+    public void AddJob_EmptyField_Throws(string name, string source, string target)
+    {
+        JobRepository.Instance.Save(new List<BackupJob>());
+        var manager = CreateManager();
+
+        var job = new BackupJob { Name = name, SourcePath = source, TargetPath = target, Type = BackupType.Full };
+
+        Assert.Throws<ArgumentException>(() => manager.AddJob(job));
+        Assert.Empty(manager.ListJobs());
+    }
 }


### PR DESCRIPTION
## Summary
- Guard `BackupManager.AddJob` against empty Name, SourcePath and TargetPath with `ArgumentException.ThrowIfNullOrWhiteSpace`
- Catch `ArgumentException` in `ConsoleUI.AddJob` and show `error.empty_field`
- Add `error.empty_field` i18n key in en.json + fr.json
- Add `AddJob_EmptyField_Throws` theory covering 4 cases (empty name, whitespace name, empty source, empty target)

Fixes the bug where pressing Enter on empty prompts would create a `{Name: "", SourcePath: "", TargetPath: ""}` job that silently consumed one of the 5 slots.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — new theory tests pass
- [ ] Interactive mode rejects empty name/source/target with localized message