### PR TITLE
fix: address release v1.0.0 review feedback

### DIFF
--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -42,7 +42,7 @@ public sealed class AppConfig
             var json = File.ReadAllText(path);
             Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or IOException)
         {
             Instance = new AppConfig();
         }

--- a/src/EasySave/Services/DifferentialBackupStrategy.cs
+++ b/src/EasySave/Services/DifferentialBackupStrategy.cs
@@ -1,6 +1,6 @@
 namespace EasySave.Services;
 
-public class DifferentialBackupStrategy : IBackupStrategy
+public sealed class DifferentialBackupStrategy : IBackupStrategy
 {
     public bool ShouldCopy(FileInfo source, string targetPath)
     {

--- a/src/EasySave/Services/FullBackupStrategy.cs
+++ b/src/EasySave/Services/FullBackupStrategy.cs
@@ -1,6 +1,6 @@
 namespace EasySave.Services;
 
-public class FullBackupStrategy : IBackupStrategy
+public sealed class FullBackupStrategy : IBackupStrategy
 {
     public bool ShouldCopy(FileInfo source, string targetPath) => true;
 }

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -46,11 +46,34 @@ public sealed class StateTracker
             var json = File.ReadAllText(path);
             return JsonSerializer.Deserialize<List<StateEntry>>(json) ?? new List<StateEntry>();
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (JsonException ex)
         {
-            // Treat a corrupted or transiently unreadable state file as empty
-            // rather than crashing the caller inside the lock.
+            QuarantineCorruptedFile(path, ex);
             return new List<StateEntry>();
+        }
+        catch (IOException)
+        {
+            // Transient read error (file locked by another process): treat as empty
+            // without quarantining, so the next Update rewrites the file.
+            return new List<StateEntry>();
+        }
+    }
+
+    // Renames a corrupted state file so operators can inspect it later,
+    // instead of silently wiping all job states on the next Update.
+    private static void QuarantineCorruptedFile(string path, Exception reason)
+    {
+        try
+        {
+            var quarantinePath = $"{path}.corrupted-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}";
+            File.Move(path, quarantinePath);
+            Console.Error.WriteLine(
+                $"[StateTracker] {Path.GetFileName(path)} was unreadable and has been moved to " +
+                $"{Path.GetFileName(quarantinePath)}. Reason: {reason.Message}");
+        }
+        catch
+        {
+            // If the rename itself fails, fall back to returning an empty list so the app keeps running.
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the three actionable issues raised by the bot review on PR #53.

## Changes

- **`AppConfig.Load`** — catches `IOException` in addition to `JsonException` so a locked or unreadable `appsettings.json` falls back to defaults instead of crashing the process at startup.
- **`StateTracker`** — on `JsonException`, moves the corrupted `state.json` to a timestamped `*.corrupted-<ts>-<guid>` file and logs to stderr, instead of silently wiping every other job's state on the next `Update`. Mirrors the `JobRepository` quarantine pattern. Transient `IOException` still returns empty without quarantining so the next write heals the file.
- **`FullBackupStrategy`** and **`DifferentialBackupStrategy`** — marked `sealed` to align with every other concrete service class.

## Out of scope

- **Progress accounting on failure** (`FilesRemaining` decrement) — kept as-is. Current semantics (*files processed*) is intentional; switching to *successfully copied* would block progress reporting when any file fails. Revisit in v1.1 with a dedicated `FilesFailed` counter.
- **Job-level failure audit trail in the daily log** — scope expansion, deferred to v1.1.
- **Extra CLI arg warning** — cosmetic UX nit, deferred.

## Test plan

- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` — 45/45 pass locally
- [ ] CI green on push