### PR TITLE
feat(config): add AppSettings (encrypted_extensions, business_software_list, log_format, crypto_soft)

### DIFF
--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -7,10 +7,10 @@ namespace EasySave.Models;
 public sealed class AppSettings
 {
     [JsonPropertyName("encrypted_extensions")]
-    public List<string> EncryptedExtensions { get; init; } = new();
+    public IReadOnlyList<string> EncryptedExtensions { get; init; } = Array.Empty<string>();
 
     [JsonPropertyName("business_software_list")]
-    public List<string> BusinessSoftwareList { get; init; } = new();
+    public IReadOnlyList<string> BusinessSoftwareList { get; init; } = Array.Empty<string>();
 
     [JsonPropertyName("log_format")]
     public string LogFormat { get; init; } = "json";

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace EasySave.Models;
+
+// User-managed application settings persisted in appsettings.json.
+// Bound at startup and injected into the services that need them.
+public sealed class AppSettings
+{
+    [JsonPropertyName("encrypted_extensions")]
+    public List<string> EncryptedExtensions { get; init; } = new();
+
+    [JsonPropertyName("business_software_list")]
+    public List<string> BusinessSoftwareList { get; init; } = new();
+
+    [JsonPropertyName("log_format")]
+    public string LogFormat { get; init; } = "json";
+
+    [JsonPropertyName("crypto_soft")]
+    public CryptoSoftSettings CryptoSoft { get; init; } = new();
+}
+
+public sealed class CryptoSoftSettings
+{
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = string.Empty;
+}

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using EasySave.Models;
 
 namespace EasySave.Services;
 
@@ -30,17 +31,9 @@ public sealed class AppConfig
     // UI language code (ISO 639-1), e.g. "en" or "fr".
     public string Language { get; init; } = "en";
 
-    // Absolute path to the CryptoSoft executable used for v2.0 file encryption.
-    // Empty string means "not deployed yet"; consumers must skip encryption rather than fail.
-    public string CryptoSoftPath { get; init; } = string.Empty;
-
-    // Comma-separated list of file extensions (e.g. ".docx,.pdf") that must be encrypted
-    // when CryptoSoftPath is set. An empty list means no file is encrypted.
-    public string CryptoSoftExtensions { get; init; } = string.Empty;
-
-    // Per-file timeout (in milliseconds) for the CryptoSoft child process.
-    // Beyond this delay EasySave kills the process and logs the file as a failure.
-    public int CryptoSoftTimeoutMs { get; init; } = 30000;
+    // User-managed v2.0 settings parsed from the same appsettings.json.
+    // The keys live at the top level (encrypted_extensions, business_software_list, log_format, crypto_soft).
+    public AppSettings Settings { get; private set; } = new();
 
     [JsonConstructor]
     private AppConfig() { }
@@ -60,7 +53,9 @@ public sealed class AppConfig
         try
         {
             var json = File.ReadAllText(path);
-            Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+            var config = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+            config.Settings = JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+            Instance = config;
         }
         catch (Exception ex) when (ex is JsonException or IOException)
         {

--- a/src/EasySave/appsettings.json
+++ b/src/EasySave/appsettings.json
@@ -1,3 +1,9 @@
 {
-  "Language": "en"
+  "Language": "en",
+  "encrypted_extensions": [".pdf", ".docx", ".xlsx"],
+  "business_software_list": ["calc.exe", "notepad.exe"],
+  "log_format": "json",
+  "crypto_soft": {
+    "path": ""
+  }
 }

--- a/tests/EasySave.Tests/AppConfigTests.cs
+++ b/tests/EasySave.Tests/AppConfigTests.cs
@@ -66,33 +66,39 @@ public class AppConfigTests : IDisposable
     }
 
     [Fact]
-    public void Load_MissingCryptoKeys_KeepsCryptoDefaults()
+    public void Load_MissingFile_KeepsSettingsDefaults()
     {
-        var missing = Path.Combine(_tempDir, "no-crypto.json");
+        var missing = Path.Combine(_tempDir, "no-settings.json");
 
         AppConfig.Load(missing);
 
-        Assert.Equal(string.Empty, AppConfig.Instance.CryptoSoftPath);
-        Assert.Equal(string.Empty, AppConfig.Instance.CryptoSoftExtensions);
-        Assert.Equal(30000, AppConfig.Instance.CryptoSoftTimeoutMs);
+        Assert.Empty(AppConfig.Instance.Settings.EncryptedExtensions);
+        Assert.Empty(AppConfig.Instance.Settings.BusinessSoftwareList);
+        Assert.Equal("json", AppConfig.Instance.Settings.LogFormat);
+        Assert.Equal(string.Empty, AppConfig.Instance.Settings.CryptoSoft.Path);
     }
 
     [Fact]
-    public void Load_CryptoKeysProvided_RoundTrip()
+    public void Load_SettingsProvided_BindsAppSettings()
     {
-        var file = Path.Combine(_tempDir, "crypto-settings.json");
-        var payload = new
+        var file = Path.Combine(_tempDir, "settings.json");
+        var payload = """
         {
-            CryptoSoftPath = "/opt/cryptosoft/CryptoSoft.exe",
-            CryptoSoftExtensions = ".docx,.pdf",
-            CryptoSoftTimeoutMs = 5000
-        };
-        File.WriteAllText(file, JsonSerializer.Serialize(payload));
+            "Language": "fr",
+            "encrypted_extensions": [".pdf", ".docx"],
+            "business_software_list": ["calc.exe", "notepad.exe"],
+            "log_format": "xml",
+            "crypto_soft": { "path": "/opt/cryptosoft/CryptoSoft.exe" }
+        }
+        """;
+        File.WriteAllText(file, payload);
 
         AppConfig.Load(file);
 
-        Assert.Equal("/opt/cryptosoft/CryptoSoft.exe", AppConfig.Instance.CryptoSoftPath);
-        Assert.Equal(".docx,.pdf", AppConfig.Instance.CryptoSoftExtensions);
-        Assert.Equal(5000, AppConfig.Instance.CryptoSoftTimeoutMs);
+        Assert.Equal("fr", AppConfig.Instance.Language);
+        Assert.Equal(new[] { ".pdf", ".docx" }, AppConfig.Instance.Settings.EncryptedExtensions);
+        Assert.Equal(new[] { "calc.exe", "notepad.exe" }, AppConfig.Instance.Settings.BusinessSoftwareList);
+        Assert.Equal("xml", AppConfig.Instance.Settings.LogFormat);
+        Assert.Equal("/opt/cryptosoft/CryptoSoft.exe", AppConfig.Instance.Settings.CryptoSoft.Path);
     }
 }

