### PR TITLE
fix(state): propagate IOException to prevent silent overwrite on locked read

### DIFF
--- a/src/EasySave/CLI/ConsoleUI.cs
+++ b/src/EasySave/CLI/ConsoleUI.cs
@@ -24,17 +24,27 @@ public sealed class ConsoleUI
         {
             DisplayMenu();
             string choice = Console.ReadLine() ?? string.Empty;
-            switch (choice.Trim())
+            try
             {
-                case "1": AddJob(); break;
-                case "2": RemoveJob(); break;
-                case "3": ListJobs(); break;
-                case "4": ExecuteJobs(); break;
-                case "5": ChangeLanguage(); break;
-                case "0": running = false; break;
-                default:
-                    Console.WriteLine(_lang.T("menu.invalid_choice"));
-                    break;
+                switch (choice.Trim())
+                {
+                    case "1": AddJob(); break;
+                    case "2": RemoveJob(); break;
+                    case "3": ListJobs(); break;
+                    case "4": ExecuteJobs(); break;
+                    case "5": ChangeLanguage(); break;
+                    case "0": running = false; break;
+                    default:
+                        Console.WriteLine(_lang.T("menu.invalid_choice"));
+                        break;
+                }
+            }
+            catch (IOException)
+            {
+                // Any unguarded Load() call (jobs.json or state.json read briefly held by an
+                // antivirus / backup agent) bubbles here. Tell the user and continue the loop
+                // — see issue #69.
+                Console.WriteLine(_lang.T("error.persistence_unavailable"));
             }
         }
     }
@@ -88,10 +98,6 @@ public sealed class ConsoleUI
             var key = colon >= 0 ? ex.Message[..colon].Trim() : ex.Message;
             Console.WriteLine(_lang.T(key));
         }
-        catch (IOException)
-        {
-            Console.WriteLine(_lang.T("error.persistence_unavailable"));
-        }
     }
 
     private void RemoveJob()
@@ -121,10 +127,6 @@ public sealed class ConsoleUI
         catch (KeyNotFoundException ex)
         {
             Console.WriteLine(string.Format(_lang.T("error.job_not_found"), ex.Message));
-        }
-        catch (IOException)
-        {
-            Console.WriteLine(_lang.T("error.persistence_unavailable"));
         }
     }
 

--- a/src/EasySave/CLI/ConsoleUI.cs
+++ b/src/EasySave/CLI/ConsoleUI.cs
@@ -88,6 +88,10 @@ public sealed class ConsoleUI
             var key = colon >= 0 ? ex.Message[..colon].Trim() : ex.Message;
             Console.WriteLine(_lang.T(key));
         }
+        catch (IOException)
+        {
+            Console.WriteLine(_lang.T("error.persistence_unavailable"));
+        }
     }
 
     private void RemoveJob()
@@ -117,6 +121,10 @@ public sealed class ConsoleUI
         catch (KeyNotFoundException ex)
         {
             Console.WriteLine(string.Format(_lang.T("error.job_not_found"), ex.Message));
+        }
+        catch (IOException)
+        {
+            Console.WriteLine(_lang.T("error.persistence_unavailable"));
         }
     }
 

--- a/src/EasySave/Resources/en.json
+++ b/src/EasySave/Resources/en.json
@@ -17,6 +17,7 @@
   "error.invalid_language": "Invalid language. Supported: en, fr.",
   "error.source_not_found": "Source directory does not exist.",
   "error.execute_failed": "Execution error: {0}",
+  "error.persistence_unavailable": "Backup configuration file is temporarily locked. Please retry in a moment.",
   "prompt.job_name": "Enter job name: ",
   "prompt.source_path": "Enter source path: ",
   "prompt.target_path": "Enter target path: ",

--- a/src/EasySave/Resources/fr.json
+++ b/src/EasySave/Resources/fr.json
@@ -17,6 +17,7 @@
   "error.invalid_language": "Langue invalide. Supportées : en, fr.",
   "error.source_not_found": "Le dossier source n'existe pas.",
   "error.execute_failed": "Erreur d'exécution : {0}",
+  "error.persistence_unavailable": "Le fichier de configuration des sauvegardes est temporairement verrouillé. Réessayez dans un instant.",
   "prompt.job_name": "Nom de la sauvegarde : ",
   "prompt.source_path": "Chemin source : ",
   "prompt.target_path": "Chemin cible : ",

--- a/src/EasySave/Services/JobRepository.cs
+++ b/src/EasySave/Services/JobRepository.cs
@@ -19,6 +19,9 @@ public sealed class JobRepository
     // Loads the persisted list of backup jobs from disk, or an empty list if the file is missing.
     // If the file is present but corrupted, it is moved aside to a timestamped ".corrupted" copy
     // so the user's definitions are not lost silently.
+    // Transient IOException (antivirus / backup agent holding the file) is propagated:
+    // returning [] here would let the caller add a job and Save() over the existing file,
+    // wiping every previously-saved job (issue #69).
     public IReadOnlyList<BackupJob> Load()
     {
         lock (_lock)
@@ -37,13 +40,6 @@ public sealed class JobRepository
             catch (JsonException ex)
             {
                 FileHelpers.QuarantineCorruptedFile(path, ex, "JobRepository");
-                return new List<BackupJob>();
-            }
-            catch (IOException)
-            {
-                // Transient read error (file locked by another process): treat as empty
-                // without quarantining, so the user's jobs.json is not lost if an antivirus
-                // or backup agent holds the file briefly.
                 return new List<BackupJob>();
             }
         }

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -94,6 +94,9 @@ public sealed class StateTracker
         }
     }
 
