### PR TITLE
chore(ui): fix dotnet format errors in EasySave.UI (BOM, imports order, trailing whitespace)

### DIFF
--- a/src/EasySave.UI/Program.cs
+++ b/src/EasySave.UI/Program.cs
@@ -1,5 +1,5 @@
-﻿using Avalonia;
 using System;
+using Avalonia;
 
 namespace EasySave.UI;
 

--- a/src/EasySave.UI/Services/LanguageService.cs
+++ b/src/EasySave.UI/Services/LanguageService.cs
@@ -1,5 +1,5 @@
-using Avalonia.Platform;
 using System.Text.Json;
+using Avalonia.Platform;
 
 namespace EasySave.UI.Services;
 

--- a/src/EasySave.UI/ViewLocator.cs
+++ b/src/EasySave.UI/ViewLocator.cs
@@ -18,7 +18,7 @@ public class ViewLocator : IDataTemplate
     {
         if (param is null)
             return null;
-        
+
         var name = param.GetType().FullName!.Replace("ViewModel", "View", StringComparison.Ordinal);
         var type = Type.GetType(name);
 
@@ -26,7 +26,7 @@ public class ViewLocator : IDataTemplate
         {
             return (Control)Activator.CreateInstance(type)!;
         }
-        
+
         return new TextBlock { Text = "Not Found: " + name };
     }
 

--- a/src/EasySave.UI/ViewModels/ViewModelBase.cs
+++ b/src/EasySave.UI/ViewModels/ViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace EasySave.UI.ViewModels;
 


### PR DESCRIPTION
## Summary
Staging Format check is failing since PR #82 (EasySave.UI Avalonia shell) was merged. This unblocks every downstream PR — currently #84 inherits the failure and cannot pass CI.

## Fixes
- `Program.cs`: strip UTF-8 BOM, reorder usings (`System` before `Avalonia` per `dotnet_sort_system_directives_first`)
- `ViewModels/ViewModelBase.cs`: strip UTF-8 BOM
- `Services/LanguageService.cs`: reorder usings (`System.Text.Json` before `Avalonia.Platform`)
- `ViewLocator.cs` lines 21 and 29: strip trailing whitespace on blank lines (`trim_trailing_whitespace = true` per `.editorconfig`)

No behavioural change. Only whitespace and using order edits.

## Test plan
- [ ] `dotnet format --severity warn` (Format check) passes
- [ ] `dotnet build` and `dotnet test` still green