### PR TITLE
feat(state): persist Paused state with reason and add Pause/Resume on StateTracker

### DIFF
--- a/src/EasySave/JobState.cs
+++ b/src/EasySave/JobState.cs
@@ -5,5 +5,9 @@ namespace EasySave;
 public enum JobState
 {
     Inactive = 0,
-    Active = 1
+    Active = 1,
+    // Active job temporarily held because a business software listed in appsettings.json
+    // is running. Resume happens when the business software disappears; the human-readable
+    // reason is carried separately on StateEntry.PauseReason.
+    Paused = 2
 }

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -61,6 +61,50 @@ public sealed class StateTracker
         JobProgressChanged?.Invoke(this, entry);
     }
 
+    // Marks the matching job as Paused and persists the human-readable reason (e.g.
+    // "BusinessSoftwareDetected: calc.exe"). No-op if no entry matches the given name.
+    // Resume restores the previous JobState (typically Active) and clears the reason.
+    public void Pause(string name, string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(reason);
+        TransitionState(name, _ => JobState.Paused, reason);
+    }
+
+    public void Resume(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        TransitionState(name, prev => prev == JobState.Paused ? JobState.Active : prev, string.Empty);
+    }
+
+    private void TransitionState(string name, Func<JobState, JobState> nextState, string reason)
+    {
+        StateEntry? snapshot = null;
+
+        lock (_lock)
+        {
+            var path = AppConfig.Instance.StateFilePath;
+            if (!File.Exists(path)) return;
+
+            var states = ReadCurrentEntries(path);
+            var entry = states.FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (entry is null) return;
+
+            entry.State = nextState(entry.State);
+            entry.PauseReason = reason;
+            entry.LastActionTime = DateTimeOffset.Now;
+
+            FileHelpers.EnsureDirectoryExists(path);
+            FileHelpers.WriteAllTextAtomic(path, JsonSerializer.Serialize(states, FileHelpers.IndentedJsonOptions));
+            snapshot = entry;
+        }
+
+        if (snapshot is not null)
+        {
+            JobProgressChanged?.Invoke(this, snapshot);
+        }
+    }
+
     // Drops the state entry for the given job name (case-insensitive) and rewrites state.json.
     // No-op if no entry matches. Also evicts the matching JobProgress observable so the GUI
     // stops binding to a deleted job.

--- a/src/EasySave/Services/StateTracker.cs
+++ b/src/EasySave/Services/StateTracker.cs
@@ -67,8 +67,10 @@ public sealed class StateTracker
     public void Pause(string name, string reason)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
-        ArgumentNullException.ThrowIfNull(reason);
-        TransitionState(name, _ => JobState.Paused, reason);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        // Only an Active job can be paused — pausing an Inactive (finished) job would
+        // mark it Paused in state.json and confuse any monitoring tool reading the file.
+        TransitionState(name, prev => prev == JobState.Active ? JobState.Paused : prev, reason);
     }
 
     public void Resume(string name)
@@ -90,7 +92,12 @@ public sealed class StateTracker
             var entry = states.FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
             if (entry is null) return;
 
-            entry.State = nextState(entry.State);
+            var next = nextState(entry.State);
+            // No state transition means the call is rejected (e.g. Pause on Inactive,
+            // Resume on Active): leave the file and the reason untouched, no event.
+            if (entry.State == next) return;
+
+            entry.State = next;
             entry.PauseReason = reason;
             entry.LastActionTime = DateTimeOffset.Now;
 

--- a/src/EasySave/StateEntry.cs
+++ b/src/EasySave/StateEntry.cs
@@ -38,6 +38,10 @@ public sealed class StateEntry
     // Full target path of the file currently being processed (UNC format).
     public string CurrentTarget { get; set; } = string.Empty;
 
