### PR TITLE
feat(easylog): add XmlFormatter with embedded XSD schema

### DIFF
--- a/docs/schemas/easysave-log.xsd
+++ b/docs/schemas/easysave-log.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Schema for EasySave daily log files produced by EasyLog v2 XmlFormatter.
+  Root element is <Logs> with zero or more <Entry> children appended over the day.
+  Embedded in the EasyLog assembly under logical name
+  "EasyLog.Schemas.easysave-log.xsd" so consumers can validate logs at runtime.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+  <xs:element name="Logs">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Entry" type="LogEntry"
+                    minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="LogEntry">
+    <xs:sequence>
+      <xs:element name="Timestamp"          type="xs:string"/>
+      <xs:element name="JobName"            type="xs:string"/>
+      <xs:element name="SourceFile"         type="xs:string"/>
+      <xs:element name="TargetFile"         type="xs:string"/>
+      <xs:element name="FileSize"           type="xs:long"/>
+      <xs:element name="FileTransferTimeMs" type="xs:long"/>
+      <xs:element name="EncryptionTimeMs"   type="xs:long" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/src/EasyLog/EasyLog.csproj
+++ b/src/EasyLog/EasyLog.csproj
@@ -7,4 +7,10 @@
     <Description>Daily JSON logger reusable across ProSoft applications.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\docs\schemas\easysave-log.xsd">
+      <LogicalName>EasyLog.Schemas.easysave-log.xsd</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/EasyLog/EasyLog.csproj
+++ b/src/EasyLog/EasyLog.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>EasyLog</RootNamespace>
     <AssemblyName>EasyLog</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>Daily JSON logger reusable across ProSoft applications.</Description>
