### PR TITLE
fix(state): make atomic writes collision-safe and clean on failure

### DIFF
--- a/src/EasySave/EasySave.csproj
+++ b/src/EasySave/EasySave.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="EasySave.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/EasySave/Services/FileHelpers.cs
+++ b/src/EasySave/Services/FileHelpers.cs
@@ -30,7 +30,7 @@ internal static class FileHelpers
             File.WriteAllText(tempPath, contents);
             File.Move(tempPath, path, overwrite: true);
         }
-        catch
+        catch (Exception)
         {
             try { File.Delete(tempPath); }
             catch { /* best effort; do not mask the original exception */ }

--- a/src/EasySave/Services/FileHelpers.cs
+++ b/src/EasySave/Services/FileHelpers.cs
@@ -17,4 +17,24 @@ internal static class FileHelpers
             Directory.CreateDirectory(directory);
         }
     }
+
+    // Writes the given text to the target path via a unique temp file, then renames it
+    // over the target in a single OS call. The GUID-suffixed temp name avoids collisions
+    // between concurrent processes writing to the same target, and a failed write deletes
+    // the temp file instead of leaving an orphan on disk.
+    public static void WriteAllTextAtomic(string path, string contents)
+    {
+        var tempPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, contents);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        catch
+        {
+            try { File.Delete(tempPath); }
+            catch { /* best effort; do not mask the original exception */ }
+            throw;
+        }
+    }
 }

--- a/src/EasySave/Services/JobRepository.cs
+++ b/src/EasySave/Services/JobRepository.cs
@@ -52,9 +52,7 @@ public sealed class JobRepository
             var path = AppConfig.Instance.JobsFilePath;
             FileHelpers.EnsureDirectoryExists(path);
 
-            var tempPath = path + ".tmp";
-            File.WriteAllText(tempPath, JsonSerializer.Serialize(jobs, FileHelpers.IndentedJsonOptions));
-            File.Move(tempPath, path, overwrite: true);
+            FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(jobs, FileHelpers.IndentedJsonOptions));
         }
     }
 

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -30,7 +30,7 @@ public sealed class StateTracker
             states.RemoveAll(s => s.Name == entry.Name);
             states.Add(entry);
 
-            WriteAtomically(path, states);
+            FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
         }
     }
 
@@ -52,12 +52,5 @@ public sealed class StateTracker
             // rather than crashing the caller inside the lock.
             return new List<StateEntry>();
         }
-    }
-
-    private static void WriteAtomically(string path, List<StateEntry> states)
-    {
-        var tempPath = path + ".tmp";
-        File.WriteAllText(tempPath, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
-        File.Move(tempPath, path, overwrite: true);
     }
 }

