### PR TITLE
docs: add v2.0 roadmap section to README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@ This file is loaded by the Claude Code Action during PR reviews. Keep reviews al
 - **EasySave** — console backup tool for the fictional editor **ProSoft**
 - School project: CESI PGE A3 FISE INFO, Software Engineering track
 - Team of 4 developers, solo owners per zone (see `docs/COMMIT_CONVENTION.md`)
-- This is **v1.0**. v2.0 will bring WPF/MVVM. v3.0 spec unknown for now.
+- v1.0 is released. v2.0 is in progress.
+- v2.0 GUI: the cahier mentions WPF/MVVM. The team chose **Avalonia** (cross-platform MVVM, same pattern as WPF) so the macOS members can run the app natively. Reviews must accept Avalonia as the v2.0 GUI framework.
+- v3.0 spec unknown for now.
 
 ## Solution layout
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ EasySave.sln
 ├── src/
 │   ├── EasySave/          # Console application (entry point)
 │   └── EasyLog/           # Reusable daily JSON logger library
+├── tests/
+│   ├── EasySave.Tests/    # v1 unit and integration tests (xUnit)
+│   └── EasySave.Tests.V2/ # v2 unit and integration tests (xUnit)
 └── docs/                  # Conventions and documentation
 ```
 
@@ -59,6 +62,54 @@ examples, and versioning policy.
 - [Architecture Decision Records](docs/adrs/) — design decisions and their rationale
 - [UML diagrams](docs/diagrams/) — use case, class, activity, sequence
 - [EasyLog DLL documentation](src/EasyLog/README.md) — public API and versioning policy
+
+## Roadmap
+
+### v1.x (current — released)
+
+- Console application, up to 5 backup jobs (Full / Differential).
+- `EasyLog.dll` — daily JSON logger, thread-safe, atomic writes.
+- Real-time `state.json`, configurable paths via `appsettings.json`.
+- English and French UI, hot-switchable.
+- Latest: [v1.0.1](https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/releases/tag/v1.0.1).
+- Maintained on the [`release/v1.x`](https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/tree/release/v1.x) branch.
+
+### v2.0 (in progress)
+
+EasySave v2.0 evolves the console tool into a graphical application while keeping
+the v1.0 services intact. The v1.x `EasyLog.dll` contract is preserved (frozen
+public API), so v2.0 reuses the library without recompilation.
+
+- **Cross-platform GUI in Avalonia** (`EasySave.UI`) — replaces the console as the
+  primary interface. MVVM pattern, Windows + macOS supported. The console stays
+  available as a fallback for scripting and CI.
+- **File encryption via CryptoSoft** — selected file extensions (configured in
+  `appsettings.json`) are passed through the external CryptoSoft binary during a
+  backup. Encryption time and failures are recorded in the daily log. See
+  [`docs/cryptosoft-integration.md`](docs/cryptosoft-integration.md) for the
+  integration contract.
+- **XML logger formatter** — `EasyLog` gains an `ILogFormatter` abstraction so
+  daily logs can be written in JSON (current) or XML (with XSD schema). Choice
+  exposed in `appsettings.json`.
+- **`EncryptionTimeMs` field on `LogEntry`** — nullable, optional, additive
+  (forward-compatible with v1.x consumers that ignore unknown fields).
+- **Job count limit removed** — v2.0 accepts more than 5 jobs (cahier v2.0
+  requirement).
+- **Settings UI** — edit `encrypted_extensions`, `business_software_list` and
+  language from the GUI without manually touching `appsettings.json`.
+- **Restore** (Phase 5 bonus) — restore a backup chain (Full + subsequent Diffs),
+  with decryption when needed.
+- **Scheduler** (Phase 5 bonus) — run jobs on a recurring schedule.
+
+Tracking: see ClickUp space *EasySave v2.0*, branch
+[`v2-dev`](https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/tree/v2-dev)
+once created.
+
+### v3.0 (planned, scope to be confirmed)
+
+A new backup mode is expected (incremental). The `IBackupStrategy` interface
+introduced in v1.0 already accepts new strategies as a single class addition,
+so the backup engine should not need restructuring.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ public API), so v2.0 reuses the library without recompilation.
   available as a fallback for scripting and CI.
 - **File encryption via CryptoSoft** — selected file extensions (configured in
   `appsettings.json`) are passed through the external CryptoSoft binary during a
-  backup. Encryption time and failures are recorded in the daily log. See
-  [`docs/cryptosoft-integration.md`](docs/cryptosoft-integration.md) for the
-  integration contract.
+  backup. Encryption time and failures are recorded in the daily log. Integration
+  contract documented in `docs/cryptosoft-integration.md` (added by PR #71, lands
+  on staging once that PR merges).
 - **XML logger formatter** — `EasyLog` gains an `ILogFormatter` abstraction so
   daily logs can be written in JSON (current) or XML (with XSD schema). Choice
   exposed in `appsettings.json`.


### PR DESCRIPTION
## Summary

Adds the v2.0 roadmap to the root README so newcomers (tutor, teammates, future maintainers) see at a glance what is shipped, what is in progress, and what is planned.

## Changes

- **New \`Roadmap\` section** with three blocks:
  - **v1.x (released)**: console, 5 jobs, EasyLog DLL, AppData defaults, EN/FR. Links to v1.0.1 release and the \`release/v1.x\` maintenance branch.
  - **v2.0 (in progress)**: Avalonia cross-platform GUI, CryptoSoft encryption, XML log formatter, \`EncryptionTimeMs\` on LogEntry, job count limit removed, settings UI, restore + scheduler bonus. Cross-references \`docs/cryptosoft-integration.md\` from PR #71.
  - **v3.0 (planned)**: incremental backup mode, will land as a new \`IBackupStrategy\` implementation.
- **Project structure block** updated with the new \`tests/EasySave.Tests.V2/\` folder.

## Test plan

- [x] Markdown renders correctly (preview locally)
- [ ] Links resolve on GitHub once merged

## ClickUp

Task \`869d01ypg\` — MAJ README avec roadmap V2 (GUI, CryptoSoft, XML log).