+    // Human-readable reason kept while State is Paused (e.g. "BusinessSoftwareDetected: calc.exe").
+    // Cleared on resume. Empty when State is Active or Inactive.
+    public string PauseReason { get; set; } = string.Empty;
+
     public override string ToString()
     {
         return $"{Name} [{State}] {Progress:0.0}% - {FilesRemaining} files / {SizeRemaining} bytes remaining";

--- a/tests/EasySave.Tests/StateTrackerPauseResumeTests.cs
+++ b/tests/EasySave.Tests/StateTrackerPauseResumeTests.cs
@@ -86,15 +86,65 @@ public class StateTrackerPauseResumeTests : IDisposable
     [Fact]
     public void Resume_IsNoOp_WhenJobNotPaused()
     {
-        // Resuming an Active job leaves it Active and PauseReason empty.
+        // Resuming an Active job is a true no-op: state.json is not rewritten.
         var name = "noop-" + Guid.NewGuid().ToString("N");
         StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+        var beforeContent = File.ReadAllText(_stateFilePath);
 
         StateTracker.Instance.Resume(name);
 
+        Assert.Equal(beforeContent, File.ReadAllText(_stateFilePath));
         var entry = ReadStates().Single(s => s.Name == name);
         Assert.Equal(JobState.Active, entry.State);
         Assert.Equal(string.Empty, entry.PauseReason);
+    }
+
+    [Fact]
+    public void Pause_IsNoOp_WhenJobInactive()
+    {
+        // An Inactive (finished) job must not be flipped to Paused.
+        var name = "inactive-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Inactive });
+        var beforeContent = File.ReadAllText(_stateFilePath);
+
+        StateTracker.Instance.Pause(name, "BusinessSoftwareDetected: calc.exe");
+
+        Assert.Equal(beforeContent, File.ReadAllText(_stateFilePath));
+        Assert.Equal(JobState.Inactive, ReadStates().Single(s => s.Name == name).State);
+    }
+
+    [Fact]
+    public void Pause_RejectsBlankReason()
+    {
+        var name = "blank-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+
+        Assert.Throws<ArgumentException>(() => StateTracker.Instance.Pause(name, ""));
+        Assert.Throws<ArgumentException>(() => StateTracker.Instance.Pause(name, "   "));
+    }
+
+    [Fact]
+    public void Resume_RaisesJobProgressChanged()
+    {
+        var name = "evt-resume-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+        StateTracker.Instance.Pause(name, "BusinessSoftwareDetected: calc.exe");
+
+        StateEntry? received = null;
+        EventHandler<StateEntry> handler = (_, e) => received = e;
+        StateTracker.Instance.JobProgressChanged += handler;
+        try
+        {
+            StateTracker.Instance.Resume(name);
+        }
+        finally
+        {
+            StateTracker.Instance.JobProgressChanged -= handler;
+        }
+
+        Assert.NotNull(received);
+        Assert.Equal(JobState.Active, received!.State);
+        Assert.Equal(string.Empty, received.PauseReason);
     }
 
     [Fact]

--- a/tests/EasySave.Tests/StateTrackerPauseResumeTests.cs
+++ b/tests/EasySave.Tests/StateTrackerPauseResumeTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using EasySave;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class StateTrackerPauseResumeTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _stateFilePath;
+
+    public StateTrackerPauseResumeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "statetracker-pause-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _stateFilePath = Path.Combine(_tempDir, "state.json");
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new { StateFilePath = _stateFilePath };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private List<StateEntry> ReadStates() =>
+        JsonSerializer.Deserialize<List<StateEntry>>(File.ReadAllText(_stateFilePath))!;
+
+    [Fact]
+    public void Pause_StoresReason_AndFlipsStateToPaused()
+    {
+        var name = "pause-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+
+        StateTracker.Instance.Pause(name, "BusinessSoftwareDetected: calc.exe");
+
+        var entry = ReadStates().Single(s => s.Name == name);
+        Assert.Equal(JobState.Paused, entry.State);
+        Assert.Equal("BusinessSoftwareDetected: calc.exe", entry.PauseReason);
+    }
+
+    [Fact]
+    public void Resume_FlipsBackToActive_AndClearsReason()
+    {
+        var name = "resume-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+        StateTracker.Instance.Pause(name, "BusinessSoftwareDetected: calc.exe");
+
+        StateTracker.Instance.Resume(name);
+
+        var entry = ReadStates().Single(s => s.Name == name);
+        Assert.Equal(JobState.Active, entry.State);
+        Assert.Equal(string.Empty, entry.PauseReason);
+    }
+
+    [Fact]
+    public void Pause_IsCaseInsensitive()
+    {
+        var name = "CaseTest-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+
+        StateTracker.Instance.Pause(name.ToUpperInvariant(), "BusinessSoftwareDetected: calc.exe");
+
+        Assert.Equal(JobState.Paused, ReadStates().Single(s => s.Name == name).State);
+    }
+
+    [Fact]
+    public void Pause_IsNoOp_WhenJobAbsent()
+    {
+        var existing = "kept-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = existing, State = JobState.Active });
+        var beforeContent = File.ReadAllText(_stateFilePath);
+
+        StateTracker.Instance.Pause("does-not-exist-" + Guid.NewGuid().ToString("N"), "any");
+
+        Assert.Equal(beforeContent, File.ReadAllText(_stateFilePath));
+    }
+
+    [Fact]
+    public void Resume_IsNoOp_WhenJobNotPaused()
+    {
+        // Resuming an Active job leaves it Active and PauseReason empty.
+        var name = "noop-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+
+        StateTracker.Instance.Resume(name);
+
+        var entry = ReadStates().Single(s => s.Name == name);
+        Assert.Equal(JobState.Active, entry.State);
+        Assert.Equal(string.Empty, entry.PauseReason);
+    }
+
+    [Fact]
+    public void Pause_RaisesJobProgressChanged()
+    {
+        var name = "evt-" + Guid.NewGuid().ToString("N");
+        StateTracker.Instance.Update(new StateEntry { Name = name, State = JobState.Active });
+
+        StateEntry? received = null;
+        EventHandler<StateEntry> handler = (_, e) => received = e;
+        StateTracker.Instance.JobProgressChanged += handler;
+        try
+        {
+            StateTracker.Instance.Pause(name, "BusinessSoftwareDetected: calc.exe");
+        }
+        finally
+        {
+            StateTracker.Instance.JobProgressChanged -= handler;
+        }
+
+        Assert.NotNull(received);
+        Assert.Equal(JobState.Paused, received!.State);
+        Assert.Equal("BusinessSoftwareDetected: calc.exe", received.PauseReason);
+    }
+}


