### PR TITLE
chore(format): fix whitespace on EasySave.UI files

### DIFF
--- a/src/EasySave.UI/Converters/StateToColorConverter.cs
+++ b/src/EasySave.UI/Converters/StateToColorConverter.cs
@@ -11,8 +11,8 @@ public sealed class StateToColorConverter : IValueConverter
         (UiJobState?)value switch
         {
             UiJobState.Running => new SolidColorBrush(Colors.Green),
-            UiJobState.Paused  => new SolidColorBrush(Color.Parse("#FF6B35")),
-            _                  => new SolidColorBrush(Color.Parse("#6B7280")),
+            UiJobState.Paused => new SolidColorBrush(Color.Parse("#FF6B35")),
+            _ => new SolidColorBrush(Color.Parse("#6B7280")),
         };
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/EasySave.UI/Services/BusinessWatcherService.cs
+++ b/src/EasySave.UI/Services/BusinessWatcherService.cs
@@ -26,7 +26,7 @@ public sealed class BusinessWatcherService : IDisposable
 
         _detector = new BusinessSoftwareDetector(new SystemProcessProvider(), processNames!);
         _detector.BusinessSoftwareDetected += OnDetected;
-        _detector.BusinessSoftwareClosed    += OnClosed;
+        _detector.BusinessSoftwareClosed += OnClosed;
         _detector.Start();
     }
 
@@ -49,7 +49,7 @@ public sealed class BusinessWatcherService : IDisposable
         if (_detector is not null)
         {
             _detector.BusinessSoftwareDetected -= OnDetected;
-            _detector.BusinessSoftwareClosed   -= OnClosed;
+            _detector.BusinessSoftwareClosed -= OnClosed;
             _detector.Dispose();
         }
     }

--- a/src/EasySave.UI/ViewModels/BackupJobVM.cs
+++ b/src/EasySave.UI/ViewModels/BackupJobVM.cs
@@ -8,7 +8,7 @@ public sealed partial class BackupJobVM : ObservableObject
 {
     public BackupJob Model { get; }
 
-    public string Name       => Model.Name;
+    public string Name => Model.Name;
     public string SourcePath => Model.SourcePath;
     public string TargetPath => Model.TargetPath;
 
@@ -27,13 +27,13 @@ public sealed partial class BackupJobVM : ObservableObject
     [ObservableProperty] private int _filesRemaining;
 
     public bool IsRunning => UiState == UiJobState.Running;
-    public bool IsPaused  => UiState == UiJobState.Paused;
+    public bool IsPaused => UiState == UiJobState.Paused;
 
     public string StateDisplayName => UiState switch
     {
         UiJobState.Running => TranslationSource.Instance["jobs.state.active"],
-        UiJobState.Paused  => TranslationSource.Instance["jobs.state.paused"],
-        _                  => TranslationSource.Instance["jobs.state.idle"],
+        UiJobState.Paused => TranslationSource.Instance["jobs.state.paused"],
+        _ => TranslationSource.Instance["jobs.state.idle"],
     };
 
     public BackupJobVM(BackupJob model) => Model = model;

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -35,7 +35,7 @@ public sealed partial class JobsViewModel : ViewModelBase
         LoadJobs();
         _backup.StateUpdated += OnStateUpdated;
         _watcher.BusinessSoftwareDetected += OnBusinessSoftwareDetected;
-        _watcher.BusinessSoftwareGone     += OnBusinessSoftwareGone;
+        _watcher.BusinessSoftwareGone += OnBusinessSoftwareGone;
         _watcher.Start();
     }
 

--- a/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
@@ -67,7 +67,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     {
         if (_jobsVm is not null) return _jobsVm;
         _jobsVm = new JobsViewModel(_backup, _watcher);
-        _jobsVm.RequestOpenJobEdit  = job => ShowJobEdit(job);
+        _jobsVm.RequestOpenJobEdit = job => ShowJobEdit(job);
         _jobsVm.RequestShowProgress = () => ShowRunProgress();
         return _jobsVm;
     }

--- a/src/EasySave.UI/ViewModels/RunProgressViewModel.cs
+++ b/src/EasySave.UI/ViewModels/RunProgressViewModel.cs
@@ -11,7 +11,7 @@ public sealed partial class RunProgressViewModel : ViewModelBase
     public ObservableCollection<BackupJobVM> Jobs => _jobsVm.Jobs;
 
     public bool IsBusinessSoftwareDetected => _jobsVm.IsBusinessSoftwareDetected;
-    public string DetectedSoftwareName     => _jobsVm.DetectedSoftwareName;
+    public string DetectedSoftwareName => _jobsVm.DetectedSoftwareName;
 
     // Set by MainWindowViewModel so this VM can trigger navigation back.
     public Action? CloseRequested { get; set; }


### PR DESCRIPTION
## Summary

Runs \`dotnet format EasySave.sln --severity warn\` to fix whitespace introduced by PR #91. The Format check was failing on staging since that merge.

Touches 6 files in \`src/EasySave.UI/\`. No behavior change.

## Test plan

- [x] \`dotnet format --verify-no-changes\` passes locally
- [x] \`dotnet test EasySave.sln\` still green