### PR TITLE
test(easylog): cover JsonFormatter v1-reader compat and append-only behavior

### DIFF
--- a/tests/EasySave.Tests.V2/JsonDailyLoggerEncryptionTests.cs
+++ b/tests/EasySave.Tests.V2/JsonDailyLoggerEncryptionTests.cs
@@ -47,6 +47,29 @@ public class JsonDailyLoggerEncryptionTests : IDisposable
     }
 
     [Fact]
+    public void Append_AccumulatesEntriesAcrossMultipleCalls()
+    {
+        // Append-only contract: every Append must extend the daily file,
+        // never replace it. A regression here would silently drop earlier
+        // entries on the same business day.
+        var logger = new JsonDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry { JobName = "first", FileTransferTimeMs = 1 });
+        logger.Append(new LogEntry { JobName = "second", FileTransferTimeMs = 2 });
+        logger.Append(new LogEntry { JobName = "third", FileTransferTimeMs = 3, EncryptionTimeMs = 10 });
+
+        var dailyFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        var entries = JsonSerializer.Deserialize<List<LogEntry>>(File.ReadAllText(dailyFile));
+
+        Assert.NotNull(entries);
+        Assert.Equal(3, entries!.Count);
+        Assert.Equal(new[] { "first", "second", "third" }, entries.Select(e => e.JobName));
+        Assert.Null(entries[0].EncryptionTimeMs);
+        Assert.Null(entries[1].EncryptionTimeMs);
+        Assert.Equal(10, entries[2].EncryptionTimeMs);
+    }
+
+    [Fact]
     public void Append_NoEncryption_KeepsV1FileShape()
     {
         // A v2 caller that does not set EncryptionTimeMs must produce a daily file

--- a/tests/EasySave.Tests.V2/JsonFormatterTests.cs
+++ b/tests/EasySave.Tests.V2/JsonFormatterTests.cs
@@ -118,4 +118,42 @@ public class JsonFormatterTests
 
         Assert.Contains("\n", json);
     }
+
+    [Fact]
+    public void Format_OutputDeserializes_IntoV1ShapeWithoutError()
+    {
+        // Simulates a v1 reader (e.g. another ProSoft app linked against EasyLog
+        // before EncryptionTimeMs existed). The v2 JSON must deserialize cleanly
+        // into a DTO that has only v1 fields — System.Text.Json ignores unknown
+        // properties by default, and we lock that contract here.
+        var formatter = new JsonFormatter();
+        var v2Json = formatter.Format(new LogEntry
+        {
+            Timestamp = "2026-04-29T08:00:00+02:00",
+            JobName = "v2-with-encryption",
+            FileSize = 1024,
+            FileTransferTimeMs = 5,
+            EncryptionTimeMs = 42,
+        });
+
+        V1LogEntryShape? v1View = JsonSerializer.Deserialize<V1LogEntryShape>(v2Json);
+
+        Assert.NotNull(v1View);
+        Assert.Equal("v2-with-encryption", v1View!.JobName);
+        Assert.Equal(1024, v1View.FileSize);
+        Assert.Equal(5, v1View.FileTransferTimeMs);
+    }
+
+    // Mirrors the public surface of EasyLog v1 LogEntry. Used to assert that a
+    // v2-produced JSON file stays loadable by a consumer that does not know
+    // about EncryptionTimeMs.
+    private sealed class V1LogEntryShape
+    {
+        public string Timestamp { get; set; } = string.Empty;
+        public string JobName { get; set; } = string.Empty;
+        public string SourceFile { get; set; } = string.Empty;
+        public string TargetFile { get; set; } = string.Empty;
+        public long FileSize { get; set; }
+        public long FileTransferTimeMs { get; set; }
+    }
 }


### PR DESCRIPTION
## Summary

Closes the two remaining gaps from task **[Tests] JsonFormatter V2** — points 1 and 2 of the spec are already covered by PR #81 (`LogEntryV2Tests.Deserialize_V1Json_LeavesEncryptionTimeNull`, `Serialize_NullEncryptionTime_OmitsProperty`) and PR #98 (`JsonFormatterTests.Format_OmitsEncryptionTimeMs_WhenNull`, `Format_IncludesEncryptionTimeMs_WhenSet`).

This PR adds:

1. **v2 → v1 reader compat** (`Format_OutputDeserializes_IntoV1ShapeWithoutError`): a private DTO mirroring the v1 `LogEntry` surface (no `EncryptionTimeMs`) deserializes a v2 JSON that includes the field — System.Text.Json ignores unknown properties by default and the test locks that contract.
2. **append-only behavior** (`Append_AccumulatesEntriesAcrossMultipleCalls`): three sequential `JsonDailyLogger.Append` calls on the same day produce a daily file holding all three entries in order, mixing v1-shaped (no `EncryptionTimeMs`) and v2-shaped (with `EncryptionTimeMs`) entries.

## Test plan

- [x] 2 new tests — all green
- [x] Full suite green: 138/142 (4 pre-existing skipped)
- [x] `dotnet format --verify-no-changes` clean