### PR TITLE
feat(ui): persist language choice in settings.json

### DIFF
--- a/docs/recettes/v2-language-runtime-switch.md
+++ b/docs/recettes/v2-language-runtime-switch.md
@@ -1,0 +1,90 @@
+# Recette V2 — Switch langue FR↔EN runtime sans restart
+
+ClickUp task: `869d036e7` — `[Recette V2] Switch langue FR↔EN runtime sans restart`
+Tags: `grille-tuteur`, `recette-v2`
+
+## Goal
+
+Verify that EasySave honors the v2.0 grille requirement
+"locale switch without restart": the user toggles FR↔EN at any time and
+every UI string updates immediately, including modals already open.
+
+## How the runtime switch works
+
+- `{markup:T Key=foo}` (custom XAML extension) returns a OneWay `Binding` to
+  `TranslationSource.Instance[foo]`.
+- `LanguageService.SetLanguage(locale)` reloads the JSON resource and raises
+  `LanguageChanged`.
+- `TranslationSource` translates that into `PropertyChanged("Item[]")`,
+  which invalidates every binding registered against the singleton —
+  including the ones owned by modal windows opened earlier.
+- The chosen locale is saved to `settings.json` (`language` key) so the
+  next launch opens in the user's preference instead of the FR default.
+
+## Pre-requisites
+
+- Build the UI once: `dotnet build src/EasySave.UI/EasySave.UI.csproj`.
+- For a clean reading, delete or rename `settings.json` so the test starts
+  with the FR default. The file lives next to the other user data:
+  - Windows: `%APPDATA%\ProSoft\EasySave\settings.json`
+  - Linux: `~/.config/ProSoft/EasySave/settings.json`
+  - macOS: `~/Library/Application Support/ProSoft/EasySave/settings.json`
+
+## Manual scenario
+
+### Steps
+
+1. Launch the GUI: `dotnet run --project src/EasySave.UI`.
+2. Confirm the sidebar labels are in French (`Sauvegardes`, `Paramètres`,
+   `Journaux`, `À propos`).
+3. Click **EN** in the bottom-left language toggle.
+4. **Critical:** confirm every label flips to English without any visible
+   reload — `Backups`, `Settings`, `Logs`, `About`.
+5. Click `About` to open the modal. Confirm the text is in English.
+6. Without closing the modal, switch back to **FR** in the sidebar.
+7. **Critical:** confirm the open About modal flips to French at the same
+   time as the main window (single shared `TranslationSource.Instance`).
+8. Close the About modal. Open **Backups** → **Add Job** to reach the
+   JobEdit view. Repeat the FR↔EN toggle and confirm `edit.name`,
+   `edit.source`, `edit.destination`, `edit.cancel`, `edit.save` all
+   refresh immediately.
+9. Close the app. Inspect `settings.json` — the `language` key must hold
+   the last locale you selected (`fr` or `en`).
+10. Relaunch the app. The window must open in the persisted locale, not
+    the hard-coded FR default.
+
+### Expected result
+
+- Every visible label updates within the same UI tick on toggle, no flash,
+  no restart.
+- The About modal and JobEdit view follow the toggle exactly like the
+  main window — no orphaned French text in an English UI or vice versa.
+- `settings.json` reflects the last selected locale after closing the app.
+- The app reopens in that locale on next launch.
+
+## Known scope
+
+- The toggle is in the main window sidebar, not inside the Settings tab.
+  This is intentional — it keeps the locale switch one click away from
+  any screen instead of buried in Settings. The recette spec wording
+  ("Settings → Language") is loose; the deliverable is the runtime switch
+  behavior, not a specific menu path.
+- Placeholder texts in `JobEditView.axaml` (e.g. example paths in the
+  `TextBox.PlaceholderText` attribute) are not localized. They are
+  illustrative only and disappear once the user types.
+
+## Result (filled by tester)
+
+| Field | Value |
+|---|---|
+| Tester | _to fill_ |
+| Date | _to fill_ |
+| App version | _v2.0-staging @ <commit>_ |
+| Operating system | _to fill_ |
+| Outcome | ☐ PASS  ☐ FAIL |
+| Open-modal switch worked | ☐ Yes  ☐ No |
+| Persistence across restart worked | ☐ Yes  ☐ No |
+| Notes | _to fill_ |
+
+If the outcome is FAIL, attach a screenshot of the affected window and
+the resulting `settings.json` content to the ClickUp task.

