### PR TITLE
docs: changelog, ADR 0001, XML docs on BackupManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project are documented here.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] — 2026-04-21
+
+First release delivered to ProSoft. Console backup tool with up to 5 jobs,
+full and differential strategies, daily JSON logging, and English/French UI.
+
+### Added
+
+- **EasySave console application** with interactive menu and direct CLI mode (`EasySave 1-3;5`).
+- **Backup engine** supporting two strategies: `Full` (every file) and `Differential` (size + mtime comparison).
+- **Job management**: create, list, remove, execute one or several jobs — limit of 5 jobs enforced.
+- **Selection syntax** for execution: single index, range (`1-3`), list (`1;3`), combined (`1-3;5`).
+- **EasyLog library** (`EasyLog.dll`): reusable daily JSON logger with thread-safe, atomic writes.
+- **Path normalization** in logs — UNC paths preserved, local Windows paths wrapped with `\\?\`.
+- **Corrupted log recovery** — unreadable day files are quarantined (`*.corrupted-<ts>-<guid>`) instead of dropped.
+- **State tracking** via a single `state.json`, updated in real time (start, per-file progress, end).
+- **Job repository** persisting the 5-job list to `jobs.json` atomically.
+- **Internationalization**: English and French messages loaded from `Resources/{lang}.json`, hot-switchable at runtime.
+- **AppConfig** singleton reading `appsettings.json` — all paths (logs, state, jobs) are configurable.
+- **Unit and integration tests** (41 tests covering logger, backup strategies, state tracker, job repository, backup manager, command parser).
+- **User manual** (`docs/user-manual.md`, one page) and **customer support guide** (`docs/support-client.md`).
+- **UML diagrams**: use case, class, activity, sequence (`docs/diagrams/`).
+- **CI pipeline** — `.NET Build` workflow running `dotnet build`, `dotnet test`, and `dotnet format --severity warn` on Ubuntu 24.04.
+- **Automated PR review** via Claude Code Review with project context in `CLAUDE.md`.
+- **Commit convention** documented in `docs/COMMIT_CONVENTION.md` (Conventional Commits + branch naming).
+
+### Fixed
+
+- Log file tmp-name collisions on concurrent append (`*.tmp` switched to GUID-suffixed names).
+- `dotnet format` catch-clause indentation violations in `JsonDailyLogger`.
+- `AppConfig` path resolution now relative to the executable, not the working directory.
+- Shipped `appsettings.json` no longer contains developer-only path overrides.
+- `BackupManager` rejects empty job names, source paths, and target paths.
+- Corrupted log files are preserved under a timestamped backup name instead of being overwritten.
+
+### Changed
+
+- `JobRepository.Load()` returns `IReadOnlyList<BackupJob>` instead of `List<BackupJob>`.
+- Test classes touching shared singletons joined to `StateCollection` to disable parallelization and prevent race conditions.
+- Exception messages in `BackupManager` carry both a translation key and human-readable detail (`"error.max_jobs: Maximum 5 jobs allowed."`).
+
+### Security
+
+- Log and state paths default to paths under the executable — no hardcoded `C:\temp` or similar.
+
+[Unreleased]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Thread-safe, atomic writes, designed to be shared across ProSoft applications.
 
 - [User manual](docs/user-manual.md) — end-user guide (1 page)
 - [Customer support guide](docs/support-client.md) — deployment, configuration, and support contacts
+- [Changelog](CHANGELOG.md) — release notes (Keep a Changelog format)
+- [Architecture Decision Records](docs/adrs/) — design decisions and their rationale
+- [UML diagrams](docs/diagrams/) — use case, class, activity, sequence
 
 ## Contributing
 

--- a/docs/adrs/0001-strategy-pattern-for-backup-types.md
+++ b/docs/adrs/0001-strategy-pattern-for-backup-types.md
@@ -1,0 +1,114 @@
+# ADR 0001 — Use the Strategy pattern for backup types
+
+- **Status:** Accepted
+- **Date:** 2026-04-21
+- **Decision drivers:** Cahier v1.0, team conventions, testability
+
+## Context
+
+The v1.0 cahier requires EasySave to support two backup modes:
+
+- **Full** — copy every file in the source tree to the target.
+- **Differential** — copy only files modified since the last full backup.
+
+v3.0 is expected to introduce at least one additional mode (the spec is not
+final yet, but the team has been warned the list will grow).
+
+The execution loop in `BackupManager` is identical regardless of mode: enumerate
+the source directory, filter eligible files, copy, log, update state. The only
+variation is the *decision* of whether a given file must be copied.
+
+## Options considered
+
+### Option A — `if/else` on `BackupType` inside `BackupManager`
+
+```csharp
+foreach (var file in files)
+{
+    bool copy = job.Type switch
+    {
+        BackupType.Full => true,
+        BackupType.Differential => IsNewerThanTarget(file, targetPath),
+        _ => throw new NotSupportedException()
+    };
+    if (copy) Copy(file, targetPath);
+}
+```
+
+- **Pro:** simple, no extra type.
+- **Con:** every new mode adds a branch. `BackupManager` knows the details of
+  every strategy. Violates the Open/Closed principle. Harder to unit-test the
+  decision logic in isolation.
+
+### Option B — Strategy pattern behind `IBackupStrategy`
+
+```csharp
+public interface IBackupStrategy
+{
+    bool ShouldCopy(FileInfo source, string targetPath);
+}
+```
+
+- `FullBackupStrategy.ShouldCopy` returns `true`.
+- `DifferentialBackupStrategy.ShouldCopy` compares size and last-write-time.
+- `BackupManager` picks the strategy from `job.Type` once and delegates.
+
+- **Pro:** each strategy is a self-contained unit with its own tests (see
+  `FullBackupStrategyTests`, `DifferentialBackupStrategyTests`). Adding a
+  v3.0 mode is a new class, no change in `BackupManager`.
+- **Con:** two extra types for a v1.0 with only two modes.
+
+### Option C — Inheritance (abstract `BackupJobExecutor` base class)
+
+Same extensibility as Strategy but couples execution and decision in one
+hierarchy. Fits less well with the existing layered architecture where
+`Models` are POCOs and `Services` hold behaviour.
+
+## Decision
+
+**Adopt Option B (Strategy).**
+
+Implemented as:
+
+```
+src/EasySave/Services/
+├── IBackupStrategy.cs
+├── FullBackupStrategy.cs
+└── DifferentialBackupStrategy.cs
+```
+
+`BackupManager` receives both strategies via constructor injection and
+selects at runtime based on `job.Type`:
+
+```csharp
+var strategy = job.Type == BackupType.Full ? _fullStrategy : _diffStrategy;
+```
+
+## Consequences
+
+### Positive
+
+- New backup modes (v3.0) are added without touching `BackupManager` —
+  one new class implementing `IBackupStrategy`, one new enum value,
+  one wiring change in `Program.Main`.
+- Strategy-specific tests stay small and focused (currently 7 tests split
+  across the two strategy files).
+- Clear separation between *orchestration* (BackupManager) and *policy*
+  (IBackupStrategy).
+
+### Negative
+
+- Two extra types for two modes in v1.0 — overhead that pays off only at v3.0.
+- Constructor arguments on `BackupManager` grow each time a new mode lands
+  (acceptable: DI is manual in `Program.Main`).
+
+### Neutral
+
+- The `BackupType` enum is kept as the persisted identifier in `jobs.json`.
+  Strategies are not serialized — they are reconstructed at startup.
+
+## References
+
+- Cahier v1.0 §2 (backup modes)
+- `src/EasySave/Services/IBackupStrategy.cs`
+- Gamma et al., *Design Patterns*, Strategy — pp. 315–323

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -4,9 +4,14 @@ using EasySave.Models;
 
 namespace EasySave.Services;
 
-// Manages backup jobs: CRUD + execution with logging and state tracking.
+/// <summary>
+/// Orchestrates the lifecycle of backup jobs: CRUD operations against the
+/// persistent store, execution using the strategy pattern, real-time state
+/// updates, and per-file logging. Enforces the v1.0 cahier limit of 5 jobs.
+/// </summary>
 public sealed class BackupManager
 {
+    /// <summary>Maximum number of jobs allowed at any time (cahier v1.0).</summary>
     private const int MaxJobs = 5;
 
     private readonly IDailyLogger _logger;
@@ -15,6 +20,15 @@ public sealed class BackupManager
     private readonly StateTracker _stateTracker;
     private readonly JobRepository _jobRepository;
 
+    /// <summary>
+    /// Wires the manager with its dependencies. All parameters are required;
+    /// null arguments throw <see cref="ArgumentNullException"/>.
+    /// </summary>
+    /// <param name="logger">Daily log writer, shared across jobs.</param>
+    /// <param name="fullStrategy">Strategy used for <see cref="BackupType.Full"/> jobs.</param>
+    /// <param name="diffStrategy">Strategy used for <see cref="BackupType.Differential"/> jobs.</param>
+    /// <param name="stateTracker">Singleton state writer persisting to <c>state.json</c>.</param>
+    /// <param name="jobRepository">Singleton repository persisting to <c>jobs.json</c>.</param>
     public BackupManager(
         IDailyLogger logger,
         IBackupStrategy fullStrategy,
@@ -35,6 +49,17 @@ public sealed class BackupManager
         _jobRepository = jobRepository;
     }
 
+    /// <summary>
+    /// Registers a new backup job and persists the updated list to disk.
+    /// The job name is matched case-insensitively for duplicate detection.
+    /// </summary>
+    /// <param name="job">Job definition with non-empty Name, SourcePath, and TargetPath.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="job"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when any of Name/SourcePath/TargetPath is null or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the repository already holds 5 jobs (key <c>error.max_jobs</c>)
+    /// or when a job with the same name exists (key <c>error.duplicate_job</c>).
+    /// </exception>
     public void AddJob(BackupJob job)
     {
         ArgumentNullException.ThrowIfNull(job);
@@ -54,6 +79,13 @@ public sealed class BackupManager
         _jobRepository.Save(jobs);
     }
 
+    /// <summary>
+    /// Removes the job matching <paramref name="name"/> (case-insensitive) and
+    /// persists the updated list to disk.
+    /// </summary>
+    /// <param name="name">Name of the job to remove.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
+    /// <exception cref="KeyNotFoundException">Thrown when no job with that name exists.</exception>
     public void RemoveJob(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -68,8 +100,18 @@ public sealed class BackupManager
         _jobRepository.Save(jobs);
     }
 
+    /// <summary>Returns the current list of configured jobs, read from disk.</summary>
     public IReadOnlyList<BackupJob> ListJobs() => _jobRepository.Load();
 
+    /// <summary>
+    /// Runs a single job by name. Copies eligible files according to the job's
+    /// strategy, logs each file (success or failure), and updates the state
+    /// tracker at start, per file, and on completion.
+    /// </summary>
+    /// <param name="name">Name of the job to execute (case-insensitive).</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
+    /// <exception cref="KeyNotFoundException">Thrown when no job with that name exists.</exception>
+    /// <exception cref="DirectoryNotFoundException">Thrown when the source directory does not exist.</exception>
     public void ExecuteJob(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -81,6 +123,10 @@ public sealed class BackupManager
         RunJob(job);
     }
 
+    /// <summary>
+    /// Runs every configured job sequentially. A failure on one job is logged
+    /// to <see cref="Console.Error"/> but does not stop the following jobs.
+    /// </summary>
     public void ExecuteAll()
     {
         foreach (var job in _jobRepository.Load())


### PR DESCRIPTION
## Summary

Preparation material for the v1.0.0 release and the soutenance.

- **`CHANGELOG.md`** — Keep a Changelog format, 1.0.0 entry grouping every feature/fix/change landed on `staging`.
- **`docs/adrs/0001-strategy-pattern-for-backup-types.md`** — records the rationale for `IBackupStrategy` (options considered, decision, consequences). Sets the template for future ADRs.
- **`src/EasySave/Services/BackupManager.cs`** — XML documentation (`/// <summary>`, `<param>`, `<exception>`) on the public surface: constructor, `AddJob`, `RemoveJob`, `ListJobs`, `ExecuteJob`, `ExecuteAll`, and `MaxJobs`.
- **`README.md`** — new links to changelog, ADR index, and UML diagrams.

## Test plan

- [ ] `dotnet build` passes (verified locally: 0 errors, 4 pre-existing xUnit deps warnings).
- [ ] `dotnet test` — 41/41 pass (no behavioural change, docs only).
- [ ] README links resolve on GitHub.
- [ ] CHANGELOG tag link (`v1.0.0`) works after tag push.