### PR TITLE
fix(config): default data paths to per-user AppData directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `AppConfig` defaults now resolve to the OS-standard per-user application data directory instead of `data/` next to the executable. `LogDirectory`, `StateFilePath`, and `JobsFilePath` now default under `%AppData%\ProSoft\EasySave\` on Windows and `~/.config/ProSoft/EasySave/` on Linux/macOS. All three remain overridable from `appsettings.json`.
+
 ## [1.0.0] — 2026-04-21
 
 First release delivered to ProSoft. Console backup tool with up to 5 jobs,

--- a/docs/support-client.md
+++ b/docs/support-client.md
@@ -15,17 +15,18 @@ The runtime can be downloaded from <https://dotnet.microsoft.com/download/dotnet
 
 ## Installation layout
 
-After installation, the application directory contains:
+The application is split between the install directory (binaries, read-only) and the per-user data directory (runtime files, writable).
+
+### Install directory
 
 ```
 <install-dir>/
 ├── EasySave(.exe)           # Entry point
 ├── EasyLog.dll              # Logger library
 ├── appsettings.json         # Configuration file (editable)
-└── data/
-    ├── logs/                # Daily log files (yyyy-MM-dd.json)
-    ├── state.json           # Real-time state of the 5 jobs
-    └── jobs.json            # Persisted job definitions
+└── Resources/
+    ├── en.json
+    └── fr.json
 ```
 
 The `<install-dir>` depends on the deployment method (MSI, ZIP extraction, or `dotnet publish` output). Typical locations per platform:
@@ -33,6 +34,23 @@ The `<install-dir>` depends on the deployment method (MSI, ZIP extraction, or `d
 - Windows: `C:\Program Files\ProSoft\EasySave\`
 - Linux: `/opt/prosoft/easysave/`
 - macOS: `/Applications/EasySave.app/Contents/MacOS/` or `/usr/local/prosoft/easysave/`
+
+### Runtime data directory (per user)
+
+Logs, state, and job definitions are written under the OS-standard per-user application data directory — never in `C:\temp` nor in the install directory (which would require elevation on Windows):
+
+- Windows: `%AppData%\ProSoft\EasySave\` (resolves to `C:\Users\<user>\AppData\Roaming\ProSoft\EasySave\`)
+- Linux: `~/.config/ProSoft/EasySave/`
+- macOS: `~/.config/ProSoft/EasySave/`
+
+```
+<data-dir>/
+├── Logs/                   # Daily log files (yyyy-MM-dd.json)
+├── state.json              # Real-time state of the 5 jobs
+└── jobs.json               # Persisted job definitions
+```
+
+The directory is created automatically on the first run. All three paths are overridable via `appsettings.json` (see below) if the customer needs to redirect them to a network share or a service account.
 
 ## Configurable locations
 
@@ -60,12 +78,12 @@ Linux / macOS example:
 }
 ```
 
-| Key | Purpose | Default |
-| --- | --- | --- |
-| `LogDirectory` | Folder where daily JSON logs are written | `./data/logs/` |
-| `StateFilePath` | Full path of the single `state.json` | `./data/state.json` |
-| `JobsFilePath` | Full path of the job definitions file | `./data/jobs.json` |
-| `Language` | UI language (`en` or `fr`) | `en` |
+| Key | Purpose | Default (Windows) | Default (Linux / macOS) |
+| --- | --- | --- | --- |
+| `LogDirectory` | Folder where daily JSON logs are written | `%AppData%\ProSoft\EasySave\Logs` | `~/.config/ProSoft/EasySave/Logs` |
+| `StateFilePath` | Full path of the single `state.json` | `%AppData%\ProSoft\EasySave\state.json` | `~/.config/ProSoft/EasySave/state.json` |
+| `JobsFilePath` | Full path of the job definitions file | `%AppData%\ProSoft\EasySave\jobs.json` | `~/.config/ProSoft/EasySave/jobs.json` |
+| `Language` | UI language (`en` or `fr`) | `en` | `en` |
 
 Network shares must be given in **UNC format** (`\\server\share\folder`). Changes take effect on the next application startup.
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -41,6 +41,6 @@ The UI supports **English** and **French**.
 
 ## Where are the logs?
 