--- a/docs/recettes/v2-language-runtime-switch.md
+++ b/docs/recettes/v2-language-runtime-switch.md
@@ -24,34 +24,38 @@ every UI string updates immediately, including modals already open.
 ## Pre-requisites
 
 - Build the UI once: `dotnet build src/EasySave.UI/EasySave.UI.csproj`.
-- For a clean reading, delete or rename `settings.json` so the test starts
-  with the FR default. The file lives next to the other user data:
+- For a clean reading, delete or rename `settings.json`. The file lives
+  next to the other user data:
   - Windows: `%APPDATA%\ProSoft\EasySave\settings.json`
   - Linux: `~/.config/ProSoft/EasySave/settings.json`
   - macOS: `~/Library/Application Support/ProSoft/EasySave/settings.json`
+- Note: with `settings.json` absent, the app starts in **English** —
+  `appsettings.json` ships `"language": "en"` and seeds `settings.json`
+  on first run. To start in French, edit the seeded `settings.json` and
+  set `"language": "fr"` before launching, or just toggle once via the
+  sidebar.
 
 ## Manual scenario
 
 ### Steps
 
 1. Launch the GUI: `dotnet run --project src/EasySave.UI`.
-2. Confirm the sidebar labels are in French (`Sauvegardes`, `Paramètres`,
-   `Journaux`, `À propos`).
-3. Click **EN** in the bottom-left language toggle.
-4. **Critical:** confirm every label flips to English without any visible
-   reload — `Backups`, `Settings`, `Logs`, `About`.
-5. Click `About` to open the modal. Confirm the text is in English.
-6. Without closing the modal, switch back to **FR** in the sidebar.
-7. **Critical:** confirm the open About modal flips to French at the same
-   time as the main window (single shared `TranslationSource.Instance`).
-8. Close the About modal. Open **Backups** → **Add Job** to reach the
+2. Click **FR** in the bottom-left language toggle.
+3. **Critical:** confirm every sidebar label flips to French immediately
+   (`Sauvegardes`, `Paramètres`, `Journaux`, `À propos`) — no flash, no
+   restart.
+4. Click `À propos` to open the modal. Confirm the text is in French.
+5. Without closing the modal, switch back to **EN** in the sidebar.
+6. **Critical:** confirm the open About modal flips to English at the
+   same time as the main window (single shared `TranslationSource.Instance`).
+7. Close the About modal. Open **Backups** → **Add Job** to reach the
    JobEdit view. Repeat the FR↔EN toggle and confirm `edit.name`,
    `edit.source`, `edit.destination`, `edit.cancel`, `edit.save` all
    refresh immediately.
-9. Close the app. Inspect `settings.json` — the `language` key must hold
+8. Close the app. Inspect `settings.json` — the `language` key must hold
    the last locale you selected (`fr` or `en`).
-10. Relaunch the app. The window must open in the persisted locale, not
-    the hard-coded FR default.
+9. Relaunch the app. The window must open in the persisted locale, not
+   the `appsettings.json` seed.
 
 ### Expected result
 

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -40,6 +40,14 @@ public partial class App : Application
         var langService = Services.GetRequiredService<ILanguageService>();
         TranslationSource.Instance.Initialize(langService);
 
+        // Apply the language the user picked on a previous run so the app
+        // opens in their chosen locale, not the LanguageService default ("fr").
+        var savedLocale = SettingsRepository.Instance.Load().Language;
+        if (!string.IsNullOrWhiteSpace(savedLocale))
+        {
+            langService.SetLanguage(savedLocale);
+        }
+
         Services.GetRequiredService<SchedulerDispatchService>().Start();
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)

