### PR TITLE
test(v2): add EasySave.Tests.V2 xUnit project

### DIFF
--- a/EasySave.sln
+++ b/EasySave.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Tests", "tests\Eas
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Tests.V2", "tests\EasySave.Tests.V2\EasySave.Tests.V2.csproj", "{933118A6-084B-4CDE-A7D8-0731F26A0008}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,11 +61,24 @@ Global
 		{A87B02F6-F8F9-455B-8E57-E1284CF5D6F2}.Release|x64.Build.0 = Release|Any CPU
 		{A87B02F6-F8F9-455B-8E57-E1284CF5D6F2}.Release|x86.ActiveCfg = Release|Any CPU
 		{A87B02F6-F8F9-455B-8E57-E1284CF5D6F2}.Release|x86.Build.0 = Release|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Debug|x64.Build.0 = Debug|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Debug|x86.Build.0 = Debug|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Release|Any CPU.Build.0 = Release|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Release|x64.ActiveCfg = Release|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Release|x64.Build.0 = Release|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Release|x86.ActiveCfg = Release|Any CPU
+		{933118A6-084B-4CDE-A7D8-0731F26A0008}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A87B02F6-F8F9-455B-8E57-E1284CF5D6F2} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{933118A6-084B-4CDE-A7D8-0731F26A0008} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/EasySave/EasySave.csproj
+++ b/src/EasySave/EasySave.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="EasySave.Tests" />
+    <InternalsVisibleTo Include="EasySave.Tests.V2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EasySave.Tests.V2/EasySave.Tests.V2.csproj
+++ b/tests/EasySave.Tests.V2/EasySave.Tests.V2.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>EasySave.Tests.V2</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EasySave\EasySave.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EasySave.Tests.V2/SmokeTests.cs
+++ b/tests/EasySave.Tests.V2/SmokeTests.cs
@@ -1,0 +1,50 @@
+using EasyLog;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests.V2;
+
+// Smoke tests confirming the V2 test project is wired up against EasyLog and EasySave.
+// Real V2 test classes (V2 logger formatters, encryption time, restore, scheduler...) will
+// land here once the corresponding features are implemented.
+public class SmokeTests
+{
+    [Fact]
+    public void EasyLog_LogEntry_IsAccessible()
+    {
+        var entry = new LogEntry
+        {
+            Timestamp = "2026-04-27T00:00:00+02:00",
+            JobName = "smoke",
+            SourceFile = "/tmp/source.txt",
+            TargetFile = "/tmp/target.txt",
+            FileSize = 42,
+            FileTransferTimeMs = 1,
+        };
+
+        Assert.Equal("smoke", entry.JobName);
+    }
+
+    [Fact]
+    public void EasySave_BackupJob_IsAccessible()
+    {
+        var job = new BackupJob
+        {
+            Name = "smoke",
+            SourcePath = "/tmp/src",
+            TargetPath = "/tmp/dst",
+            Type = BackupType.Full,
+        };
+
+        Assert.Equal(BackupType.Full, job.Type);
+    }
+
+    [Fact]
+    public void EasySave_AppConfig_HasDefaults()
+    {
+        Assert.NotNull(AppConfig.Instance);
+        Assert.False(string.IsNullOrWhiteSpace(AppConfig.Instance.LogDirectory));
+        Assert.False(string.IsNullOrWhiteSpace(AppConfig.Instance.StateFilePath));
+        Assert.False(string.IsNullOrWhiteSpace(AppConfig.Instance.JobsFilePath));
+    }
+}


### PR DESCRIPTION
## Summary

Lays down the foundation for v2 testing. Mirrors the v1 test project setup so the team can start writing v2 tests immediately as features ship.

## Changes

- **`tests/EasySave.Tests.V2/`** new project with the same xUnit/coverlet stack as the v1 tests.
- **Project reference** to `EasySave` (transitively pulls `EasyLog`).
- **`InternalsVisibleTo`** extended to `EasySave.Tests.V2` in `src/EasySave/EasySave.csproj`.
- **3 smoke tests** confirming `LogEntry`, `BackupJob`, and `AppConfig` are reachable. Will be replaced by real V2 tests as features ship.

## Out of scope

- **`EasySave.UI` (Avalonia) reference**: project does not exist yet. Will be added in a follow-up once Samuel adds the Avalonia project to the solution.

## Test plan

- [x] \`dotnet build\` passes
- [x] \`dotnet test\` — 49/49 v1 + 3/3 v2 = 52/52 pass locally
- [ ] CI green on push

## ClickUp

Task \`869d035hn\` — Créer projet xUnit EasySave.Tests.V2.