### PR TITLE
feat(easylog): add ILogFormatter interface and LogEntry.EncryptionTimeMs

### DIFF
--- a/src/EasyLog/ILogFormatter.cs
+++ b/src/EasyLog/ILogFormatter.cs
@@ -1,0 +1,27 @@
+namespace EasyLog;
+
+/// <summary>
+/// Serializes a <see cref="LogEntry"/> to the textual representation used in
+/// daily log files. Concrete formatters are introduced in EasyLog v2 to support
+/// both JSON and XML outputs without changing the v1 <see cref="IDailyLogger"/>
+/// contract.
+/// </summary>
+/// <remarks>
+/// Implementations must be thread-safe and pure: <see cref="Format"/> may be
+/// called from concurrent backup jobs and must not mutate shared state.
+/// </remarks>
+public interface ILogFormatter
+{
+    /// <summary>
+    /// Returns the serialized representation of <paramref name="entry"/>.
+    /// </summary>
+    /// <param name="entry">The log entry to serialize. Must not be null.</param>
+    /// <returns>The serialized text, ready to append to the daily log file.</returns>
+    string Format(LogEntry entry);
+
+    /// <summary>
+    /// File extension (including the leading dot) used by daily log files
+    /// produced by this formatter, e.g. <c>".json"</c> or <c>".xml"</c>.
+    /// </summary>
+    string FileExtension { get; }
+}

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -65,6 +65,7 @@ public sealed class JsonDailyLogger : IDailyLogger
             TargetFile = ToNormalizedPath(entry.TargetFile),
             FileSize = entry.FileSize,
             FileTransferTimeMs = entry.FileTransferTimeMs,
+            EncryptionTimeMs = entry.EncryptionTimeMs,
         };
 
         lock (_writeLock)

--- a/src/EasyLog/LogEntry.cs
+++ b/src/EasyLog/LogEntry.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace EasyLog;
 
 /// <summary>
@@ -37,4 +39,16 @@ public sealed class LogEntry
     /// A negative value indicates a transfer error.
     /// </summary>
     public long FileTransferTimeMs { get; set; }
+
+    /// <summary>
+    /// Encryption duration in milliseconds (EasyLog v2+).
+    /// A negative value indicates an encryption failure.
+    /// Null when no encryption was performed (default for v1 consumers).
+    /// </summary>
+    /// <remarks>
+    /// The property is omitted from the JSON output when null so that v1
+    /// consumers reading the log file see the exact same shape as before.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? EncryptionTimeMs { get; set; }
 }

--- a/tests/EasySave.Tests.V2/ILogFormatterContractTests.cs
+++ b/tests/EasySave.Tests.V2/ILogFormatterContractTests.cs
@@ -1,0 +1,33 @@
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+public class ILogFormatterContractTests
+{
+    [Fact]
+    public void Interface_IsPublic()
+    {
+        // Cheap sanity check that the public surface is reachable from outside the assembly,
+        // which is the whole point of shipping ILogFormatter to other ProSoft applications.
+        Assert.True(typeof(ILogFormatter).IsInterface);
+        Assert.True(typeof(ILogFormatter).IsPublic);
+    }
+
+    [Fact]
+    public void Implementation_CanBeWrittenInTestAssembly()
+    {
+        // Concrete formatters (JsonFormatter, XmlFormatter) ship in Phase 3.
+        // Until then this fake proves the interface is implementable as documented.
+        ILogFormatter formatter = new TextFormatterFake();
+
+        var entry = new LogEntry { JobName = "fake" };
+        Assert.Equal("fake", formatter.Format(entry));
+        Assert.Equal(".txt", formatter.FileExtension);
+    }
+
+    private sealed class TextFormatterFake : ILogFormatter
+    {
+        public string Format(LogEntry entry) => entry.JobName;
+        public string FileExtension => ".txt";
+    }
+}