--- a/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
+++ b/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
@@ -1,0 +1,35 @@
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class AppSettingsLiveFileTests
+{
+    [Fact]
+    public void Load_RealAppsettingsJson_BindsAllSettingsKeys()
+    {
+        var repoRoot = FindRepoRoot();
+        var liveFile = Path.Combine(repoRoot, "src", "EasySave", "appsettings.json");
+
+        AppConfig.Load(liveFile);
+
+        Assert.Contains(".pdf", AppConfig.Instance.Settings.EncryptedExtensions);
+        Assert.Contains(".docx", AppConfig.Instance.Settings.EncryptedExtensions);
+        Assert.Contains(".xlsx", AppConfig.Instance.Settings.EncryptedExtensions);
+        Assert.Contains("calc.exe", AppConfig.Instance.Settings.BusinessSoftwareList);
+        Assert.Contains("notepad.exe", AppConfig.Instance.Settings.BusinessSoftwareList);
+        Assert.Equal("json", AppConfig.Instance.Settings.LogFormat);
+        Assert.NotNull(AppConfig.Instance.Settings.CryptoSoft);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "EasySave.sln")))
+        {
+            dir = dir.Parent;
+        }
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AppSettings` POCO bound from `appsettings.json` with the 4 keys mandated by the V2 grading grid: `encrypted_extensions`, `business_software_list`, `log_format`, `crypto_soft.path`.
- `AppConfig.Settings` exposes the bound `AppSettings` for constructor injection into future services (CryptoSoft wrapper, business-software detector, log writer).
- Drop unused `CryptoSoftPath` / `CryptoSoftExtensions` / `CryptoSoftTimeoutMs` (replaced by the structured `Settings.CryptoSoft.Path`).

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` 55/55 green (incl. live test reading the real `src/EasySave/appsettings.json`)
- [x] `dotnet format --verify-no-changes --severity warn` exit 0
- [x] App boots and reads new `appsettings.json` without falling back to defaults

ClickUp: https://app.clickup.com/t/869d01ykg