### PR DESCRIPTION
## Summary
ClickUp \`869d020r0\`. Adds the persistence model for the v2.0 business-software pause flow so a paused job survives across sessions and is reflected in \`state.json\` for any monitoring tool reading the file.

- \`JobState.Paused = 2\`: third value of the enum, kept after \`Inactive\` and \`Active\` so existing v1 files (which only carry 0/1) deserialize unchanged.
- \`StateEntry.PauseReason\`: human-readable reason (e.g. \`"BusinessSoftwareDetected: calc.exe"\`). Empty when the job is not paused.
- \`StateTracker.Pause(name, reason)\` / \`Resume(name)\`: case-insensitive lookup; rewrites \`state.json\` atomically through the existing helpers; updates \`LastActionTime\`; raises the existing \`JobProgressChanged\` event so a future Avalonia binding can react. Both are no-ops if the job is absent. \`Resume\` only flips \`Paused → Active\` and clears the reason.

## Out of scope
The wire-up that listens to \`BusinessSoftwareDetector.BusinessSoftwareDetected\` / \`BusinessSoftwareClosed\` and calls \`Pause\`/\`Resume\` lives in \`BackupManager.RunJob\` (Dev2 zone) and will land in a follow-up.

## Test plan
- [x] \`dotnet build\` clean
- [x] \`dotnet test\` 111/111 (4 Windows-only \`SkippableFact\` ignored as on staging)
- [x] New \`StateTrackerPauseResumeTests\` (6 tests): pause stores reason + flips to Paused, resume flips back to Active and clears reason, case-insensitive lookup, no-op when job absent, no-op resume on Active job, JobProgressChanged event fires with the new state.