### PR TITLE
fix: avoid data loss on locked jobs.json and route interactive errors to stderr

### DIFF
--- a/src/EasySave/CLI/ConsoleUI.cs
+++ b/src/EasySave/CLI/ConsoleUI.cs
@@ -157,7 +157,7 @@ public sealed class ConsoleUI
             return;
         }
 
-        JobSelectionRunner.Execute(indices, jobs, _backupManager, _lang, Console.WriteLine, Console.WriteLine);
+        JobSelectionRunner.Execute(indices, jobs, _backupManager, _lang, Console.WriteLine, Console.Error.WriteLine);
     }
 
     private void ChangeLanguage()

--- a/src/EasySave/Services/JobRepository.cs
+++ b/src/EasySave/Services/JobRepository.cs
@@ -34,9 +34,16 @@ public sealed class JobRepository
                 var json = File.ReadAllText(path);
                 return JsonSerializer.Deserialize<List<BackupJob>>(json) ?? new List<BackupJob>();
             }
-            catch (Exception ex) when (ex is JsonException or IOException)
+            catch (JsonException ex)
             {
                 FileHelpers.QuarantineCorruptedFile(path, ex, "JobRepository");
+                return new List<BackupJob>();
+            }
+            catch (IOException)
+            {
+                // Transient read error (file locked by another process): treat as empty
+                // without quarantining, so the user's jobs.json is not lost if an antivirus
+                // or backup agent holds the file briefly.
                 return new List<BackupJob>();
             }
         }


### PR DESCRIPTION
## Summary

Two follow-ups from the post-v1.0.1 review.

### 1. Data loss bug — \`JobRepository.Load\`

Previously caught \`JsonException\` **and** \`IOException\` in the same block and triggered quarantine for both. A transient file lock (antivirus, backup agent reading the file) would rename \`jobs.json\` to \`jobs.json.corrupted-<ts>-<guid>\` and the next run would see zero jobs — user's 5 job definitions effectively deleted until they find the quarantined file.

Fix: split the catch blocks. Only \`JsonException\` quarantines now; \`IOException\` returns empty without renaming so the next attempt reads the file cleanly once the lock releases. Mirrors the existing \`StateTracker\` behaviour.

### 2. stderr inconsistency — \`ConsoleUI.ExecuteJobs\`

Both \`writeInfo\` and \`writeError\` callbacks were \`Console.WriteLine\`. Direct CLI mode in \`Program.cs\` already routes errors to \`Console.Error.WriteLine\`; the interactive menu now does the same.

## Test plan

- [x] \`dotnet build\` passes
- [x] \`dotnet test\` — 49/49 pass locally
- [ ] CI green on push