### PR TITLE
feat(backup): remove 5-job limit per v2.0 grille and clean up orphan i18n keys

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,10 +87,10 @@ console; swapping the view is a localised change in `Program.Main`.
 - No call to `File.Copy`, `File.WriteAllText`, `Directory.CreateDirectory`, or any filesystem API.
 - No JSON serialization or deserialization.
 - No backup-type decision — it only passes `BackupType` to `BackupManager`.
-- No enforcement of the 5-job limit, duplicate-name check, or path validation — these live in `BackupManager`.
+- No enforcement of the duplicate-name check or path validation — these live in `BackupManager`.
 - No direct access to `StateTracker`, `JobRepository`, or `AppConfig` — it only talks to `BackupManager` and `LanguageService`.
 
-Service-layer exceptions carry **translation keys** (`"error.max_jobs"`, `"error.duplicate_job"`, ...), not prose. The View translates; it never invents the policy.
+Service-layer exceptions carry **translation keys** (`"error.duplicate_job"`, `"error.empty_field"`, ...), not prose. The View translates; it never invents the policy.
 
 ### v1.0 → v2.0 migration path
 

--- a/docs/support-client.md
+++ b/docs/support-client.md
@@ -46,7 +46,7 @@ Logs, state, and job definitions are written under the OS-standard per-user appl
 ```
 <data-dir>/
 ├── Logs/                   # Daily log files (yyyy-MM-dd.json)
-├── state.json              # Real-time state of the 5 jobs
+├── state.json              # Real-time state of every configured job
 └── jobs.json               # Persisted job definitions
 ```
 

--- a/src/EasySave/Resources/en.json
+++ b/src/EasySave/Resources/en.json
@@ -10,7 +10,6 @@
   "menu.invalid_choice": "Invalid choice. Please try again.",
   "error.not_implemented": "Not implemented.",
   "error.job_not_found": "Job not found: {0}",
-  "error.max_jobs": "Maximum of 5 backup jobs allowed.",
   "error.invalid_selection": "Invalid job selection.",
   "error.invalid_backup_type": "Invalid backup type. Use Full or Differential.",
   "error.duplicate_job": "A job with this name already exists.",

--- a/src/EasySave/Resources/fr.json
+++ b/src/EasySave/Resources/fr.json
@@ -10,7 +10,6 @@
   "menu.invalid_choice": "Choix invalide. Veuillez réessayer.",
   "error.not_implemented": "Non implémenté.",
   "error.job_not_found": "Sauvegarde introuvable : {0}",
-  "error.max_jobs": "Maximum de 5 sauvegardes autorisées.",
   "error.invalid_selection": "Sélection invalide.",
   "error.invalid_backup_type": "Type invalide. Utilisez Full ou Differential.",
   "error.duplicate_job": "Un job avec ce nom existe déjà.",

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -7,13 +7,11 @@ namespace EasySave.Services;
 /// <summary>
 /// Orchestrates the lifecycle of backup jobs: CRUD operations against the
 /// persistent store, execution using the strategy pattern, real-time state
-/// updates, and per-file logging. Enforces the v1.0 cahier limit of 5 jobs.
+/// updates, and per-file logging. v2.0 lifts the v1.0 5-job cap; the number
+/// of jobs is now unlimited.
 /// </summary>
 public sealed class BackupManager
 {
-    /// <summary>Maximum number of jobs allowed at any time (cahier v1.0).</summary>
-    private const int MaxJobs = 5;
-
     private readonly IDailyLogger _logger;
     private readonly IBackupStrategy _fullStrategy;
     private readonly IBackupStrategy _diffStrategy;
@@ -57,8 +55,7 @@ public sealed class BackupManager
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="job"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when any of Name/SourcePath/TargetPath is null or whitespace.</exception>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when the repository already holds 5 jobs (key <c>error.max_jobs</c>)
-    /// or when a job with the same name exists (key <c>error.duplicate_job</c>).
+    /// Thrown when a job with the same name already exists (key <c>error.duplicate_job</c>).
     /// </exception>
     public void AddJob(BackupJob job)
     {
@@ -68,9 +65,6 @@ public sealed class BackupManager
         ArgumentException.ThrowIfNullOrWhiteSpace(job.TargetPath);
 
         var jobs = _jobRepository.Load().ToList();
-
-        if (jobs.Count >= MaxJobs)
-            throw new InvalidOperationException($"error.max_jobs: Maximum {MaxJobs} jobs allowed.");
 
         if (jobs.Any(j => j.Name.Equals(job.Name, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"error.duplicate_job: Job '{job.Name}' already exists.");

--- a/tests/EasySave.Tests/BackupManagerAddJobTests.cs
+++ b/tests/EasySave.Tests/BackupManagerAddJobTests.cs
@@ -50,26 +50,17 @@ public class BackupManagerAddJobTests : IDisposable
     };
 
     [Fact]
-    public void AddJob_WhenLessThan5_Succeeds()
+    public void AddJob_NoLimit_AcceptsManyJobs()
     {
+        // v2.0 lifts the v1.0 5-job cap. Ten jobs is enough to prove the gate is gone
+        // without making the test slow.
+        JobRepository.Instance.Save(new List<BackupJob>());
         var manager = CreateManager();
 
-        for (int i = 1; i <= 5; i++)
+        for (int i = 1; i <= 10; i++)
             manager.AddJob(MakeJob($"job-{i}"));
 
-        Assert.Equal(5, manager.ListJobs().Count);
-    }
-
-    [Fact]
-    public void AddJob_When5Already_Throws()
-    {
-        var manager = CreateManager();
-
-        for (int i = 1; i <= 5; i++)
-            manager.AddJob(MakeJob($"job-{i}"));
-
-        var ex = Assert.Throws<InvalidOperationException>(() => manager.AddJob(MakeJob("job-6")));
-        Assert.Contains("5", ex.Message);
+        Assert.Equal(10, manager.ListJobs().Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
v2.0 grille requires unlimited backup jobs. Drops the v1.0 5-job cap.

- `BackupManager`: removed `MaxJobs` const and the `jobs.Count >= MaxJobs` guard in `AddJob`; XML docs updated
- `BackupManagerAddJobTests`: removed `AddJob_When5Already_Throws`, replaced `AddJob_WhenLessThan5_Succeeds` with `AddJob_NoLimit_AcceptsManyJobs` (10 jobs to prove the gate is gone)
- `Resources/en.json` + `fr.json`: removed the now-orphan `error.max_jobs` key
- `docs/architecture.md`: dropped the two references to the 5-job limit and `error.max_jobs`
- `CHANGELOG.md` left untouched on purpose (historical v1.x note)

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — `AddJob_NoLimit_AcceptsManyJobs` passes; other AddJob tests still green
- [ ] No more `error.max_jobs` references in code or docs (CHANGELOG aside)