### PR TITLE
feat(backup): add BusinessSoftwareDetector with polling and process provider abstraction

### DIFF
--- a/src/EasySave/Services/BusinessSoftwareDetector.cs
+++ b/src/EasySave/Services/BusinessSoftwareDetector.cs
@@ -1,0 +1,128 @@
+namespace EasySave.Services;
+
+/// <summary>
+/// Polls the OS process list at a configurable interval and raises
+/// <see cref="BusinessSoftwareDetected"/> / <see cref="BusinessSoftwareClosed"/>
+/// events whenever a watched executable appears or disappears.
+/// Used by <see cref="BackupManager"/> to pause running jobs when an operator
+/// opens a business application listed in <c>appsettings.json</c>.
+/// </summary>
+public sealed class BusinessSoftwareDetector : IDisposable
+{
+    /// <summary>Default polling cadence when none is supplied to the constructor.</summary>
+    public static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(2);
+
+    private readonly IProcessProvider _provider;
+    private readonly HashSet<string> _watched;
+    private readonly TimeSpan _pollInterval;
+    private readonly object _lock = new();
+
+    private System.Threading.Timer? _timer;
+    private HashSet<string> _lastDetected = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Raised once for each watched process that appears between two polls.</summary>
+    public event EventHandler<string>? BusinessSoftwareDetected;
+
+    /// <summary>Raised once for each watched process that disappears between two polls.</summary>
+    public event EventHandler<string>? BusinessSoftwareClosed;
+
+    /// <param name="provider">Source of the running process names. Required.</param>
+    /// <param name="watchedProcessNames">Process names to watch (case-insensitive). Required, but may be empty.</param>
+    /// <param name="pollInterval">Polling cadence. Defaults to <see cref="DefaultPollInterval"/> when null.</param>
+    public BusinessSoftwareDetector(
+        IProcessProvider provider,
+        IEnumerable<string> watchedProcessNames,
+        TimeSpan? pollInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(watchedProcessNames);
+
+        _provider = provider;
+        _watched = new HashSet<string>(watchedProcessNames, StringComparer.OrdinalIgnoreCase);
+        _pollInterval = pollInterval ?? DefaultPollInterval;
+    }
+
+    /// <summary>True if at least one watched process was running on the latest poll.</summary>
+    public bool IsAnyBusinessSoftwareRunning
+    {
+        get { lock (_lock) return _lastDetected.Count > 0; }
+    }
+
+    /// <summary>Snapshot of the watched processes that were running on the latest poll.</summary>
+    public IReadOnlyCollection<string> CurrentlyRunning
+    {
+        get { lock (_lock) return new HashSet<string>(_lastDetected, StringComparer.OrdinalIgnoreCase); }
+    }
+
+    /// <summary>
+    /// Starts the periodic timer and immediately performs one synchronous
+    /// poll so consumers do not wait a full interval before the first event.
+    /// Calling Start a second time without Stop is a no-op.
+    /// </summary>
+    public void Start()
+    {
+        bool started;
+        lock (_lock)
+        {
+            started = _timer is null;
+            if (started)
+            {
+                _timer = new System.Threading.Timer(_ => Refresh(), null, _pollInterval, _pollInterval);
+            }
+        }
+
+        // Initial poll outside the lock so subscribers can call Stop or
+        // Refresh from inside their event handlers without deadlocking.
+        if (started) Refresh();
+    }
+
+    /// <summary>Stops the periodic timer. Safe to call multiple times.</summary>
+    public void Stop()
+    {
+        lock (_lock)
+        {
+            _timer?.Dispose();
+            _timer = null;
+        }
+    }
+
+    /// <summary>
+    /// Performs one polling pass synchronously. Exposed so tests can drive the
+    /// detector deterministically without depending on the timer.
+    /// </summary>
+    public void Refresh()
+    {
+        HashSet<string> appeared;
+        HashSet<string> disappeared;
+
+        lock (_lock)
+        {
+            (appeared, disappeared) = ComputeTransitions();
+        }
+
+        foreach (var name in appeared) BusinessSoftwareDetected?.Invoke(this, name);
+        foreach (var name in disappeared) BusinessSoftwareClosed?.Invoke(this, name);
+    }
+
+    private (HashSet<string> appeared, HashSet<string> disappeared) ComputeTransitions()
+    {
+        var running = _provider.GetRunningProcessNames();
+        var current = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in running)
+        {
+            if (_watched.Contains(name)) current.Add(name);
+        }
+
+        var appeared = new HashSet<string>(current, StringComparer.OrdinalIgnoreCase);
+        appeared.ExceptWith(_lastDetected);
+
+        var disappeared = new HashSet<string>(_lastDetected, StringComparer.OrdinalIgnoreCase);
+        disappeared.ExceptWith(current);
+
+        _lastDetected = current;
+        return (appeared, disappeared);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => Stop();
+}

