### PR TITLE
style: address review nits from PR #61

### DIFF
--- a/src/EasySave/CLI/JobSelectionRunner.cs
+++ b/src/EasySave/CLI/JobSelectionRunner.cs
@@ -3,20 +3,9 @@ using EasySave.Services;
 
 namespace EasySave.CLI;
 
-/// <summary>
-/// Runs a pre-parsed list of job indices against the backup manager and reports
-/// each result through the language service. Shared by the interactive menu
-/// (<see cref="ConsoleUI"/>) and the direct-mode CLI (<c>Program.Main</c>) so
-/// the execution feedback stays consistent and i18n-correct everywhere.
-/// </summary>
 internal static class JobSelectionRunner
 {
-    /// <summary>
-    /// Executes each <paramref name="indices"/> entry against the matching job in
-    /// <paramref name="jobs"/>. Invalid indices and job failures are reported via
-    /// <paramref name="writeError"/>; successes via <paramref name="writeInfo"/>.
-    /// Continues on failure so a single bad job does not abort the batch.
-    /// </summary>
+    // indices are 1-based; writeError and writeInfo let callers route to stdout vs stderr
     public static void Execute(
         IReadOnlyList<int> indices,
         IReadOnlyList<BackupJob> jobs,

--- a/src/EasySave/Services/FileHelpers.cs
+++ b/src/EasySave/Services/FileHelpers.cs
@@ -54,7 +54,7 @@ internal static class FileHelpers
         }
         catch
         {
-            // If the rename itself fails, fall back to returning an empty list so the app keeps running.
+            // best effort — if the rename fails the caller continues with empty state
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses the two non-blocking nits raised by the bot review on PR #61 (already merged):

- **`FileHelpers.cs:57`** — catch comment was factually wrong after the refactor (the method is \`void\`, the empty-list fallback lives in the caller). Replaced with \"best effort — if the rename fails the caller continues with empty state\".
- **`JobSelectionRunner.cs`** — dropped the verbose XML \`<summary>\` blocks (described what, not why). Kept a single \`//\` line on the method documenting the non-obvious parts: the 1-based index contract and the stdout/stderr routing via callbacks.

## Test plan

- [x] \`dotnet build\` passes
- [ ] CI green on push