### PR TITLE
feat(state): expose JobProgress INotifyPropertyChanged and JobProgressChanged event

### DIFF
--- a/src/EasySave/Models/JobProgress.cs
+++ b/src/EasySave/Models/JobProgress.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace EasySave.Models;
+
+// Observable view of a single job's live progress.
+// One instance per backup job; mutated in place by StateTracker so GUI bindings
+// see real-time updates via INotifyPropertyChanged.
+public sealed class JobProgress : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string Name { get; }
+
+    public JobProgress(string name)
+    {
+        Name = name;
+    }
+
+    private string _currentFile = string.Empty;
+    public string CurrentFile
+    {
+        get => _currentFile;
+        set => Set(ref _currentFile, value);
+    }
+
+    private int _filesRemaining;
+    public int FilesRemaining
+    {
+        get => _filesRemaining;
+        set => Set(ref _filesRemaining, value);
+    }
+
+    private double _percent;
+    public double Percent
+    {
+        get => _percent;
+        set => Set(ref _percent, value);
+    }
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -35,8 +35,6 @@ public sealed class StateTracker
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        EventHandler<StateEntry>? handler;
-
         lock (_lock)
         {
             var path = AppConfig.Instance.StateFilePath;
@@ -47,18 +45,20 @@ public sealed class StateTracker
             states.Add(entry);
 
             FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
-
-            // Inside the lock so concurrent Updates for the same job name cannot interleave
-            // and produce a torn JobProgress (current_file from one call, percent from another).
-            var progress = _jobs.GetOrAdd(entry.Name, name => new JobProgress(name));
-            progress.CurrentFile = entry.CurrentSource;
-            progress.FilesRemaining = entry.FilesRemaining;
-            progress.Percent = entry.Progress;
-
-            handler = JobProgressChanged;
         }
 
-        handler?.Invoke(this, entry);
+        // Observable side-effects run outside _lock on purpose: PropertyChanged subscribers
+        // (Avalonia bindings, log forwarders) may call back into Update. Keeping them under
+        // _lock would deadlock or violate the lock invariant on re-entry.
+        // The trade-off is eventually-consistent JobProgress (state.json is always consistent;
+        // the in-memory observable can briefly see interleaved values under concurrent updates
+        // for the same job — acceptable for a transient progress display).
+        var progress = _jobs.GetOrAdd(entry.Name, name => new JobProgress(name));
+        progress.CurrentFile = entry.CurrentSource;
+        progress.FilesRemaining = entry.FilesRemaining;
+        progress.Percent = entry.Progress;
+
+        JobProgressChanged?.Invoke(this, entry);
     }
 
     private static List<StateEntry> ReadCurrentEntries(string path)

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -17,11 +17,14 @@ public sealed class StateTracker
     private readonly ConcurrentDictionary<string, JobProgress> _jobs = new();
 
     // Raised after every Update with the snapshot just persisted.
-    // Subscribers receive the immutable StateEntry for inspection / logging.
+    // Subscribers receive the StateEntry passed to Update — treat it as a snapshot
+    // and do not mutate; StateEntry currently has public setters but is used as a DTO.
     public event EventHandler<StateEntry>? JobProgressChanged;
 
     // Live observable views, indexed by job name. The same instance is reused across updates
-    // so GUI bindings stay attached for the lifetime of the job.
+    // so GUI bindings stay attached for the lifetime of a job.
+    // Entries are never auto-removed: finished jobs stay in the map so the GUI keeps showing
+    // their final progress until the consumer explicitly chooses to filter or evict them.
     public IReadOnlyDictionary<string, JobProgress> Jobs => _jobs;
 
     private StateTracker() { }