--- a/tests/EasySave.Tests.V2/ILogFormatterContractTests.cs
+++ b/tests/EasySave.Tests.V2/ILogFormatterContractTests.cs
@@ -5,12 +5,15 @@ namespace EasySave.Tests.V2;
 public class ILogFormatterContractTests
 {
     [Fact]
-    public void Interface_IsPublic()
+    public void Interface_HasExpectedPublicMembers()
     {
-        // Cheap sanity check that the public surface is reachable from outside the assembly,
-        // which is the whole point of shipping ILogFormatter to other ProSoft applications.
-        Assert.True(typeof(ILogFormatter).IsInterface);
-        Assert.True(typeof(ILogFormatter).IsPublic);
+        // Guards against accidental rename/removal of the v2 contract that
+        // EasyLog ships to other ProSoft applications.
+        var type = typeof(ILogFormatter);
+
+        Assert.True(type.IsPublic);
+        Assert.NotNull(type.GetMethod(nameof(ILogFormatter.Format), new[] { typeof(LogEntry) }));
+        Assert.NotNull(type.GetProperty(nameof(ILogFormatter.FileExtension)));
     }
 
     [Fact]

--- a/tests/EasySave.Tests.V2/JsonDailyLoggerEncryptionTests.cs
+++ b/tests/EasySave.Tests.V2/JsonDailyLoggerEncryptionTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+public class JsonDailyLoggerEncryptionTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public JsonDailyLoggerEncryptionTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "easylog-v2-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void Append_PreservesEncryptionTimeMs_WhenSet()
+    {
+        // Regression: the v1 logger reconstructs the entry to normalize paths.
+        // EncryptionTimeMs must propagate through the copy, otherwise v2 callers
+        // would silently lose the encryption duration in the daily log file.
+        var logger = new JsonDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry
+        {
+            Timestamp = "2026-04-28T10:00:00+02:00",
+            JobName = "encrypt-job",
+            SourceFile = @"\\nas\share\src.docx",
+            TargetFile = @"\\nas\share\dst.docx",
+            FileSize = 1024,
+            FileTransferTimeMs = 5,
+            EncryptionTimeMs = 17,
+        });
+
+        var dailyFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        var entries = JsonSerializer.Deserialize<List<LogEntry>>(File.ReadAllText(dailyFile));
+
+        Assert.NotNull(entries);
+        var saved = Assert.Single(entries!);
+        Assert.Equal(17, saved.EncryptionTimeMs);
+    }
+
+    [Fact]
+    public void Append_NoEncryption_KeepsV1FileShape()
+    {
+        // A v2 caller that does not set EncryptionTimeMs must produce a daily file
+        // byte-shape-compatible with v1 (no extra property in the JSON).
+        var logger = new JsonDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry
+        {
+            Timestamp = "2026-04-28T10:00:00+02:00",
+            JobName = "plain-job",
+            SourceFile = @"\\nas\share\src.txt",
+            TargetFile = @"\\nas\share\dst.txt",
+            FileSize = 256,
+            FileTransferTimeMs = 1,
+            // EncryptionTimeMs intentionally left null
+        });
+
+        var dailyFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        var raw = File.ReadAllText(dailyFile);
+
+        Assert.DoesNotContain("EncryptionTimeMs", raw);
+    }
+}

--- a/tests/EasySave.Tests.V2/LogEntryV2Tests.cs
+++ b/tests/EasySave.Tests.V2/LogEntryV2Tests.cs
@@ -26,13 +26,15 @@ public class LogEntryV2Tests
     }
 
     [Fact]
-    public void Serialize_NonNullEncryptionTime_IncludesProperty()
+    public void Serialize_NonNullEncryptionTime_IsRoundtripPreserved()
     {
         var entry = new LogEntry { JobName = "encrypted", EncryptionTimeMs = 42 };
 
         var json = JsonSerializer.Serialize(entry);
+        var roundtripped = JsonSerializer.Deserialize<LogEntry>(json);
 
-        Assert.Contains("\"EncryptionTimeMs\":42", json);
+        Assert.NotNull(roundtripped);
+        Assert.Equal(42, roundtripped!.EncryptionTimeMs);
     }
 
     [Fact]

