### PR TITLE
fix(state): remove state.json entry when a job is deleted

### DIFF
--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -102,6 +102,7 @@ public sealed class BackupManager
 
         jobs.RemoveAt(index);
         _jobRepository.Save(jobs);
+        _stateTracker.Remove(name);
     }
 
     /// <summary>Returns the current list of configured jobs, read from disk.</summary>

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -61,6 +61,41 @@ public sealed class StateTracker
         JobProgressChanged?.Invoke(this, entry);
     }
 
+    // Drops the state entry for the given job name (case-insensitive) and rewrites state.json.
+    // No-op if no entry matches. Also evicts the matching JobProgress observable so the GUI
+    // stops binding to a deleted job.
+    public void Remove(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        lock (_lock)
+        {
+            var path = AppConfig.Instance.StateFilePath;
+            if (!File.Exists(path))
+            {
+                _jobs.TryRemove(name, out _);
+                return;
+            }
+
+            var states = ReadCurrentEntries(path);
+            var initialCount = states.Count;
+            states.RemoveAll(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (states.Count != initialCount)
+            {
+                FileHelpers.EnsureDirectoryExists(path);
+                FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
+            }
+        }
+
+        // Outside the lock — same reasoning as Update for observable side-effects.
+        var match = _jobs.Keys.FirstOrDefault(k => string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
+        if (match is not null)
+        {
+            _jobs.TryRemove(match, out _);
+        }
+    }
+
     private static List<StateEntry> ReadCurrentEntries(string path)
     {
         if (!File.Exists(path))

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -71,24 +71,22 @@ public sealed class StateTracker
         lock (_lock)
         {
             var path = AppConfig.Instance.StateFilePath;
-            if (!File.Exists(path))
+            if (File.Exists(path))
             {
-                _jobs.TryRemove(name, out _);
-                return;
-            }
+                var states = ReadCurrentEntries(path);
+                var initialCount = states.Count;
+                states.RemoveAll(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
 
-            var states = ReadCurrentEntries(path);
-            var initialCount = states.Count;
-            states.RemoveAll(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
-
-            if (states.Count != initialCount)
-            {
-                FileHelpers.EnsureDirectoryExists(path);
-                FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
+                if (states.Count != initialCount)
+                {
+                    FileHelpers.EnsureDirectoryExists(path);
+                    FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
+                }
             }
         }
 
         // Outside the lock — same reasoning as Update for observable side-effects.
+        // Case-insensitive lookup so an entry added under a different casing is still evicted.
         var match = _jobs.Keys.FirstOrDefault(k => string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
         if (match is not null)
         {

--- a/tests/EasySave.Tests/StateTrackerRemoveTests.cs
+++ b/tests/EasySave.Tests/StateTrackerRemoveTests.cs
@@ -98,9 +98,16 @@ public class StateTrackerRemoveTests : IDisposable
     }
 
     [Fact]
-    public void Remove_NoStateFile_DoesNotThrow()
+    public void Remove_NoStateFile_StillEvictsJobProgress()
     {
-        var ex = Record.Exception(() => StateTracker.Instance.Remove("anything"));
+        var name = "no-file-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Inactive });
+        File.Delete(_stateFilePath);
+        Assert.True(StateTracker.Instance.Jobs.ContainsKey(name));
+
+        var ex = Record.Exception(() => StateTracker.Instance.Remove(name.ToUpperInvariant()));
+
         Assert.Null(ex);
+        Assert.False(StateTracker.Instance.Jobs.ContainsKey(name));
     }
 }

--- a/tests/EasySave.Tests/StateTrackerRemoveTests.cs
+++ b/tests/EasySave.Tests/StateTrackerRemoveTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using EasySave;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class StateTrackerRemoveTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _stateFilePath;
+
+    public StateTrackerRemoveTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "statetracker-remove-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _stateFilePath = Path.Combine(_tempDir, "state.json");
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new { StateFilePath = _stateFilePath };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private List<StateEntry> ReadStates()
+    {
+        var json = File.ReadAllText(_stateFilePath);
+        return JsonSerializer.Deserialize<List<StateEntry>>(json) ?? new List<StateEntry>();
+    }
+
+    [Fact]
+    public void Remove_RemovesEntry_WhenPresent()
+    {
+        var name = "rm-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Inactive });
+        Assert.Contains(ReadStates(), s => s.Name == name);
+
+        StateTracker.Instance.Remove(name);
+
+        Assert.DoesNotContain(ReadStates(), s => s.Name == name);
+    }
+
+    [Fact]
+    public void Remove_IsNoOp_WhenAbsent()
+    {
+        var kept = "keep-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = kept, State = JobState.Inactive });
+
+        StateTracker.Instance.Remove("does-not-exist-" + Guid.NewGuid().ToString("N"));
+
+        Assert.Contains(ReadStates(), s => s.Name == kept);
+    }
+
+    [Fact]
+    public void Remove_PreservesOtherEntries()
+    {
+        var a = "a-" + Guid.NewGuid().ToString("N");
+        var b = "b-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = a, State = JobState.Inactive });
+        StateTracker.Instance.Update(new StateEntry { Name = b, State = JobState.Inactive });
+
+        StateTracker.Instance.Remove(a);
+
+        var states = ReadStates();
+        Assert.DoesNotContain(states, s => s.Name == a);
+        Assert.Contains(states, s => s.Name == b);
+    }
+
+    [Fact]
+    public void Remove_IsCaseInsensitive()
+    {
+        var name = "CaseTest-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Inactive });
+
+        StateTracker.Instance.Remove(name.ToUpperInvariant());
+
+        Assert.DoesNotContain(ReadStates(), s => s.Name == name);
+    }
+
+    [Fact]
+    public void Remove_EvictsJobProgressFromMap()
+    {
+        var name = "evict-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Inactive });
+        Assert.True(StateTracker.Instance.Jobs.ContainsKey(name));
+
+        StateTracker.Instance.Remove(name);
+
+        Assert.False(StateTracker.Instance.Jobs.ContainsKey(name));
+    }
+
+    [Fact]
+    public void Remove_NoStateFile_DoesNotThrow()
+    {
+        var ex = Record.Exception(() => StateTracker.Instance.Remove("anything"));
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #68. `BackupManager.RemoveJob` deleted the job from `jobs.json` but left the entry in `state.json`, so any monitoring tool kept seeing ghost jobs after a deletion.

- Add `StateTracker.Remove(string name)` (case-insensitive, atomic write, no-op if absent or file missing).
- Also evicts the matching `JobProgress` from the observable map so GUI bindings to a deleted job are released.
- `BackupManager.RemoveJob` now calls `_stateTracker.Remove(name)` after persisting the updated jobs list.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` 106/106 green (6 new tests covering present/absent/preserve-others/case-insensitive/eviction-from-map/no-state-file)
- [x] `dotnet format --verify-no-changes --severity warn` exit 0