### PR TITLE
refactor: extract shared quarantine helper and job selection runner

### DIFF
--- a/src/EasySave/CLI/ConsoleUI.cs
+++ b/src/EasySave/CLI/ConsoleUI.cs
@@ -157,29 +157,7 @@ public sealed class ConsoleUI
             return;
         }
 
-        foreach (var idx in indices)
-        {
-            if (idx < 1 || idx > jobs.Count)
-            {
-                Console.WriteLine(string.Format(_lang.T("error.job_not_found"), idx));
-                continue;
-            }
-
-            Console.WriteLine(string.Format(_lang.T("job.executing"), jobs[idx - 1].Name));
-            try
-            {
-                _backupManager.ExecuteJob(jobs[idx - 1].Name);
-                Console.WriteLine(string.Format(_lang.T("job.done"), jobs[idx - 1].Name));
-            }
-            catch (DirectoryNotFoundException)
-            {
-                Console.WriteLine(_lang.T("error.source_not_found"));
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(string.Format(_lang.T("error.execute_failed"), ex.Message));
-            }
-        }
+        JobSelectionRunner.Execute(indices, jobs, _backupManager, _lang, Console.WriteLine, Console.WriteLine);
     }
 
     private void ChangeLanguage()

--- a/src/EasySave/CLI/JobSelectionRunner.cs
+++ b/src/EasySave/CLI/JobSelectionRunner.cs
@@ -1,0 +1,53 @@
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.CLI;
+
+/// <summary>
+/// Runs a pre-parsed list of job indices against the backup manager and reports
+/// each result through the language service. Shared by the interactive menu
+/// (<see cref="ConsoleUI"/>) and the direct-mode CLI (<c>Program.Main</c>) so
+/// the execution feedback stays consistent and i18n-correct everywhere.
+/// </summary>
+internal static class JobSelectionRunner
+{
+    /// <summary>
+    /// Executes each <paramref name="indices"/> entry against the matching job in
+    /// <paramref name="jobs"/>. Invalid indices and job failures are reported via
+    /// <paramref name="writeError"/>; successes via <paramref name="writeInfo"/>.
+    /// Continues on failure so a single bad job does not abort the batch.
+    /// </summary>
+    public static void Execute(
+        IReadOnlyList<int> indices,
+        IReadOnlyList<BackupJob> jobs,
+        BackupManager backupManager,
+        LanguageService lang,
+        Action<string> writeInfo,
+        Action<string> writeError)
+    {
+        foreach (var idx in indices)
+        {
+            if (idx < 1 || idx > jobs.Count)
+            {
+                writeError(string.Format(lang.T("error.job_not_found"), idx));
+                continue;
+            }
+
+            var name = jobs[idx - 1].Name;
+            writeInfo(string.Format(lang.T("job.executing"), name));
+            try
+            {
+                backupManager.ExecuteJob(name);
+                writeInfo(string.Format(lang.T("job.done"), name));
+            }
+            catch (DirectoryNotFoundException)
+            {
+                writeError(lang.T("error.source_not_found"));
+            }
+            catch (Exception ex)
+            {
+                writeError(string.Format(lang.T("error.execute_failed"), ex.Message));
+            }
+        }
+    }
+}

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -25,30 +25,13 @@ if (cliArgs.Length > 0)
         return;
     }
 
-    var jobs = backupManager.ListJobs();
-    foreach (var idx in indices)
-    {
-        if (idx < 1 || idx > jobs.Count)
-        {
-            Console.Error.WriteLine(string.Format(langService.T("error.job_not_found"), idx));
-            continue;
-        }
-
-        Console.WriteLine(string.Format(langService.T("job.executing"), jobs[idx - 1].Name));
-        try
-        {
-            backupManager.ExecuteJob(jobs[idx - 1].Name);
-            Console.WriteLine(string.Format(langService.T("job.done"), jobs[idx - 1].Name));
-        }
-        catch (DirectoryNotFoundException)
-        {
-            Console.Error.WriteLine(langService.T("error.source_not_found"));
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine(string.Format(langService.T("error.execute_failed"), ex.Message));
-        }
-    }
+    JobSelectionRunner.Execute(
+        indices,
+        backupManager.ListJobs(),
+        backupManager,
+        langService,
+        Console.WriteLine,
+        Console.Error.WriteLine);
 }
 else
 {

--- a/src/EasySave/Services/FileHelpers.cs
+++ b/src/EasySave/Services/FileHelpers.cs
@@ -37,4 +37,24 @@ internal static class FileHelpers
             throw;
         }
     }