@@ -31,6 +34,8 @@ public sealed class StateTracker
     public void Update(StateEntry entry)
     {
         ArgumentNullException.ThrowIfNull(entry);
+
+        EventHandler<StateEntry>? handler;
 
         lock (_lock)
         {
@@ -42,14 +47,17 @@ public sealed class StateTracker
             states.Add(entry);
 
             FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
+
+            // Inside the lock so concurrent Updates for the same job name cannot interleave
+            // and produce a torn JobProgress (current_file from one call, percent from another).
+            var progress = _jobs.GetOrAdd(entry.Name, name => new JobProgress(name));
+            progress.CurrentFile = entry.CurrentSource;
+            progress.FilesRemaining = entry.FilesRemaining;
+            progress.Percent = entry.Progress;
+
+            handler = JobProgressChanged;
         }
 
-        var progress = _jobs.GetOrAdd(entry.Name, name => new JobProgress(name));
-        progress.CurrentFile = entry.CurrentSource;
-        progress.FilesRemaining = entry.FilesRemaining;
-        progress.Percent = entry.Progress;
-
-        var handler = JobProgressChanged;
         handler?.Invoke(this, entry);
     }
 

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -1,22 +1,33 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
+using EasySave.Models;
 
 namespace EasySave.Services;
 
 // Singleton that tracks the real-time state of every backup job.
-// State is persisted to AppConfig.Instance.StateFilePath as a single JSON array,
-// rewritten atomically on each call to Update.
+// Persists a JSON array to AppConfig.Instance.StateFilePath (rewritten atomically) and
+// exposes a per-job INotifyPropertyChanged view + a JobProgressChanged event so a GUI
+// can react to live updates without re-reading state.json.
 public sealed class StateTracker
 {
-    // Lazy, thread-safe singleton instance.
     private static readonly Lazy<StateTracker> _instance = new(() => new StateTracker());
     public static StateTracker Instance => _instance.Value;
 
-    // Serialises concurrent writes coming from multiple backup managers.
     private readonly object _lock = new();
+    private readonly ConcurrentDictionary<string, JobProgress> _jobs = new();
+
+    // Raised after every Update with the snapshot just persisted.
+    // Subscribers receive the immutable StateEntry for inspection / logging.
+    public event EventHandler<StateEntry>? JobProgressChanged;
+
+    // Live observable views, indexed by job name. The same instance is reused across updates
+    // so GUI bindings stay attached for the lifetime of the job.
+    public IReadOnlyDictionary<string, JobProgress> Jobs => _jobs;
 
     private StateTracker() { }
 
-    // Inserts or replaces the snapshot for a job, then rewrites the state file atomically.
+    // Inserts or replaces the snapshot for a job, persists the full state.json atomically,
+    // mutates the matching JobProgress to fire INotifyPropertyChanged, then raises JobProgressChanged.
     public void Update(StateEntry entry)
     {
         ArgumentNullException.ThrowIfNull(entry);
@@ -32,6 +43,14 @@ public sealed class StateTracker
 
             FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
         }
+
+        var progress = _jobs.GetOrAdd(entry.Name, name => new JobProgress(name));
+        progress.CurrentFile = entry.CurrentSource;
+        progress.FilesRemaining = entry.FilesRemaining;
+        progress.Percent = entry.Progress;
+
+        var handler = JobProgressChanged;
+        handler?.Invoke(this, entry);
     }
 
     private static List<StateEntry> ReadCurrentEntries(string path)