--- a/tests/EasySave.Tests.V2/LogEntryV2Tests.cs
+++ b/tests/EasySave.Tests.V2/LogEntryV2Tests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+public class LogEntryV2Tests
+{
+    [Fact]
+    public void EncryptionTimeMs_DefaultsToNull()
+    {
+        var entry = new LogEntry();
+
+        Assert.Null(entry.EncryptionTimeMs);
+    }
+
+    [Fact]
+    public void Serialize_NullEncryptionTime_OmitsProperty()
+    {
+        // v1 consumers reading the file must see the v1 shape exactly,
+        // so EncryptionTimeMs must not appear when it is null.
+        var entry = new LogEntry { JobName = "v1-shape" };
+
+        var json = JsonSerializer.Serialize(entry);
+
+        Assert.DoesNotContain("EncryptionTimeMs", json);
+    }
+
+    [Fact]
+    public void Serialize_NonNullEncryptionTime_IncludesProperty()
+    {
+        var entry = new LogEntry { JobName = "encrypted", EncryptionTimeMs = 42 };
+
+        var json = JsonSerializer.Serialize(entry);
+
+        Assert.Contains("\"EncryptionTimeMs\":42", json);
+    }
+
+    [Fact]
+    public void Roundtrip_PreservesEncryptionTime()
+    {
+        var entry = new LogEntry { JobName = "roundtrip", EncryptionTimeMs = -1 };
+
+        var json = JsonSerializer.Serialize(entry);
+        var roundtripped = JsonSerializer.Deserialize<LogEntry>(json);
+
+        Assert.NotNull(roundtripped);
+        Assert.Equal(-1, roundtripped!.EncryptionTimeMs);
+    }
+
+    [Fact]
+    public void Deserialize_V1Json_LeavesEncryptionTimeNull()
+    {
+        // A v1 file (written before EncryptionTimeMs existed) must deserialize
+        // cleanly with the new property left at null.
+        const string v1Json = """
+        {
+          "Timestamp": "2026-04-22T13:35:46.7763460+02:00",
+          "JobName": "v1-job",
+          "SourceFile": "\\\\?\\C:\\src\\a.txt",
+          "TargetFile": "\\\\?\\C:\\dst\\a.txt",
+          "FileSize": 38,
+          "FileTransferTimeMs": 0
+        }
+        """;
+
+        var entry = JsonSerializer.Deserialize<LogEntry>(v1Json);
+
+        Assert.NotNull(entry);
+        Assert.Equal("v1-job", entry!.JobName);
+        Assert.Null(entry.EncryptionTimeMs);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 V2 skeleton on the EasyLog side. Sets up the strategy contract for the upcoming JSON/XML formatters and adds the encryption-duration field to \`LogEntry\` — without breaking the v1 contract or v1 file shape.

## Changes

### \`src/EasyLog/ILogFormatter.cs\` (new)

The v2 formatter contract:

- \`string Format(LogEntry entry)\` — pure, thread-safe, returns the serialized text.
- \`string FileExtension\` — \`.json\`, \`.xml\`, etc.

\`IDailyLogger\` v1.0 stays untouched. Concrete implementations (\`JsonFormatter\`, \`XmlFormatter\`) ship in Phase 3 (ClickUp \`869d020nd\` and \`869d020ju\`).

### \`src/EasyLog/LogEntry.cs\`

New nullable property \`EncryptionTimeMs\`:

- Same convention as \`FileTransferTimeMs\` — negative value = error.
- Marked \`[JsonIgnore(Condition = WhenWritingNull)]\` so a v2 entry with no encryption serializes byte-for-byte like a v1 entry. **v1 consumers reading the log file see the unchanged shape.**
- v1 JSON without the field deserializes cleanly with the property left at \`null\`.

### Tests (\`tests/EasySave.Tests.V2/\`)

- **LogEntryV2Tests** (5 tests): default null, omit-when-null serialization, include-when-set, roundtrip, v1 file backward compat on read.
- **ILogFormatterContractTests** (2 tests): public surface check + implementability via a fake formatter.

## Compat with v1

- \`IDailyLogger\` API: untouched ✅
- v1 \`LogEntry\` JSON shape: untouched ✅ (test \`Serialize_NullEncryptionTime_OmitsProperty\` enforces it)
- v1 consumers reading v2 logs: unaffected (unknown properties silently ignored by default)
- v2 reading v1 logs: \`EncryptionTimeMs = null\` (test \`Deserialize_V1Json_LeavesEncryptionTimeNull\` enforces it)

## Test plan

- [x] \`dotnet build\` passes
- [x] \`dotnet test\` — 65 v1 + 10 v2 = 75/75 pass locally
- [ ] CI green on push

## ClickUp

- \`869d01zdc\` — [EasyLog] Interface ILogFormatter
- \`869d01zht\` — [EasyLog] LogEntry : ajouter EncryptionTimeMs (nullable)