+    <Description>Daily JSON and XML logger reusable across ProSoft applications.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EasyLog/XmlFormatter.cs
+++ b/src/EasyLog/XmlFormatter.cs
@@ -1,0 +1,67 @@
+using System.Xml.Linq;
+using System.Xml.Schema;
+
+namespace EasyLog;
+
+/// <summary>
+/// Serializes a <see cref="LogEntry"/> as an <c>&lt;Entry&gt;</c> XML fragment
+/// for the daily XML log file required by EasySave v2.
+/// </summary>
+/// <remarks>
+/// The fragment is meant to be appended under a <c>&lt;Logs&gt;</c> root element
+/// produced by the daily logger. The accompanying schema (embedded as
+/// <c>EasyLog.Schemas.easysave-log.xsd</c>) describes the full document.
+/// </remarks>
+public sealed class XmlFormatter : ILogFormatter
+{
+    private const string EmbeddedSchemaResourceName = "EasyLog.Schemas.easysave-log.xsd";
+
+    /// <inheritdoc />
+    public string FileExtension => ".xml";
+
+    /// <inheritdoc />
+    public string Format(LogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        XElement element = new("Entry",
+            new XElement("Timestamp", entry.Timestamp),
+            new XElement("JobName", entry.JobName),
+            new XElement("SourceFile", entry.SourceFile),
+            new XElement("TargetFile", entry.TargetFile),
+            new XElement("FileSize", entry.FileSize),
+            new XElement("FileTransferTimeMs", entry.FileTransferTimeMs));
+
+        // Mirror the JSON formatter: omit the v2-only field when unset so that
+        // v1 consumers reading the file see the v1 element set exactly.
+        if (entry.EncryptionTimeMs.HasValue)
+        {
+            element.Add(new XElement("EncryptionTimeMs", entry.EncryptionTimeMs.Value));
+        }
+
+        return element.ToString(SaveOptions.None);
+    }
+
+    /// <summary>
+    /// Loads the XSD schema describing the daily XML log document
+    /// (<c>&lt;Logs&gt;</c> with zero or more <c>&lt;Entry&gt;</c> children).
+    /// </summary>
+    /// <remarks>
+    /// Exposed so daily loggers and external consumers of EasyLog can validate
+    /// the on-disk log without shipping their own copy of the schema.
+    /// </remarks>
+    /// <returns>The parsed <see cref="XmlSchema"/> embedded in the assembly.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the embedded resource is missing or the schema cannot be parsed.
+    /// </exception>
+    public static XmlSchema LoadSchema()
+    {
+        using Stream stream = typeof(XmlFormatter).Assembly
+            .GetManifestResourceStream(EmbeddedSchemaResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded XSD resource '{EmbeddedSchemaResourceName}' was not found.");
+
+        return XmlSchema.Read(stream, validationEventHandler: null)
+            ?? throw new InvalidOperationException("Failed to parse the embedded XSD.");
+    }
+}

--- a/tests/EasySave.Tests.V2/XmlFormatterTests.cs
+++ b/tests/EasySave.Tests.V2/XmlFormatterTests.cs
@@ -1,0 +1,155 @@
+using System.Xml.Linq;
+using System.Xml.Schema;
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+public class XmlFormatterTests
+{
+    [Fact]
+    public void FileExtension_IsXml()
+    {
+        var formatter = new XmlFormatter();
+        Assert.Equal(".xml", formatter.FileExtension);
+    }
+
+    [Fact]
+    public void Format_NullEntry_Throws()
+    {
+        var formatter = new XmlFormatter();
+        Assert.Throws<ArgumentNullException>(() => formatter.Format(null!));
+    }
+
+    [Fact]
+    public void Format_ProducesParseableEntryFragment()
+    {
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "fragment", FileTransferTimeMs = 1 };
+
+        var xml = formatter.Format(entry);
+        var element = XElement.Parse(xml);
+
+        Assert.Equal("Entry", element.Name.LocalName);
+    }
+
+    [Fact]
+    public void Format_OmitsEncryptionTimeMs_WhenNull()
+    {
+        // Mirrors the JSON behavior: a v1-style entry must not surface a v2-only field.
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "no-encrypt", FileTransferTimeMs = 1 };
+
+        var element = XElement.Parse(formatter.Format(entry));
+
+        Assert.Null(element.Element("EncryptionTimeMs"));
+    }
+
+    [Fact]
+    public void Format_IncludesEncryptionTimeMs_WhenSet()
+    {
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "encrypt", EncryptionTimeMs = 42 };
+
+        var element = XElement.Parse(formatter.Format(entry));
+
+        Assert.Equal("42", element.Element("EncryptionTimeMs")?.Value);
+    }
+
+    [Fact]
+    public void Format_RoundTrip_PreservesAllFields()
+    {
+        var formatter = new XmlFormatter();
+        var original = new LogEntry
+        {
+            Timestamp = "2026-04-28T12:00:00+02:00",
+            JobName = "roundtrip",
+            SourceFile = @"\\nas\share\src.docx",
+            TargetFile = @"\\nas\share\dst.docx",
+            FileSize = 1024,
+            FileTransferTimeMs = 5,
+            EncryptionTimeMs = 17,
+        };
+
+        var element = XElement.Parse(formatter.Format(original));
+        var rebuilt = new LogEntry
+        {
+            Timestamp = element.Element("Timestamp")!.Value,
+            JobName = element.Element("JobName")!.Value,
+            SourceFile = element.Element("SourceFile")!.Value,
+            TargetFile = element.Element("TargetFile")!.Value,
+            FileSize = long.Parse(element.Element("FileSize")!.Value),
+            FileTransferTimeMs = long.Parse(element.Element("FileTransferTimeMs")!.Value),
+            EncryptionTimeMs = long.Parse(element.Element("EncryptionTimeMs")!.Value),
+        };
+
+        Assert.Equal(original.Timestamp, rebuilt.Timestamp);
+        Assert.Equal(original.JobName, rebuilt.JobName);
+        Assert.Equal(original.SourceFile, rebuilt.SourceFile);
+        Assert.Equal(original.TargetFile, rebuilt.TargetFile);
+        Assert.Equal(original.FileSize, rebuilt.FileSize);
+        Assert.Equal(original.FileTransferTimeMs, rebuilt.FileTransferTimeMs);
+        Assert.Equal(original.EncryptionTimeMs, rebuilt.EncryptionTimeMs);
+    }
+
+    [Fact]
+    public void RoundTrip_NegativeFileTransferTime_PreservedAsErrorSignal()
+    {
+        // Cahier: FileTransferTimeMs < 0 is the error signal for a failed copy.
+        // The XML form must preserve negative values exactly.
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "copy-failed", FileTransferTimeMs = -1 };
+
+        var element = XElement.Parse(formatter.Format(entry));
+
+        Assert.Equal("-1", element.Element("FileTransferTimeMs")?.Value);
+    }
+
+    [Fact]
+    public void Format_OutputValidatesAgainstXsd_WhenWrappedInLogs()
+    {
+        var formatter = new XmlFormatter();
+        var entries = new[]
+        {
+            new LogEntry { JobName = "v1-shape", FileTransferTimeMs = 1 },
+            new LogEntry { JobName = "encrypt", EncryptionTimeMs = 42 },
+        };
+
+        var doc = WrapInLogs(entries.Select(e => XElement.Parse(formatter.Format(e))));
+
+        // Validate throws on first error — reaching the assertion means valid.
+        ValidateAgainstSchema(doc);
+        Assert.Equal("Logs", doc.Root!.Name.LocalName);
+    }
+
+    [Fact]
+    public void Format_EmptyLogs_ValidatesAgainstXsd()
+    {
+        // A daily file produced before any job has run must still validate;
+        // the schema declares Entry minOccurs=0 for that reason.
+        var doc = WrapInLogs(Enumerable.Empty<XElement>());
+
+        ValidateAgainstSchema(doc);
+    }
+
+    [Fact]
+    public void LoadSchema_ReturnsEmbeddedXsd()
+    {
+        // Guards against the embedded resource being dropped from the csproj.
+        var schema = XmlFormatter.LoadSchema();
+
+        Assert.NotNull(schema);
+    }
+
+    private static XDocument WrapInLogs(IEnumerable<XElement> entries)
+    {
+        return new XDocument(new XElement("Logs", entries));
+    }
+
+    private static void ValidateAgainstSchema(XDocument doc)
+    {
+        var schemas = new XmlSchemaSet();
+        schemas.Add(XmlFormatter.LoadSchema());
+        doc.Validate(schemas, (sender, e) =>
+            throw new XmlSchemaValidationException(e.Message));
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `XmlFormatter : ILogFormatter` (v2 daily XML log).
- `Format()` returns an `<Entry>` fragment built with `XDocument`; the v2 daily logger will wrap entries in a `<Logs>` root.
- Adds `docs/schemas/easysave-log.xsd` (source-of-truth) embedded in `EasyLog.dll` as `EasyLog.Schemas.easysave-log.xsd` so consumers can validate logs without shipping their own copy.
- `EncryptionTimeMs` is omitted when null to match the JSON formatter shape.

## Grille v2 coverage

- Log journalier XML
- Schéma XSD du format XML
- `ILogFormatter` strategy honored

## Test plan

- [x] `dotnet build` clean (0 warning, 0 error on EasyLog)
- [x] 10 new tests in `XmlFormatterTests` — all green
  - extension, null guard, parseable fragment
  - omit / include `EncryptionTimeMs`
  - 7-field round-trip + negative `FileTransferTimeMs` preserved
  - XSD validation when wrapped in `<Logs>`, empty `<Logs/>` valid, schema loads from embedded resource
- [x] Full suite `dotnet test EasySave.sln` — 118/118 (96 v1 + 22 v2)