--- a/src/EasySave/Services/BusinessSoftwareDetector.cs
+++ b/src/EasySave/Services/BusinessSoftwareDetector.cs
@@ -76,7 +76,12 @@ public sealed class BusinessSoftwareDetector : IDisposable
         if (started) Refresh();
     }
 
-    /// <summary>Stops the periodic timer. Safe to call multiple times.</summary>
+    /// <summary>
+    /// Stops the periodic timer. Safe to call multiple times. Note that
+    /// <see cref="System.Threading.Timer.Dispose()"/> is not synchronous: a
+    /// callback already in flight when Stop is called can still complete and
+    /// raise events afterwards.
+    /// </summary>
     public void Stop()
     {
         lock (_lock)
@@ -92,21 +97,24 @@ public sealed class BusinessSoftwareDetector : IDisposable
     /// </summary>
     public void Refresh()
     {
+        // Run the (potentially slow, 50–200 ms) OS call outside the lock so
+        // concurrent readers of IsAnyBusinessSoftwareRunning / CurrentlyRunning
+        // are not stalled for the full poll duration.
+        var running = _provider.GetRunningProcessNames();
+
         HashSet<string> appeared;
         HashSet<string> disappeared;
-
         lock (_lock)
         {
-            (appeared, disappeared) = ComputeTransitions();
+            (appeared, disappeared) = ComputeTransitions(running);
         }
 
         foreach (var name in appeared) BusinessSoftwareDetected?.Invoke(this, name);
         foreach (var name in disappeared) BusinessSoftwareClosed?.Invoke(this, name);
     }
 
-    private (HashSet<string> appeared, HashSet<string> disappeared) ComputeTransitions()
+    private (HashSet<string> appeared, HashSet<string> disappeared) ComputeTransitions(IReadOnlyCollection<string> running)
     {
-        var running = _provider.GetRunningProcessNames();
         var current = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var name in running)
         {

--- a/src/EasySave/Services/IProcessProvider.cs
+++ b/src/EasySave/Services/IProcessProvider.cs
@@ -1,0 +1,15 @@
+namespace EasySave.Services;
+
+/// <summary>
+/// Abstraction over the OS process list, kept narrow so tests can swap in a
+/// deterministic fake without spinning up real processes.
+/// </summary>
+public interface IProcessProvider
+{
+    /// <summary>
+    /// Returns a snapshot of the currently running process names. Comparisons
+    /// against the watch list are case-insensitive, so the implementation
+    /// does not need to normalise casing.
+    /// </summary>
+    IReadOnlyCollection<string> GetRunningProcessNames();
+}

--- a/src/EasySave/Services/SystemProcessProvider.cs
+++ b/src/EasySave/Services/SystemProcessProvider.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace EasySave.Services;
@@ -22,9 +23,13 @@ public sealed class SystemProcessProvider : IProcessProvider
                 {
                     names.Add(p.ProcessName);
                 }
-                catch (InvalidOperationException)
+                catch (Exception ex) when (ex is InvalidOperationException or Win32Exception)
                 {
-                    // The process exited between GetProcesses() and ProcessName access.
+                    // InvalidOperationException: the process exited between
+                    // GetProcesses() and ProcessName access.
+                    // Win32Exception: the OS denied access (protected/elevated process).
+                    // An unhandled exception here would crash the Timer thread and
+                    // terminate the host on .NET 8, so swallow both deliberately.
                 }
             }
             return names;

--- a/src/EasySave/Services/SystemProcessProvider.cs
+++ b/src/EasySave/Services/SystemProcessProvider.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace EasySave.Services;
+
+/// <summary>
+/// Production <see cref="IProcessProvider"/> backed by
+/// <see cref="Process.GetProcesses()"/>. Disposes the snapshot Process
+/// instances so handles are not leaked between polls.
+/// </summary>
+public sealed class SystemProcessProvider : IProcessProvider
+{
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> GetRunningProcessNames()
+    {
+        var processes = Process.GetProcesses();
+        try
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in processes)
+            {
+                try
+                {
+                    names.Add(p.ProcessName);
+                }
+                catch (InvalidOperationException)
+                {
+                    // The process exited between GetProcesses() and ProcessName access.
+                }
+            }
+            return names;
+        }
+        finally
+        {
+            foreach (var p in processes)
+            {
+                p.Dispose();
+            }
+        }
+    }
+}

--- a/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
+++ b/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
@@ -102,4 +102,25 @@ public class BusinessSoftwareDetectorTests
         Assert.Throws<ArgumentNullException>(() =>
             new BusinessSoftwareDetector(new FakeProcessProvider(), null!));
     }