--- a/src/EasySave.UI/Views/MainWindow.axaml.cs
+++ b/src/EasySave.UI/Views/MainWindow.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using EasySave.Models;
+using EasySave.Services;
 using EasySave.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,10 +21,38 @@ public partial class MainWindow : Window
 
     private void OnLanguageButtonClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is Button { Tag: string locale })
+        if (sender is not Button { Tag: string locale })
+            return;
+
+        // Apply at runtime so every {markup:T} binding refreshes immediately —
+        // including any modal currently open (About, JobEdit) that subscribes
+        // to the same TranslationSource.Instance.
+        var langService = App.Services?.GetService<ILanguageService>();
+        langService?.SetLanguage(locale);
+
+        PersistLanguage(locale);
+    }
+
+    private static void PersistLanguage(string locale)
+    {
+        // Best-effort: a transient I/O failure must not block the runtime
+        // switch the user just performed. The switch already happened.
+        try
         {
-            var langService = App.Services?.GetService<ILanguageService>();
-            langService?.SetLanguage(locale);
+            var current = SettingsRepository.Instance.Load();
+            SettingsRepository.Instance.Save(new AppSettings
+            {
+                EncryptedExtensions = current.EncryptedExtensions,
+                BusinessSoftware = current.BusinessSoftware,
+                Language = locale,
+                LogFormat = current.LogFormat,
+                CryptoSoft = current.CryptoSoft,
+            });
+        }
+        catch (System.IO.IOException ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                $"[MainWindow] Failed to persist language '{locale}': {ex.Message}");
         }
     }
 

--- a/src/EasySave.UI/Views/MainWindow.axaml.cs
+++ b/src/EasySave.UI/Views/MainWindow.axaml.cs
@@ -37,6 +37,9 @@ public partial class MainWindow : Window
     {
         // Best-effort: a transient I/O failure must not block the runtime
         // switch the user just performed. The switch already happened.
+        // UnauthorizedAccessException does not inherit from IOException
+        // (it inherits from SystemException), so it must be caught explicitly
+        // — File.WriteAllText / File.Move both throw it on a restrictive ACL.
         try
         {
             var current = SettingsRepository.Instance.Load();
@@ -49,7 +52,8 @@ public partial class MainWindow : Window
                 CryptoSoft = current.CryptoSoft,
             });
         }
-        catch (System.IO.IOException ex)
+        catch (Exception ex) when (ex is System.IO.IOException
+                                       or UnauthorizedAccessException)
         {
             System.Diagnostics.Trace.TraceWarning(
                 $"[MainWindow] Failed to persist language '{locale}': {ex.Message}");


### PR DESCRIPTION
## Summary

Closes ClickUp task **869d036e7** — `[Recette V2] Switch langue FR↔EN runtime sans restart`.

The runtime switch was already working: `LanguageService.SetLanguage` raises `LanguageChanged`, `TranslationSource` fans it out as `PropertyChanged("Item[]")` so every `{markup:T}` binding refreshes — including bindings owned by modals already open. The gap was persistence: closing and reopening the app silently reset to the hard-coded FR default.

This PR fixes that:

- `MainWindow.OnLanguageButtonClick` now writes the locale to `settings.json` via `SettingsRepository` immediately after `SetLanguage`. I/O failures during persistence are traced and ignored — the runtime switch the user just performed is already visible, no rollback needed.
- `App.OnFrameworkInitializationCompleted` reads `settings.Language` at startup and applies it through `SetLanguage`, so the saved locale wins over the `LanguageService` FR default.

## Recette deliverable

`docs/recettes/v2-language-runtime-switch.md` — scenario covers the runtime switch, the open-modal case (About + JobEdit), and the across-restart persistence. Result section is left blank for the tester.

## Test plan

- [x] `dotnet build EasySave.sln` clean (0 errors)
- [x] `dotnet test EasySave.sln` — 147/153 (6 pre-existing skipped, no regressions)
- [x] `dotnet format --verify-no-changes` clean
- [ ] Manual recette to be executed by the tester