-Daily logs are written in real time as JSON files named `yyyy-MM-dd.json` inside the log directory. The default location is `data/logs/` next to the executable, and it is configurable from `appsettings.json` (see the support guide). Each entry records the job name, source, target, size, and transfer time.
+Daily logs are written in real time as JSON files named `yyyy-MM-dd.json` inside the log directory. The default location is the per-user application data directory (`%AppData%\ProSoft\EasySave\Logs\` on Windows, `~/.config/ProSoft/EasySave/Logs/` on Linux/macOS), and it is configurable from `appsettings.json` (see the support guide). Each entry records the job name, source, target, size, and transfer time.
 
 A failed file copy is recorded with a **negative transfer time** (`FileTransferTimeMs < 0`).

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -7,17 +7,25 @@ namespace EasySave.Services;
 // Any service that needs a file path or a user-facing setting reads from AppConfig.Instance.
 public sealed class AppConfig
 {
+    // Per-user application data root. Resolves to %AppData%\ProSoft\EasySave on Windows
+    // and ~/.config/ProSoft/EasySave on Linux / macOS. Avoids C:\temp or the install
+    // directory (which would require UAC under C:\Program Files).
+    private static readonly string DataRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "ProSoft",
+        "EasySave");
+
     // Current configuration. Replaced once at startup by Load().
     public static AppConfig Instance { get; private set; } = new AppConfig();
 
-    // Directory where daily log files are written. Anchored to the executable directory.
-    public string LogDirectory { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "logs");
+    // Directory where daily log files are written.
+    public string LogDirectory { get; init; } = Path.Combine(DataRoot, "Logs");
 
-    // Full path of the real-time state file. Anchored to the executable directory.
-    public string StateFilePath { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "state.json");
+    // Full path of the real-time state file.
+    public string StateFilePath { get; init; } = Path.Combine(DataRoot, "state.json");
 
-    // Full path of the backup jobs definitions file. Anchored to the executable directory.
-    public string JobsFilePath { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "jobs.json");
+    // Full path of the backup jobs definitions file.
+    public string JobsFilePath { get; init; } = Path.Combine(DataRoot, "jobs.json");
 
     // UI language code (ISO 639-1), e.g. "en" or "fr".
     public string Language { get; init; } = "en";


### PR DESCRIPTION
## Summary

Addresses the grille tuteur: *"Les emplacements des fichiers (log journalier, état, fichier configuration) sont judicieux."*

Previous defaults wrote logs/state/jobs under \`data/\` next to the executable. On a Windows production install under \`C:\\Program Files\\ProSoft\\EasySave\\\`, this fails without UAC elevation.

## Changes

- **\`AppConfig.cs\`** — defaults now resolve under \`Environment.SpecialFolder.ApplicationData\`:
  - Windows: \`%AppData%\\ProSoft\\EasySave\\{Logs,state.json,jobs.json}\`
  - Linux: \`~/.config/ProSoft/EasySave/{Logs,state.json,jobs.json}\`
  - macOS: \`~/.config/ProSoft/EasySave/{Logs,state.json,jobs.json}\`
- **\`docs/support-client.md\`** — split Install directory (read-only) from Runtime data directory (writable per-user), updated defaults table with Windows/Unix columns.
- **\`docs/user-manual.md\`** — updated log location line.
- **\`CHANGELOG.md\`** — added entry under Unreleased → Changed.

All three paths remain overridable via \`appsettings.json\` unchanged.

## Test plan

- [x] \`dotnet build\` passes
- [x] \`dotnet test\` — 49/49 pass locally
- [ ] CI green on push

## ClickUp

Task \`869cym65f\` — [Grille] Emplacements judicieux des fichiers (log, état, config).