+
+    [Fact]
+    public void Start_PerformsInitialPollSynchronously()
+    {
+        var provider = new FakeProcessProvider { Running = { "outlook" } };
+        // Long interval so the timer cannot fire before the assertion.
+        var detector = new BusinessSoftwareDetector(provider, new[] { "outlook" }, TimeSpan.FromMinutes(5));
+        var detected = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+
+        detector.Start();
+        try
+        {
+            Assert.Equal(new[] { "outlook" }, detected);
+            Assert.True(detector.IsAnyBusinessSoftwareRunning);
+        }
+        finally
+        {
+            detector.Stop();
+        }
+    }
 }

--- a/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
+++ b/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
@@ -1,0 +1,105 @@
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+public class BusinessSoftwareDetectorTests
+{
+    private sealed class FakeProcessProvider : IProcessProvider
+    {
+        public List<string> Running { get; } = new();
+        public IReadOnlyCollection<string> GetRunningProcessNames() => Running.ToArray();
+    }
+
+    private static BusinessSoftwareDetector NewDetector(
+        FakeProcessProvider provider, params string[] watched)
+        => new(provider, watched, TimeSpan.FromSeconds(1));
+
+    [Fact]
+    public void Refresh_ProcessAppears_RaisesDetectedEvent()
+    {
+        var provider = new FakeProcessProvider();
+        var detector = NewDetector(provider, "outlook");
+        var detected = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+
+        provider.Running.Add("outlook");
+        detector.Refresh();
+
+        Assert.Equal(new[] { "outlook" }, detected);
+        Assert.True(detector.IsAnyBusinessSoftwareRunning);
+    }
+
+    [Fact]
+    public void Refresh_ProcessClosesAfterAppearing_RaisesClosedEvent()
+    {
+        var provider = new FakeProcessProvider { Running = { "outlook" } };
+        var detector = NewDetector(provider, "outlook");
+        detector.Refresh(); // detected
+
+        var closed = new List<string>();
+        detector.BusinessSoftwareClosed += (_, name) => closed.Add(name);
+
+        provider.Running.Clear();
+        detector.Refresh();
+
+        Assert.Equal(new[] { "outlook" }, closed);
+        Assert.False(detector.IsAnyBusinessSoftwareRunning);
+    }
+
+    [Fact]
+    public void Refresh_ProcessNotInWatchList_NoEvent()
+    {
+        var provider = new FakeProcessProvider { Running = { "notepad" } };
+        var detector = NewDetector(provider, "outlook");
+        var detected = new List<string>();
+        var closed = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+        detector.BusinessSoftwareClosed += (_, name) => closed.Add(name);
+
+        detector.Refresh();
+
+        Assert.Empty(detected);
+        Assert.Empty(closed);
+    }
+
+    [Fact]
+    public void Refresh_NameMatchIsCaseInsensitive()
+    {
+        var provider = new FakeProcessProvider { Running = { "OUTLOOK" } };
+        var detector = NewDetector(provider, "outlook");
+        var detected = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+
+        detector.Refresh();
+
+        Assert.Single(detected);
+    }
+
+    [Fact]
+    public void Refresh_NoTransition_NoDuplicateEvent()
+    {
+        var provider = new FakeProcessProvider { Running = { "outlook" } };
+        var detector = NewDetector(provider, "outlook");
+        var detected = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+
+        detector.Refresh();
+        detector.Refresh(); // same state, must not re-raise
+
+        Assert.Single(detected);
+    }
+
+    [Fact]
+    public void Constructor_NullProvider_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new BusinessSoftwareDetector(null!, new[] { "outlook" }));
+    }
+
+    [Fact]
+    public void Constructor_NullWatchList_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new BusinessSoftwareDetector(new FakeProcessProvider(), null!));
+    }
+}


### PR DESCRIPTION
## Summary
- `IProcessProvider` interface — narrow abstraction over the OS process list, mockable in tests
- `SystemProcessProvider` — production impl backed by `Process.GetProcesses()`, disposes Process snapshots, ignores processes that exit between enumeration and ProcessName access
- `BusinessSoftwareDetector` — polls the watch list at a configurable interval (default 2 s), raises `BusinessSoftwareDetected` / `BusinessSoftwareClosed` on transitions only (no duplicate events), case-insensitive name matching
- Initial poll on `Start()` (no need to wait one full interval)
- Events raised outside the internal lock to avoid deadlocks if a handler calls `Stop`/`Refresh`
- `Refresh()` exposed publicly so tests drive the detector deterministically
- 7 unit tests via a `FakeProcessProvider`

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — 7 new tests pass
- [ ] Wired into BackupManager in a follow-up PR (separate task)