--- a/tests/EasySave.Tests/FileHelpersTests.cs
+++ b/tests/EasySave.Tests/FileHelpersTests.cs
@@ -1,0 +1,91 @@
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+// Unit tests for the atomic write helper that protects StateTracker, JobRepository
+// and future callers from partial writes and cross-process temp-file collisions.
+public class FileHelpersTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FileHelpersTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "easysave-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WriteAllTextAtomic_Success_WritesExpectedContent()
+    {
+        var path = Path.Combine(_tempDir, "payload.json");
+
+        FileHelpers.WriteAllTextAtomic(path, "hello world");
+
+        Assert.Equal("hello world", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void WriteAllTextAtomic_Success_LeavesNoTempOrphan()
+    {
+        var path = Path.Combine(_tempDir, "payload.json");
+
+        FileHelpers.WriteAllTextAtomic(path, "content");
+
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
+    }
+
+    [Fact]
+    public void WriteAllTextAtomic_MoveFails_DeletesTempFileAndRethrows()
+    {
+        // Using a directory as the target path forces File.Move to fail after the temp
+        // file has been written, which is exactly the code path that must clean up.
+        var target = Path.Combine(_tempDir, "target-dir");
+        Directory.CreateDirectory(target);
+
+        Assert.ThrowsAny<Exception>(() => FileHelpers.WriteAllTextAtomic(target, "content"));
+
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
+    }
+
+    [Fact]
+    public void WriteAllTextAtomic_ConcurrentCalls_DoNotCollideOnTempName()
+    {
+        // Ten threads write to the same target. With a fixed ".tmp" suffix this would
+        // race and surface as IOException or interleaved content; with unique GUID
+        // names every call owns its own temp file.
+        var path = Path.Combine(_tempDir, "shared.json");
+        const int threadCount = 10;
+
+        var threads = new Thread[threadCount];
+        var exceptions = new List<Exception>();
+        var exceptionsLock = new object();
+
+        for (var i = 0; i < threadCount; i++)
+        {
+            var payload = $"thread-{i}";
+            threads[i] = new Thread(() =>
+            {
+                try { FileHelpers.WriteAllTextAtomic(path, payload); }
+                catch (Exception ex)
+                {
+                    lock (exceptionsLock) { exceptions.Add(ex); }
+                }
+            });
+        }
+
+        foreach (var t in threads) t.Start();
+        foreach (var t in threads) t.Join();
+
+        Assert.Empty(exceptions);
+        Assert.True(File.Exists(path));
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
+    }
+}

--- a/tests/EasySave.Tests/JobRepositoryTests.cs
+++ b/tests/EasySave.Tests/JobRepositoryTests.cs
@@ -86,7 +86,8 @@ public class JobRepositoryTests : IDisposable
             Assert.NotNull(parsed);
             Assert.Equal(2, parsed!.Count);
 
-            Assert.False(File.Exists(_jobsFilePath + ".tmp"));
+            // Temp names now carry a GUID suffix; verify no *.tmp orphan in the dir.
+            Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
         }
     }
 }

--- a/tests/EasySave.Tests/StateTrackerTests.cs
+++ b/tests/EasySave.Tests/StateTrackerTests.cs
@@ -91,7 +91,8 @@ public class StateTrackerTests : IDisposable
             var parsed = JsonSerializer.Deserialize<List<StateEntry>>(content);
             Assert.NotNull(parsed);
 
-            Assert.False(File.Exists(_stateFilePath + ".tmp"));
+            // Temp names now carry a GUID suffix; verify no *.tmp orphan in the dir.
+            Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
         }
     }
 


### PR DESCRIPTION
Closes #49.

## Problem
`StateTracker.WriteAtomically` and `JobRepository.Save` both used a fixed `path + ".tmp"` sibling and did nothing if the write failed:

- Two `EasySave.exe` processes (e.g. CLI + interactive console) would race on the same `state.json.tmp` / `jobs.json.tmp`. On Windows this can surface as `IOException: file in use`; on Linux the contents can interleave.
- If `File.WriteAllText` threw (disk full, permission denied), the `.tmp` was left orphaned on disk. Monitoring tools scanning `data/` would see `state.json.tmp` and think the run is broken.

## Fix
Factor the atomic write into `FileHelpers.WriteAllTextAtomic` and route both services through it:

- Temp name is now `{path}.{Guid.NewGuid():N}.tmp` → collision-free between processes.
- A `try/catch` deletes the temp file before rethrowing so a crash never leaves an orphan.
- Removes the duplicated atomic-write logic that previously lived in both `StateTracker` and `JobRepository` (aligns with the "zero duplication" grading criterion).

## Tests
New `FileHelpersTests` (4 tests):
- `WriteAllTextAtomic_Success_WritesExpectedContent`
- `WriteAllTextAtomic_Success_LeavesNoTempOrphan`
- `WriteAllTextAtomic_MoveFails_DeletesTempFileAndRethrows` — forces `File.Move` to fail by pointing at an existing directory and verifies the temp file is deleted.
- `WriteAllTextAtomic_ConcurrentCalls_DoNotCollideOnTempName` — 10 threads hammering the same target path; none throw, no `.tmp` orphan remains.

Existing `.tmp` assertions in `StateTrackerTests` and `JobRepositoryTests` now use `Directory.GetFiles(dir, "*.tmp")` since the suffix is dynamic.

All 49 tests pass via `dotnet test`.

## Scope
Only `EasySave` services are touched here. The same pattern could be applied to `JsonDailyLogger` in `EasyLog` (mentioned in the issue), but that crosses into Dev1's territory and is better as a separate PR.