+
+    // Renames a corrupted persistence file to a timestamped backup so operators can inspect
+    // it later. Used by JobRepository and StateTracker to avoid silently dropping user data
+    // when jobs.json or state.json cannot be deserialized. If the rename itself fails, the
+    // caller keeps running with empty state (best effort, we never mask the original error).
+    public static void QuarantineCorruptedFile(string path, Exception reason, string loggerTag)
+    {
+        try
+        {
+            var quarantinePath = $"{path}.corrupted-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}";
+            File.Move(path, quarantinePath);
+            Console.Error.WriteLine(
+                $"[{loggerTag}] {Path.GetFileName(path)} was unreadable and has been moved to " +
+                $"{Path.GetFileName(quarantinePath)}. Reason: {reason.Message}");
+        }
+        catch
+        {
+            // If the rename itself fails, fall back to returning an empty list so the app keeps running.
+        }
+    }
 }

--- a/src/EasySave/Services/JobRepository.cs
+++ b/src/EasySave/Services/JobRepository.cs
@@ -36,7 +36,7 @@ public sealed class JobRepository
             }
             catch (Exception ex) when (ex is JsonException or IOException)
             {
-                QuarantineCorruptedFile(path, ex);
+                FileHelpers.QuarantineCorruptedFile(path, ex, "JobRepository");
                 return new List<BackupJob>();
             }
         }
@@ -53,24 +53,6 @@ public sealed class JobRepository
             FileHelpers.EnsureDirectoryExists(path);
 
             FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(jobs, FileHelpers.IndentedJsonOptions));
-        }
-    }
-
-    // Renames a corrupted jobs file so the user can inspect or recover it later,
-    // instead of silently dropping their backup job definitions.
-    private static void QuarantineCorruptedFile(string path, Exception reason)
-    {
-        try
-        {
-            var quarantinePath = $"{path}.corrupted.{DateTime.UtcNow:yyyyMMddHHmmss}";
-            File.Move(path, quarantinePath);
-            Console.Error.WriteLine(
-                $"[JobRepository] {Path.GetFileName(path)} was unreadable and has been moved to " +
-                $"{Path.GetFileName(quarantinePath)}. Reason: {reason.Message}");
-        }
-        catch
-        {
-            // If the rename itself fails, fall back to returning an empty list so the app keeps running.
         }
     }
 }

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -48,7 +48,7 @@ public sealed class StateTracker
         }
         catch (JsonException ex)
         {
-            QuarantineCorruptedFile(path, ex);
+            FileHelpers.QuarantineCorruptedFile(path, ex, "StateTracker");
             return new List<StateEntry>();
         }
         catch (IOException)
@@ -56,24 +56,6 @@ public sealed class StateTracker
             // Transient read error (file locked by another process): treat as empty
             // without quarantining, so the next Update rewrites the file.
             return new List<StateEntry>();
-        }
-    }
-
-    // Renames a corrupted state file so operators can inspect it later,
-    // instead of silently wiping all job states on the next Update.
-    private static void QuarantineCorruptedFile(string path, Exception reason)
-    {
-        try
-        {
-            var quarantinePath = $"{path}.corrupted-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}";
-            File.Move(path, quarantinePath);
-            Console.Error.WriteLine(
-                $"[StateTracker] {Path.GetFileName(path)} was unreadable and has been moved to " +
-                $"{Path.GetFileName(quarantinePath)}. Reason: {reason.Message}");
-        }
-        catch
-        {
-            // If the rename itself fails, fall back to returning an empty list so the app keeps running.
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses the grille tuteur: *"Le code est optimisé (absence de redondance)."*

After the earlier `FileHelpers.WriteAllTextAtomic` pass, two real duplications remained. This PR consolidates both.

## Changes

### 1. `FileHelpers.QuarantineCorruptedFile(path, reason, loggerTag)`

Centralises the *"rename corrupted file to \`.corrupted-<ts>-<guid>\` + log to stderr"* pattern previously copy-pasted in `JobRepository.QuarantineCorruptedFile` and `StateTracker.QuarantineCorruptedFile`. Both now delegate to the helper.

Not touched: `JsonDailyLogger` in `EasyLog.dll` keeps its own inline copy — the DLL must stay standalone and cannot depend on EasySave services (per the v1.x API contract).

### 2. `CLI/JobSelectionRunner.Execute(indices, jobs, manager, lang, writeInfo, writeError)`

Centralises the *"foreach-over-indices loop with bounds check + i18n messaging + typed catch (DirectoryNotFound / generic)"* previously duplicated between:
- `Program.cs` (direct CLI mode): 23 lines
- `ConsoleUI.ExecuteJobs` (interactive menu): 23 lines

Both call sites now reduce to a single helper invocation. Interactive menu writes everything to stdout; CLI mode sends errors to stderr — the \`writeInfo\`/\`writeError\` callbacks let each caller pick.

## Test plan

- [x] \`dotnet build\` passes (0 errors)
- [x] \`dotnet test\` — 49/49 pass locally
- [ ] CI green on push

## Stats

\`6 files changed, 83 insertions(+), 85 deletions(-)\` — net reduction.

## ClickUp

Task \`869cym60d\` — [Grille] Code optimisé (absence de redondance).