### PR TITLE
test(easylog): cover special-character escaping in XmlFormatter paths

### DIFF
--- a/tests/EasySave.Tests.V2/XmlFormatterTests.cs
+++ b/tests/EasySave.Tests.V2/XmlFormatterTests.cs
@@ -140,6 +140,31 @@ public class XmlFormatterTests
         Assert.NotNull(schema);
     }
 
+    [Theory]
+    [InlineData(@"C:\path\with & ampersand\file.txt")]
+    [InlineData("C:\\path\\with <angle> brackets\\file.txt")]
+    [InlineData("C:\\path\\with \"quotes\" and 'apos'\\file.txt")]
+    [InlineData(@"\\server\share\file with spaces.txt")]
+    [InlineData("Café Résumé/Ωmega/файл.txt")]
+    public void Format_EscapesSpecialCharactersInFilePaths(string path)
+    {
+        // Real-world paths can contain XML-meta characters (& < > " ') and
+        // non-ASCII glyphs. The formatter must escape them so the output is
+        // both valid XML and valid against the schema, and the original
+        // string must come back intact after parsing.
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "special-chars", SourceFile = path, TargetFile = path };
+
+        var xml = formatter.Format(entry);
+        var element = XElement.Parse(xml);
+
+        Assert.Equal(path, element.Element("SourceFile")?.Value);
+        Assert.Equal(path, element.Element("TargetFile")?.Value);
+
+        var doc = WrapInLogs(new[] { element });
+        ValidateAgainstSchema(doc);
+    }
+
     private static XDocument WrapInLogs(IEnumerable<XElement> entries)
     {
         return new XDocument(new XElement("Logs", entries));


### PR DESCRIPTION
## Summary

Closes the only gap from task **[Tests] XmlFormatter + XSD**: the existing `XmlFormatterTests` (PR #92) already covered roundtrip equality, XSD validation via `XmlSchemaSet`, and optional `EncryptionTimeMs` presence/absence. This PR adds the missing case — escaping of XML-meta characters in file paths.

A `Theory` exercises 5 representative paths:

- `&` (ampersand)
- `<` and `>` (angle brackets)
- `\"` and `'` (quotes / apostrophes)
- UNC path with spaces
- Non-ASCII glyphs (Latin accents, Greek, Cyrillic)

Each case asserts both that the parsed value is byte-equal to the original AND that the wrapped `<Logs>` document validates against the embedded XSD.

## Test plan

- [x] 5 new theory cases — all green (`XmlFormatterTests` 15/15)
- [x] Full suite green: 128/132 (4 pre-existing skipped)
- [x] `dotnet format --verify-no-changes` clean