### PR TITLE
fix(backup): strip .exe suffix when matching watched process names

### DIFF
--- a/src/EasySave/Services/BusinessSoftwareDetector.cs
+++ b/src/EasySave/Services/BusinessSoftwareDetector.cs
@@ -20,10 +20,19 @@ public sealed class BusinessSoftwareDetector : IDisposable
     private System.Threading.Timer? _timer;
     private HashSet<string> _lastDetected = new(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Raised once for each watched process that appears between two polls.</summary>
+    /// <summary>
+    /// Raised once for each watched process that appears between two polls.
+    /// The string argument is the canonical (normalized) process name without
+    /// any <c>.exe</c> suffix, regardless of how the watch list or provider
+    /// reported it.
+    /// </summary>
     public event EventHandler<string>? BusinessSoftwareDetected;
 
-    /// <summary>Raised once for each watched process that disappears between two polls.</summary>
+    /// <summary>
+    /// Raised once for each watched process that disappears between two polls.
+    /// The string argument follows the same canonical (normalized) form as
+    /// <see cref="BusinessSoftwareDetected"/>.
+    /// </summary>
     public event EventHandler<string>? BusinessSoftwareClosed;
 
     /// <param name="provider">Source of the running process names. Required.</param>

--- a/src/EasySave/Services/BusinessSoftwareDetector.cs
+++ b/src/EasySave/Services/BusinessSoftwareDetector.cs
@@ -38,7 +38,13 @@ public sealed class BusinessSoftwareDetector : IDisposable
         ArgumentNullException.ThrowIfNull(watchedProcessNames);
 
         _provider = provider;
-        _watched = new HashSet<string>(watchedProcessNames, StringComparer.OrdinalIgnoreCase);
+        // Normalise once at construction so the per-poll comparison is a plain
+        // hash lookup. Stripping ".exe" lets operators write either "calc" or
+        // "calc.exe" in appsettings.json — Process.ProcessName always returns
+        // the bare name on Windows.
+        _watched = new HashSet<string>(
+            watchedProcessNames.Select(NormalizeProcessName),
+            StringComparer.OrdinalIgnoreCase);
         _pollInterval = pollInterval ?? DefaultPollInterval;
     }
 
@@ -118,7 +124,10 @@ public sealed class BusinessSoftwareDetector : IDisposable
         var current = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var name in running)
         {
-            if (_watched.Contains(name)) current.Add(name);
+            // Normalise the running name with the same rule used for _watched
+            // so providers that report "calc.exe" still match a "calc" watch.
+            var normalized = NormalizeProcessName(name);
+            if (_watched.Contains(normalized)) current.Add(normalized);
         }
 
         var appeared = new HashSet<string>(current, StringComparer.OrdinalIgnoreCase);
@@ -129,6 +138,14 @@ public sealed class BusinessSoftwareDetector : IDisposable
 
         _lastDetected = current;
         return (appeared, disappeared);
+    }
+
+    private static string NormalizeProcessName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return name;
+        return name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+            ? name[..^4]
+            : name;
     }
 
     /// <inheritdoc />

--- a/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
+++ b/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
@@ -104,6 +104,7 @@ public class BusinessSoftwareDetectorTests
         detector.Refresh();
 
         Assert.Single(detected);
+        Assert.True(detector.IsAnyBusinessSoftwareRunning);
     }
 
     [Fact]

--- a/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
+++ b/tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs
@@ -76,6 +76,37 @@ public class BusinessSoftwareDetectorTests
     }
 
     [Fact]
+    public void Refresh_WatchedHasExeSuffix_MatchesBareName()
+    {
+        // Process.ProcessName strips ".exe" on Windows; operators commonly write
+        // "calc.exe" in appsettings.json. The detector must accept both forms.
+        var provider = new FakeProcessProvider { Running = { "calc" } };
+        var detector = NewDetector(provider, "calc.exe");
+        var detected = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+
+        detector.Refresh();
+
+        Assert.Single(detected);
+        Assert.True(detector.IsAnyBusinessSoftwareRunning);
+    }
+
+    [Fact]
+    public void Refresh_RunningHasExeSuffix_MatchesBareWatch()
+    {
+        // Symmetric case: a non-Windows or future provider that returns "calc.exe"
+        // must still match a "calc" watch entry.
+        var provider = new FakeProcessProvider { Running = { "calc.exe" } };
+        var detector = NewDetector(provider, "calc");
+        var detected = new List<string>();
+        detector.BusinessSoftwareDetected += (_, name) => detected.Add(name);
+
+        detector.Refresh();
+
+        Assert.Single(detected);
+    }
+
+    [Fact]
     public void Refresh_NoTransition_NoDuplicateEvent()
     {
         var provider = new FakeProcessProvider { Running = { "outlook" } };


### PR DESCRIPTION
Closes #77.

## Summary
`Process.ProcessName` strips `.exe` on Windows (returns `"calc"` for `calc.exe`), but operators commonly write `"calc.exe"` in `appsettings.json`. The case-insensitive comparison in the detector never matched, so `IsAnyBusinessSoftwareRunning` stayed `false` forever in production while the test suite (using `FakeProcessProvider` with bare names) stayed green.

## Fix
- New private helper `NormalizeProcessName` that strips a trailing `.exe` (case-insensitive)
- Watched list normalised **once** at construction (no per-poll cost)
- Running names normalised inside `ComputeTransitions` so providers reporting `.exe` (non-Windows / future) also match

## Tests
- `Refresh_WatchedHasExeSuffix_MatchesBareName` — real Windows case (config `calc.exe`, provider `calc`)
- `Refresh_RunningHasExeSuffix_MatchesBareWatch` — symmetric case

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — 2 new tests pass, existing 8 detector tests still green