### PR TITLE
docs: document MVC mapping and v2.0 migration path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,58 @@ are in the constructor. Singletons (`StateTracker`, `JobRepository`) are
 fetched via `Instance` and passed in explicitly — they are never located
 from inside a service.
 
+## MVC mapping — ready for the v2.0 WPF migration
+
+The layered architecture above maps cleanly onto the MVC triad the cahier
+requires for v2.0 (WPF / MVVM). Nothing in the business layer is tied to the
+console; swapping the view is a localised change in `Program.Main`.
+
+| MVC role | v1.0 implementation | Files |
+| --- | --- | --- |
+| **Model** | Domain types + business services. No UI dependency. | `src/EasySave/Models/BackupJob.cs`, `src/EasySave/StateEntry.cs`, `src/EasySave/BackupType.cs`, `src/EasySave/JobState.cs`, `src/EasySave/Services/BackupManager.cs`, `src/EasySave/Services/{Full,Differential}BackupStrategy.cs`, `src/EasySave/Services/{StateTracker,JobRepository,AppConfig,LanguageService}.cs`, `src/EasyLog/*` |
+| **View** | Rendering + user input. No business rule. | `src/EasySave/CLI/ConsoleUI.cs` |
+| **Controller** | Input parsing + orchestration between View and Model. | `src/EasySave/CLI/CommandParser.cs`, menu dispatcher in `ConsoleUI.Run()`, direct-mode dispatcher in `src/EasySave/Program.cs` |
+
+### What the View is **not** allowed to do (v1.0 audit)
+
+`ConsoleUI` has been reviewed against these rules and is compliant today:
+
+- No call to `File.Copy`, `File.WriteAllText`, `Directory.CreateDirectory`, or any filesystem API.
+- No JSON serialization or deserialization.
+- No backup-type decision — it only passes `BackupType` to `BackupManager`.
+- No enforcement of the 5-job limit, duplicate-name check, or path validation — these live in `BackupManager`.
+- No direct access to `StateTracker`, `JobRepository`, or `AppConfig` — it only talks to `BackupManager` and `LanguageService`.
+
+Service-layer exceptions carry **translation keys** (`"error.max_jobs"`, `"error.duplicate_job"`, ...), not prose. The View translates; it never invents the policy.
+
+### v1.0 → v2.0 migration path
+
+Switching from console to WPF is a two-line change in `Program.Main`:
+
+```csharp
+// v1.0 — console
+var ui = new ConsoleUI(backupManager, langService);
+ui.Run();
+```
+
+becomes:
+
+```csharp
+// v2.0 — WPF/MVVM (hypothetical)
+var app = new App();
+app.MainViewModel = new MainViewModel(backupManager, langService);
+app.Run();
+```
+
+`backupManager`, `langService`, and every service/model behind them stay
+untouched. The new `MainViewModel` consumes the exact same public API
+(`AddJob`, `RemoveJob`, `ListJobs`, `ExecuteJob`, `ExecuteAll`, `T(key)`),
+binds to WPF controls, and subscribes to progress by polling or wrapping
+`StateTracker` in a v2 event source.
+
+The `EasyLog` DLL v1.x contract is frozen (see [`src/EasyLog/README.md`](../src/EasyLog/README.md))
+and is reused as-is in v2.0 — no recompilation, no adapter.
+
 ## Design patterns
 
 | Pattern | Where | Why |


### PR DESCRIPTION
## Summary

Addresses the grille tuteur: *"L'architecture a permis aux étudiants de passer facilement du mode console au mode graphique (Design Pattern type MVC)."*

The code already satisfies the structural requirement (no business logic in `ConsoleUI`, all services UI-agnostic). This PR adds the explicit documentation so the tutor can validate without re-reading source files.

## Changes

- New section **MVC mapping — ready for the v2.0 WPF migration** in `docs/architecture.md`:
  - Table mapping Model / View / Controller to actual v1.0 files (paths included)
  - Audit of what `ConsoleUI` is not allowed to do — all 5 rules checked against the current code
  - Two-line migration snippet from `ConsoleUI` to a WPF `MainViewModel`
  - Note that `EasyLog v1.x` contract is reused as-is in v2.0

## Test plan

- [ ] Docs only, no build impact
- [ ] Links in the MVC table resolve on GitHub

## ClickUp

Task `869cym658` — [Grille] Architecture MVC prête pour passage console → graphique (V2).