### PR TITLE
fix(backup): always flip state to Inactive when RunJob loop throws

### DIFF
--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -165,49 +165,64 @@ public sealed class BackupManager
         };
         _stateTracker.Update(state);
 
-        foreach (var (file, targetPath) in eligible)
+        try
         {
-            FileHelpers.EnsureDirectoryExists(targetPath);
+            foreach (var (file, targetPath) in eligible)
+            {
+                FileHelpers.EnsureDirectoryExists(targetPath);
 
-            var sw = Stopwatch.StartNew();
-            long transferMs;
+                var sw = Stopwatch.StartNew();
+                long transferMs;
+                try
+                {
+                    File.Copy(file.FullName, targetPath, overwrite: true);
+                    sw.Stop();
+                    transferMs = sw.ElapsedMilliseconds;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    sw.Stop();
+                    transferMs = -1;
+                }
+
+                _logger.Append(new LogEntry
+                {
+                    Timestamp = DateTimeOffset.Now.ToString("o"),
+                    JobName = job.Name,
+                    SourceFile = file.FullName,
+                    TargetFile = targetPath,
+                    FileSize = file.Length,
+                    FileTransferTimeMs = transferMs
+                });
+
+                state.FilesRemaining--;
+                state.SizeRemaining -= file.Length;
+                state.CurrentSource = file.FullName;
+                state.CurrentTarget = targetPath;
+                state.LastActionTime = DateTimeOffset.Now;
+                _stateTracker.Update(state);
+            }
+        }
+        finally
+        {
+            // Always flip the state back to Inactive, even if the loop above
+            // throws (logger I/O error, state writer failure, permission glitch).
+            // A nested try/catch keeps the original exception from being masked
+            // by a follow-up failure inside the state tracker.
             try
             {
-                File.Copy(file.FullName, targetPath, overwrite: true);
-                sw.Stop();
-                transferMs = sw.ElapsedMilliseconds;
+                state.State = JobState.Inactive;
+                state.CurrentSource = string.Empty;
+                state.CurrentTarget = string.Empty;
+                state.LastActionTime = DateTimeOffset.Now;
+                _stateTracker.Update(state);
             }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            catch
             {
-                sw.Stop();
-                transferMs = -1;
+                // Swallow on purpose: we are in a finally and must not replace
+                // the in-flight exception with a state-write follow-up.
             }
-
-            _logger.Append(new LogEntry
-            {
-                Timestamp = DateTimeOffset.Now.ToString("o"),
-                JobName = job.Name,
-                SourceFile = file.FullName,
-                TargetFile = targetPath,
-                FileSize = file.Length,
-                FileTransferTimeMs = transferMs
-            });
-
-            state.FilesRemaining--;
-            state.SizeRemaining -= file.Length;
-            state.CurrentSource = file.FullName;
-            state.CurrentTarget = targetPath;
-            state.LastActionTime = DateTimeOffset.Now;
-            _stateTracker.Update(state);
         }
-
-        state.State = JobState.Inactive;
-        state.FilesRemaining = 0;
-        state.SizeRemaining = 0;
-        state.CurrentSource = string.Empty;
-        state.CurrentTarget = string.Empty;
-        state.LastActionTime = DateTimeOffset.Now;
-        _stateTracker.Update(state);
     }
 
     private static string GetTargetPath(BackupJob job, DirectoryInfo sourceDir, FileInfo file)

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -165,6 +165,7 @@ public sealed class BackupManager
         };
         _stateTracker.Update(state);
 
+        bool succeeded = false;
         try
         {
             foreach (var (file, targetPath) in eligible)
@@ -202,25 +203,28 @@ public sealed class BackupManager
                 state.LastActionTime = DateTimeOffset.Now;
                 _stateTracker.Update(state);
             }
+            succeeded = true;
         }
         finally
         {
             // Always flip the state back to Inactive, even if the loop above
             // throws (logger I/O error, state writer failure, permission glitch).
-            // A nested try/catch keeps the original exception from being masked
-            // by a follow-up failure inside the state tracker.
+            // The conditional catch below only swallows on the failure path so
+            // the in-flight exception is not masked by a follow-up state-writer
+            // failure; on the success path any state-writer error propagates.
             try
             {
                 state.State = JobState.Inactive;
+                state.FilesRemaining = 0;
+                state.SizeRemaining = 0;
                 state.CurrentSource = string.Empty;
                 state.CurrentTarget = string.Empty;
                 state.LastActionTime = DateTimeOffset.Now;
                 _stateTracker.Update(state);
             }
-            catch
+            catch when (!succeeded)
             {
-                // Swallow on purpose: we are in a finally and must not replace
-                // the in-flight exception with a state-write follow-up.
+                // Failure path only: do not replace the in-flight exception.
             }
         }
     }

--- a/tests/EasySave.Tests/BackupManagerExecuteTests.cs
+++ b/tests/EasySave.Tests/BackupManagerExecuteTests.cs
@@ -150,4 +150,34 @@ public class BackupManagerExecuteTests : IDisposable
         Assert.Equal(JobState.Inactive, entry.State);
         Assert.Equal(0, entry.FilesRemaining);
     }
+
+    [Fact]
+    public void ExecuteJob_LoggerThrows_StateStillFlipsToInactive()
+    {
+        File.WriteAllText(Path.Combine(_sourceDir, "file.txt"), "data");
+
+        SeedJob("logger-fail", BackupType.Full);
+        var failingLogger = new ThrowingLogger();
+        var manager = new BackupManager(
+            failingLogger,
+            new FullBackupStrategy(),
+            new DifferentialBackupStrategy(),
+            StateTracker.Instance,
+            JobRepository.Instance);
+
+        Assert.Throws<IOException>(() => manager.ExecuteJob("logger-fail"));
+
+        var stateFile = Path.Combine(_dataDir, "state.json");
+        Assert.True(File.Exists(stateFile));
+        var stateJson = File.ReadAllText(stateFile);
+        var entries = System.Text.Json.JsonSerializer.Deserialize<List<StateEntry>>(stateJson);
+        Assert.NotNull(entries);
+        var entry = Assert.Single(entries);
+        Assert.Equal(JobState.Inactive, entry.State);
+    }
+
+    private sealed class ThrowingLogger : IDailyLogger
+    {
+        public void Append(LogEntry entry) => throw new IOException("simulated logger failure");
+    }
 }


### PR DESCRIPTION
Closes #67.

## Summary
- Wrap the per-file loop in `RunJob` with a `try/finally` so `state.json` is always flipped to `Inactive` even when the logger, state tracker, or directory creation throws mid-loop.
- Nested `try/catch` in the finally block prevents a follow-up state-writer failure from masking the original exception.
- `FilesRemaining`/`SizeRemaining` are intentionally **not** forced to zero in the finally: on success they are already 0 (loop completed), on failure they retain their residual value to signal the incident.
- Add `ExecuteJob_LoggerThrows_StateStillFlipsToInactive` test using a `ThrowingLogger` that raises `IOException` on `Append`.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — new test passes, existing 4 BackupManagerExecuteTests still green