--- a/tests/EasySave.Tests/StateTrackerObservableTests.cs
+++ b/tests/EasySave.Tests/StateTrackerObservableTests.cs
@@ -1,0 +1,139 @@
+using System.ComponentModel;
+using System.Text.Json;
+using EasySave;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class StateTrackerObservableTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public StateTrackerObservableTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "statetracker-obs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new { StateFilePath = Path.Combine(_tempDir, "state.json") };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private static StateEntry MakeEntry(string name, int total, int remaining, string current)
+    {
+        return new StateEntry
+        {
+            Name = name,
+            State = JobState.Active,
+            TotalFilesEligible = total,
+            FilesRemaining = remaining,
+            CurrentSource = current
+        };
+    }
+
+    [Fact]
+    public void Update_ExposesJobProgressInJobsMap()
+    {
+        var jobName = "obs-" + Guid.NewGuid().ToString("N");
+
+        StateTracker.Instance.Update(MakeEntry(jobName, 10, 4, @"\\share\file.bin"));
+
+        Assert.True(StateTracker.Instance.Jobs.ContainsKey(jobName));
+        var progress = StateTracker.Instance.Jobs[jobName];
+        Assert.Equal(@"\\share\file.bin", progress.CurrentFile);
+        Assert.Equal(4, progress.FilesRemaining);
+        Assert.Equal(60.0, progress.Percent);
+    }
+
+    [Fact]
+    public void Update_ReusesSameJobProgressInstance()
+    {
+        var jobName = "obs-" + Guid.NewGuid().ToString("N");
+
+        StateTracker.Instance.Update(MakeEntry(jobName, 10, 9, @"\\share\a"));
+        var first = StateTracker.Instance.Jobs[jobName];
+
+        StateTracker.Instance.Update(MakeEntry(jobName, 10, 5, @"\\share\b"));
+        var second = StateTracker.Instance.Jobs[jobName];
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void Update_RaisesPropertyChangedForChangedFields()
+    {
+        var jobName = "obs-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(MakeEntry(jobName, 10, 9, @"\\share\a"));
+        var progress = StateTracker.Instance.Jobs[jobName];
+
+        var changed = new List<string>();
+        PropertyChangedEventHandler handler = (_, e) => changed.Add(e.PropertyName!);
+        progress.PropertyChanged += handler;
+        try
+        {
+            StateTracker.Instance.Update(MakeEntry(jobName, 10, 4, @"\\share\b"));
+        }
+        finally
+        {
+            progress.PropertyChanged -= handler;
+        }
+
+        Assert.Contains(nameof(JobProgress.CurrentFile), changed);
+        Assert.Contains(nameof(JobProgress.FilesRemaining), changed);
+        Assert.Contains(nameof(JobProgress.Percent), changed);
+    }
+
+    [Fact]
+    public void Update_DoesNotRaisePropertyChangedWhenValueUnchanged()
+    {
+        var jobName = "obs-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(MakeEntry(jobName, 10, 4, @"\\share\a"));
+        var progress = StateTracker.Instance.Jobs[jobName];
+
+        var changed = new List<string>();
+        PropertyChangedEventHandler handler = (_, e) => changed.Add(e.PropertyName!);
+        progress.PropertyChanged += handler;
+        try
+        {
+            StateTracker.Instance.Update(MakeEntry(jobName, 10, 4, @"\\share\a"));
+        }
+        finally
+        {
+            progress.PropertyChanged -= handler;
+        }
+
+        Assert.Empty(changed);
+    }
+
+    [Fact]
+    public void Update_RaisesJobProgressChanged()
+    {
+        var jobName = "obs-" + Guid.NewGuid().ToString("N");
+        StateEntry? received = null;
+        EventHandler<StateEntry> handler = (_, entry) => received = entry;
+        StateTracker.Instance.JobProgressChanged += handler;
+        try
+        {
+            StateTracker.Instance.Update(MakeEntry(jobName, 10, 4, @"\\share\f"));
+        }
+        finally
+        {
+            StateTracker.Instance.JobProgressChanged -= handler;
+        }
+
+        Assert.NotNull(received);
+        Assert.Equal(jobName, received!.Name);
+        Assert.Equal(4, received.FilesRemaining);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `JobProgress` observable POCO (INotifyPropertyChanged on `CurrentFile`, `FilesRemaining`, `Percent`).
- `StateTracker` exposes `Jobs` (live map of `JobProgress` per job) and `JobProgressChanged` event so the v2.0 GUI can bind without re-reading state.json.
- Same `JobProgress` instance reused across updates so GUI bindings remain attached.
- File persistence path unchanged.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` 75/75 green (5 new observable tests: map presence, instance reuse, PropertyChanged fired on change, no fire on equal value, JobProgressChanged event)
- [x] `dotnet format --verify-no-changes --severity warn` exit 0

ClickUp: https://app.clickup.com/t/869d01zbb