### PR TITLE
fix(state): propagate IOException in SettingsRepository.Load to prevent silent overwrite

### DIFF
--- a/src/EasySave/Services/SettingsRepository.cs
+++ b/src/EasySave/Services/SettingsRepository.cs
@@ -20,6 +20,9 @@ public sealed class SettingsRepository
     // Loads the persisted settings from disk, or defaults if the file is missing.
     // A corrupted file is moved aside to a timestamped ".corrupted" copy so the user's
     // values are not lost silently.
+    // Transient IOException is propagated to the caller — swallowing it and returning
+    // defaults would let the next Save() write the defaults over the existing file
+    // and silently wipe the user's settings (issue #97, same trap as #69).
     public AppSettings Load()
     {
         lock (_lock)
@@ -38,10 +41,6 @@ public sealed class SettingsRepository
             catch (JsonException ex)
             {
                 FileHelpers.QuarantineCorruptedFile(path, ex, "SettingsRepository");
-                return new AppSettings();
-            }
-            catch (IOException)
-            {
                 return new AppSettings();
             }
         }

--- a/tests/EasySave.Tests/PersistenceLockPropagationTests.cs
+++ b/tests/EasySave.Tests/PersistenceLockPropagationTests.cs
@@ -18,6 +18,7 @@ public class PersistenceLockPropagationTests : IDisposable
     private readonly string _tempDir;
     private readonly string _jobsFilePath;
     private readonly string _stateFilePath;
+    private readonly string _settingsFilePath;
 
     public PersistenceLockPropagationTests()
     {
@@ -25,9 +26,15 @@ public class PersistenceLockPropagationTests : IDisposable
         Directory.CreateDirectory(_tempDir);
         _jobsFilePath = Path.Combine(_tempDir, "jobs.json");
         _stateFilePath = Path.Combine(_tempDir, "state.json");
+        _settingsFilePath = Path.Combine(_tempDir, "settings.json");
 
         var configPath = Path.Combine(_tempDir, "appsettings.json");
-        var payload = new { JobsFilePath = _jobsFilePath, StateFilePath = _stateFilePath };
+        var payload = new
+        {
+            JobsFilePath = _jobsFilePath,
+            StateFilePath = _stateFilePath,
+            SettingsFilePath = _settingsFilePath,
+        };
         File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
         AppConfig.Load(configPath);
     }
@@ -112,5 +119,48 @@ public class PersistenceLockPropagationTests : IDisposable
         }
 
         Assert.Equal(originalJson, File.ReadAllText(_stateFilePath));
+    }
+
+    // Issue #97: SettingsRepository.Load used to swallow IOException and return defaults,
+    // which would let the next Save write the defaults over a still-valid settings.json
+    // and silently wipe the user's settings as soon as the GUI is wired.
+    [SkippableFact]
+    public void SettingsRepository_Load_PropagatesIOException_WhenFileLocked()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var existing = new AppSettings
+        {
+            Language = "fr",
+            EncryptedExtensions = new[] { ".pdf", ".docx" },
+        };
+        File.WriteAllText(_settingsFilePath, JsonSerializer.Serialize(existing));
+
+        using var lockHolder = new FileStream(_settingsFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        Assert.Throws<IOException>(() => SettingsRepository.Instance.Load());
+    }
+
+    [SkippableFact]
+    public void SettingsRepository_Load_PreservesFile_WhenIOExceptionPropagates()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var existing = new AppSettings
+        {
+            Language = "fr",
+            EncryptedExtensions = new[] { ".pdf", ".docx" },
+        };
+        var originalJson = JsonSerializer.Serialize(existing);
+        File.WriteAllText(_settingsFilePath, originalJson);
+
+        using (var lockHolder = new FileStream(_settingsFilePath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.Throws<IOException>(() => SettingsRepository.Instance.Load());
+        }
+
+        Assert.Equal(originalJson, File.ReadAllText(_settingsFilePath));
     }
 }


### PR DESCRIPTION
## Summary
Closes #97. Same anti-pattern as #69 / #90, this time on \`SettingsRepository.Load()\`. A transient \`IOException\` (antivirus, OneDrive, backup agent holding \`settings.json\` for a few ms) was silently downgraded to \`new AppSettings()\`, which would let the next \`Save()\` write the defaults over the existing file and wipe the user's settings as soon as the GUI is wired.

- \`SettingsRepository.Load()\`: drop the swallow-and-return-defaults \`catch (IOException)\`. The exception propagates to the caller (\`SettingsViewModel\` once wired) so it can show an error instead of overwriting.
- Comment on the \`Load\` method documents the rationale and references issues #97 / #69.

## Test plan
- [x] \`dotnet build\` clean
- [x] \`dotnet test\` 110/116 (6 \`SkippableFact\` Windows-only ignored on macOS — same convention as the existing lock tests)
- [x] Two new \`SkippableFact\` in \`PersistenceLockPropagationTests\`:
  - \`SettingsRepository_Load_PropagatesIOException_WhenFileLocked\` — locked file → \`Load\` throws
  - \`SettingsRepository_Load_PreservesFile_WhenIOExceptionPropagates\` — file content stays intact when the lock fires