+    // Transient IOException is propagated to the caller (Update / Remove): swallowing it
+    // and returning [] would cause the next atomic write to overwrite state.json with only
+    // the current job's entry, wiping every other job's live state (issue #69).
     private static List<StateEntry> ReadCurrentEntries(string path)
     {
         if (!File.Exists(path))
@@ -109,12 +112,6 @@ public sealed class StateTracker
         catch (JsonException ex)
         {
             FileHelpers.QuarantineCorruptedFile(path, ex, "StateTracker");
-            return new List<StateEntry>();
-        }
-        catch (IOException)
-        {
-            // Transient read error (file locked by another process): treat as empty
-            // without quarantining, so the next Update rewrites the file.
             return new List<StateEntry>();
         }
     }

--- a/tests/EasySave.Tests/PersistenceLockPropagationTests.cs
+++ b/tests/EasySave.Tests/PersistenceLockPropagationTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using EasySave;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+// Issue #69: a transient IOException at read time used to be swallowed and downgraded to an empty
+// list, causing the next Save() to wipe every previously-saved entry. The fix is to let the
+// IOException propagate so the caller aborts the destructive write path.
+//
+// Tests are Windows-only because Unix file locks (flock / FileShare.None on .NET) are advisory
+// and do not actually block File.ReadAllText. We still ship them so Windows CI / dev boxes
+// regression-check the fix.
+[Collection("StateCollection")]
+public class PersistenceLockPropagationTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _jobsFilePath;
+    private readonly string _stateFilePath;
+
+    public PersistenceLockPropagationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "persist-lock-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _jobsFilePath = Path.Combine(_tempDir, "jobs.json");
+        _stateFilePath = Path.Combine(_tempDir, "state.json");
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new { JobsFilePath = _jobsFilePath, StateFilePath = _stateFilePath };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public void JobRepository_Load_PropagatesIOException_WhenFileLocked()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var existing = new[]
+        {
+            new BackupJob { Name = "Existing1", SourcePath = @"\\share\src", TargetPath = @"\\share\tgt", Type = BackupType.Full }
+        };
+        File.WriteAllText(_jobsFilePath, JsonSerializer.Serialize(existing));
+
+        using var lockHolder = new FileStream(_jobsFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        Assert.Throws<IOException>(() => JobRepository.Instance.Load());
+    }
+
+    [SkippableFact]
+    public void JobRepository_Load_PreservesFile_WhenIOExceptionPropagates()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var existing = new[]
+        {
+            new BackupJob { Name = "A", SourcePath = @"\\share\a", TargetPath = @"\\share\at", Type = BackupType.Full },
+            new BackupJob { Name = "B", SourcePath = @"\\share\b", TargetPath = @"\\share\bt", Type = BackupType.Differential },
+        };
+        var originalJson = JsonSerializer.Serialize(existing);
+        File.WriteAllText(_jobsFilePath, originalJson);
+
+        using (var lockHolder = new FileStream(_jobsFilePath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.Throws<IOException>(() => JobRepository.Instance.Load());
+        }
+
+        Assert.Equal(originalJson, File.ReadAllText(_jobsFilePath));
+    }
+
+    [SkippableFact]
+    public void StateTracker_Update_PropagatesIOException_WhenFileLocked()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        File.WriteAllText(_stateFilePath, "[]");
+        using var lockHolder = new FileStream(_stateFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var entry = new StateEntry { Name = "Foo", State = JobState.Active };
+        Assert.Throws<IOException>(() => StateTracker.Instance.Update(entry));
+    }
+
+    [SkippableFact]
+    public void StateTracker_Update_PreservesFile_WhenIOExceptionPropagates()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var seeded = new[]
+        {
+            new StateEntry { Name = "OtherJob", State = JobState.Active, FilesRemaining = 3 }
+        };
+        var originalJson = JsonSerializer.Serialize(seeded);
+        File.WriteAllText(_stateFilePath, originalJson);
+
+        using (var lockHolder = new FileStream(_stateFilePath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.Throws<IOException>(() =>
+                StateTracker.Instance.Update(new StateEntry { Name = "Intruder", State = JobState.Active }));
+        }
+
+        Assert.Equal(originalJson, File.ReadAllText(_stateFilePath));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #69. PR #66 traded a corrupted-file quarantine path for an empty-list fallback on transient \`IOException\`, which silently wiped \`jobs.json\` and \`state.json\` whenever an antivirus / backup agent briefly held the file: the next \`Save\`/\`Update\` rewrote it with only the new entry.

- \`JobRepository.Load()\`: drop the swallow-and-return-empty \`catch (IOException)\`. \`Save\` is now never called against a stale empty list, so the file is preserved.
- \`StateTracker.ReadCurrentEntries()\`: same fix — propagate \`IOException\` to \`Update\`/\`Remove\`.
- \`ConsoleUI.AddJob\`/\`RemoveJob\`: catch the propagated \`IOException\` and display \`error.persistence_unavailable\` instead of crashing.
- New i18n key \`error.persistence_unavailable\` in \`Resources/en.json\` and \`fr.json\`.
- Comments on both call sites document why we re-throw rather than silently degrade.

## Test plan
- [x] \`dotnet build\` clean
- [x] \`dotnet test\` 100 total, 96 green + 4 Windows-only skipped on macOS (lock propagation requires kernel-level file locking which Unix advisory locks do not provide)
- [x] New \`PersistenceLockPropagationTests\`: 4 \`SkippableFact\` covering \`JobRepository.Load\`, \`StateTracker.Update\` — assert \`IOException\` is thrown AND the file content stays intact when a \`FileShare.None\` lock is held during read

## Notes
- Pre-existing \`.NETCoreApp\` charset warnings under \`src/EasySave.UI/\` are unrelated to this PR (already on staging).