### PR TITLE
feat(backup): support diff backup of encrypted files via target mtime alignment

### DIFF
--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -240,6 +240,11 @@ public sealed class BackupManager
             var result = _encryption.Encrypt(file.FullName, targetPath);
             sw.Stop();
 
+            if (result.Success)
+            {
+                AlignTargetMtime(file, targetPath);
+            }
+
             // CryptoSoft writes the encrypted bytes to targetPath itself, so the
             // wall-clock duration of the Encrypt call doubles as the file
             // transfer time for v1.0 log consumers.
@@ -252,11 +257,30 @@ public sealed class BackupManager
         {
             File.Copy(file.FullName, targetPath, overwrite: true);
             copyTimer.Stop();
+            AlignTargetMtime(file, targetPath);
             return (copyTimer.ElapsedMilliseconds, null);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return (-1, null);
+        }
+    }
+
+    // Carries the source file's LastWriteTimeUtc onto the target so the next
+    // run of DifferentialBackupStrategy can decide based on dates alone.
+    // This is what lets diff backups work for encrypted files (whose size
+    // never matches the source) without storing a parallel history file.
+    private static void AlignTargetMtime(FileInfo source, string targetPath)
+    {
+        try
+        {
+            File.SetLastWriteTimeUtc(targetPath, source.LastWriteTimeUtc);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // The copy already succeeded; failing to stamp the mtime only
+            // means the next diff run will re-copy this file. Better to keep
+            // going than to fail the whole job over a metadata write.
         }
     }
 

--- a/src/EasySave/Services/DifferentialBackupStrategy.cs
+++ b/src/EasySave/Services/DifferentialBackupStrategy.cs
@@ -1,12 +1,24 @@
 namespace EasySave.Services;
 
+/// <summary>
+/// Differential backup strategy: re-copies a file only when the source is
+/// newer than the previous backup.
+/// <para>
+/// v2.0 dropped the size comparison so encrypted targets work too: an
+/// encrypted file's size never matches its plaintext source, so a size-based
+/// gate would re-encrypt every run. The contract is now "trust the source
+/// modification time", and <see cref="BackupManager"/> guarantees this works
+/// by aligning the target's <c>LastWriteTimeUtc</c> on the source's after
+/// every successful copy or encryption.
+/// </para>
+/// </summary>
 public sealed class DifferentialBackupStrategy : IBackupStrategy
 {
+    /// <inheritdoc />
     public bool ShouldCopy(FileInfo source, string targetPath)
     {
         if (!File.Exists(targetPath)) return true;
         var target = new FileInfo(targetPath);
-        return source.Length != target.Length
-            || source.LastWriteTimeUtc > target.LastWriteTimeUtc;
+        return source.LastWriteTimeUtc > target.LastWriteTimeUtc;
     }
 }

--- a/tests/EasySave.Tests/BackupManagerEncryptionTests.cs
+++ b/tests/EasySave.Tests/BackupManagerEncryptionTests.cs
@@ -181,4 +181,38 @@ public class BackupManagerEncryptionTests : IDisposable
         manager.ExecuteJob("diff-crypto");
         Assert.Single(stub.Calls); // still one call, not two
     }
+
+    [Fact]
+    public void Execute_DiffStrategy_EncryptedFileModified_ReEncrypted()
+    {
+        // v2.0 grille +1: when the plaintext source is modified after a first
+        // diff backup, the second run must re-encrypt the file even though the
+        // encrypted target's size is still different from the source's.
+        var sourceFile = Path.Combine(_sourceDir, "secret.pdf");
+        File.WriteAllText(sourceFile, "secret");
+        JobRepository.Instance.Save(new List<BackupJob>
+        {
+            new()
+            {
+                Name = "diff-crypto-mod",
+                SourcePath = _sourceDir,
+                TargetPath = _targetDir,
+                Type = BackupType.Differential,
+            },
+        });
+
+        var stub = new StubEncryption(EncryptResult.Succeeded(5));
+        var manager = CreateManager(stub, ".pdf");
+
+        manager.ExecuteJob("diff-crypto-mod");
+        Assert.Single(stub.Calls);
+
+        // Touch the source: rewrite content and bump LastWriteTimeUtc clearly
+        // forward so the strategy sees a newer source.
+        File.WriteAllText(sourceFile, "secret v2");
+        File.SetLastWriteTimeUtc(sourceFile, DateTime.UtcNow.AddMinutes(1));
+
+        manager.ExecuteJob("diff-crypto-mod");
+        Assert.Equal(2, stub.Calls.Count);
+    }
 }

--- a/tests/EasySave.Tests/BackupManagerEncryptionTests.cs
+++ b/tests/EasySave.Tests/BackupManagerEncryptionTests.cs
@@ -151,4 +151,34 @@ public class BackupManagerEncryptionTests : IDisposable
 
         Assert.Single(stub.Calls);
     }
