### PR TITLE
fix(crypto): align integration doc with real appsettings keys and add timeout_ms

### DIFF
--- a/docs/cryptosoft-integration.md
+++ b/docs/cryptosoft-integration.md
@@ -18,24 +18,29 @@ on the CryptoSoft side that breaks one of these points must be coordinated with 
 
 ## Configuration
 
-Path is resolved through `appsettings.json` via two new keys:
+Three keys in `appsettings.json` drive the integration. They live alongside the
+other v2.0 settings parsed by `AppSettings`:
 
 ```json
 {
-  "Language": "en",
-  "CryptoSoftPath": "C:\\Program Files\\ProSoft\\CryptoSoft\\CryptoSoft.exe",
-  "CryptoSoftExtensions": ".docx,.pdf,.xlsx",
-  "CryptoSoftTimeoutMs": 30000
+  "language": "en",
+  "encrypted_extensions": [".pdf", ".docx", ".xlsx"],
+  "business_software": ["calc.exe", "notepad.exe"],
+  "log_format": "json",
+  "crypto_soft": {
+    "path": "C:\\Program Files\\ProSoft\\CryptoSoft\\CryptoSoft.exe",
+    "timeout_ms": 30000
+  }
 }
 ```
 
-| Key | Type | Default | Meaning |
-|---|---|---|---|
-| `CryptoSoftPath` | string | `""` | Absolute path to the executable. Empty = encryption disabled. |
-| `CryptoSoftExtensions` | string | `""` | Comma-separated list of file extensions to encrypt (lowercase, leading dot). Empty = nothing is encrypted. |
-| `CryptoSoftTimeoutMs` | int | `30000` | Per-file timeout for the CryptoSoft child process, in milliseconds. |
+| JSON key | C# property | Type | Default | Meaning |
+|---|---|---|---|---|
+| `crypto_soft.path` | `AppSettings.CryptoSoft.Path` | string | `""` | Absolute path to the executable. Empty = encryption disabled. |
+| `crypto_soft.timeout_ms` | `AppSettings.CryptoSoft.TimeoutMs` | int | `30000` | Per-file timeout for the CryptoSoft child process, in milliseconds. |
+| `encrypted_extensions` | `AppSettings.EncryptedExtensions` | string array | `[]` | File extensions (lowercase, leading dot) that must be encrypted. Empty = nothing is encrypted. |
 
-When `CryptoSoftPath` is empty, EasySave **must not fail**: the file is copied as-is
+When `crypto_soft.path` is empty, EasySave **must not fail**: the file is copied as-is
 and the log entry records `EncryptionTimeMs = 0` (no encryption performed). See
 [Log entry contract](#log-entry-contract) below.
 
@@ -69,7 +74,7 @@ EasySave logs this value into a new `LogEntry.EncryptionTimeMs` field (see
 field stays reserved for the file copy duration and is unaffected.
 
 A timeout on the EasySave side wraps the call. The duration is configurable via
-`CryptoSoftTimeoutMs` in `appsettings.json` (default: 30000 ms). If the timeout
+`crypto_soft.timeout_ms` in `appsettings.json` (default: 30000 ms). If the timeout
 fires, EasySave kills the process and logs `EncryptionTimeMs = -1`.
 
 ## Log entry contract
@@ -110,7 +115,7 @@ encryption failures on the loser.
 - Missing executable → `FileNotFoundException` raised by `Process.Start`. EasySave
   logs `EncryptionTimeMs = -1` and continues with the next file.
 - Non-zero negative exit code → log `EncryptionTimeMs = <code>` and continue.
-- Process hang → enforce the `CryptoSoftTimeoutMs` timeout, kill, log `-1`, continue.
+- Process hang → enforce the `crypto_soft.timeout_ms` timeout, kill, log `-1`, continue.
 
 In every failure case the **backup job itself does not stop**. The user gets a
 warning message at the end summarizing the count of failed encryptions.

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -27,4 +27,9 @@ public sealed class CryptoSoftSettings
 {
     [JsonPropertyName("path")]
     public string Path { get; init; } = string.Empty;
+
+    // Per-file timeout for the CryptoSoft child process. EasySave kills the
+    // process and logs the file as a failure once this delay elapses.
+    [JsonPropertyName("timeout_ms")]
+    public int TimeoutMs { get; init; } = 30000;
 }

--- a/src/EasySave/appsettings.json
+++ b/src/EasySave/appsettings.json
@@ -4,6 +4,7 @@
   "business_software": ["calc.exe", "notepad.exe"],
   "log_format": "json",
   "crypto_soft": {
-    "path": ""
+    "path": "",
+    "timeout_ms": 30000
   }
 }

--- a/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
+++ b/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
@@ -20,6 +20,11 @@ public class AppSettingsLiveFileTests
         Assert.Contains("notepad.exe", AppConfig.Instance.Settings.BusinessSoftware);
         Assert.Equal("json", AppConfig.Instance.Settings.LogFormat);
         Assert.NotNull(AppConfig.Instance.Settings.CryptoSoft);
+        // Sanity-check the CryptoSoft sub-section keys documented in
+        // docs/cryptosoft-integration.md so the doc and the live appsettings
+        // cannot drift apart silently.
+        Assert.Equal(string.Empty, AppConfig.Instance.Settings.CryptoSoft.Path);
+        Assert.Equal(30000, AppConfig.Instance.Settings.CryptoSoft.TimeoutMs);
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
Closes #78.

## Summary
The integration doc described root-level PascalCase keys (`CryptoSoftPath`, `CryptoSoftExtensions`, `CryptoSoftTimeoutMs`) that were never bound by the real `AppSettings` model. Following the doc verbatim would silently disable encryption.

## Fix
- `AppSettings.CryptoSoftSettings`: add `TimeoutMs` (`[JsonPropertyName("timeout_ms")]`, default 30000)
- `appsettings.json`: surface `"timeout_ms": 30000` explicitly inside the `crypto_soft` object
- `docs/cryptosoft-integration.md`: rewrite the Configuration section with the real snake_case nested keys (`crypto_soft.path`, `crypto_soft.timeout_ms`, `encrypted_extensions`); add a JSON↔C# mapping table; replace the three timeout references throughout the doc
- `AppSettingsLiveFileTests`: assert on `CryptoSoft.Path` and `CryptoSoft.TimeoutMs` so the live file and the doc cannot drift apart silently again

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — `AppSettingsLiveFileTests.Load_RealAppsettingsJson_BindsAllSettingsKeys` covers the new field
- [ ] Visual review of the doc against `appsettings.json`