+
+    [Fact]
+    public void Execute_DiffStrategy_EncryptedFileUnchanged_NotReEncrypted()
+    {
+        // v2.0 grille +1: differential backup must skip encrypted files when
+        // the plaintext source is unchanged, even though the target file's
+        // size never matches the source's.
+        File.WriteAllText(Path.Combine(_sourceDir, "secret.pdf"), "secret");
+        JobRepository.Instance.Save(new List<BackupJob>
+        {
+            new()
+            {
+                Name = "diff-crypto",
+                SourcePath = _sourceDir,
+                TargetPath = _targetDir,
+                Type = BackupType.Differential,
+            },
+        });
+
+        var stub = new StubEncryption(EncryptResult.Succeeded(5));
+        var manager = CreateManager(stub, ".pdf");
+
+        // First run: file is new, encryption fires.
+        manager.ExecuteJob("diff-crypto");
+        Assert.Single(stub.Calls);
+
+        // Second run: nothing on disk changed, so DiffStrategy must skip the file.
+        manager.ExecuteJob("diff-crypto");
+        Assert.Single(stub.Calls); // still one call, not two
+    }
 }

--- a/tests/EasySave.Tests/DifferentialBackupStrategyTests.cs
+++ b/tests/EasySave.Tests/DifferentialBackupStrategyTests.cs
@@ -42,15 +42,21 @@ public class DifferentialBackupStrategyTests : IDisposable
     }
 
     [Fact]
-    public void Diff_DifferentSize_ShouldCopy()
+    public void Diff_DifferentSizeSameDate_DoesNotCopy_EncryptedTargetCase()
     {
-        var sourcePath = Path.Combine(_tempDir, "source.txt");
-        var targetPath = Path.Combine(_tempDir, "target.txt");
-        File.WriteAllText(sourcePath, "longer content");
-        File.WriteAllText(targetPath, "short");
+        // v2.0 contract: encrypted targets do not match the plaintext source's
+        // size, so the strategy must trust the modification time only. When
+        // the source has not been touched since the last backup, the file is
+        // skipped even if the target's size differs (because it was encrypted).
+        var sourcePath = Path.Combine(_tempDir, "secret.pdf");
+        var targetPath = Path.Combine(_tempDir, "secret.pdf");
+        Directory.CreateDirectory(Path.Combine(_tempDir, "tgt"));
+        targetPath = Path.Combine(_tempDir, "tgt", "secret.pdf");
+        File.WriteAllText(sourcePath, "plaintext");
+        File.WriteAllText(targetPath, "encrypted-bytes-much-longer-than-source");
         File.SetLastWriteTimeUtc(targetPath, File.GetLastWriteTimeUtc(sourcePath));
 
-        Assert.True(_strategy.ShouldCopy(new FileInfo(sourcePath), targetPath));
+        Assert.False(_strategy.ShouldCopy(new FileInfo(sourcePath), targetPath));
     }
 
     [Fact]

--- a/tests/EasySave.Tests/DifferentialBackupStrategyTests.cs
+++ b/tests/EasySave.Tests/DifferentialBackupStrategyTests.cs
@@ -49,9 +49,8 @@ public class DifferentialBackupStrategyTests : IDisposable
         // the source has not been touched since the last backup, the file is
         // skipped even if the target's size differs (because it was encrypted).
         var sourcePath = Path.Combine(_tempDir, "secret.pdf");
-        var targetPath = Path.Combine(_tempDir, "secret.pdf");
         Directory.CreateDirectory(Path.Combine(_tempDir, "tgt"));
-        targetPath = Path.Combine(_tempDir, "tgt", "secret.pdf");
+        var targetPath = Path.Combine(_tempDir, "tgt", "secret.pdf");
         File.WriteAllText(sourcePath, "plaintext");
         File.WriteAllText(targetPath, "encrypted-bytes-much-longer-than-source");
         File.SetLastWriteTimeUtc(targetPath, File.GetLastWriteTimeUtc(sourcePath));


### PR DESCRIPTION
## Summary
v2.0 grille (+1): differential backup must skip encrypted files when the plaintext source has not changed. The encrypted target's size never matches the source's, so the previous size-based gate would re-encrypt the file on every run.

### Approach
Instead of maintaining a parallel per-file backup-history store on disk, the BackupManager now aligns the target's `LastWriteTimeUtc` on the source's after every successful copy or encryption. This lets `DifferentialBackupStrategy` decide on dates alone — no extra persistence layer needed.

### Changes
- `DifferentialBackupStrategy.ShouldCopy`: drops the size comparison, keeps date comparison only. XML doc explains why.
- `BackupManager.ProcessFile`: new private helper `AlignTargetMtime` called after each successful copy or encryption. Failures are silenced — a failed mtime stamp only means the next diff run will re-copy this file, no reason to abort the job.
- `DifferentialBackupStrategyTests`: replaces `Diff_DifferentSize_ShouldCopy` (no longer reflects the v2.0 contract) with `Diff_DifferentSizeSameDate_DoesNotCopy_EncryptedTargetCase`, which asserts the new behaviour.
- `BackupManagerEncryptionTests`: new integration test `Execute_DiffStrategy_EncryptedFileUnchanged_NotReEncrypted` runs two consecutive diff backups on the same .pdf file and asserts the encryption stub is called exactly once.

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — new tests pass; existing 3 DiffStrategy tests still green
- [ ] Manual: diff backup of a directory with .pdf files, ensure second run logs no encryption activity