### PR TITLE
test(easylog): cover XmlDailyLogger and add log-format recette doc

### DIFF
--- a/docs/recettes/v2-log-format-switch.md
+++ b/docs/recettes/v2-log-format-switch.md
@@ -1,0 +1,120 @@
+# Recette V2 — Log : EncryptionTimeMs présent + format XML vs JSON switchable
+
+ClickUp task: `869d036gw` — `[Recette V2] Log : EncryptionTimeMs présent + format XML vs JSON switchable`
+Tags: `grille-tuteur`, `recette-v2`, priority **urgent**
+
+## Goal
+
+Verify the v2.0 grille items "log journalier au format XML" and "temps de
+cryptage" end-to-end:
+
+- A run with `log_format = "json"` produces `Logs/yyyy-MM-dd.json` where
+  encrypted files carry `EncryptionTimeMs > 0` and plain copies omit the
+  field (v1 byte-shape compat).
+- A run with `log_format = "xml"` produces `Logs/yyyy-MM-dd.xml` valid
+  against the embedded XSD with `EncryptionTimeMs` present where
+  applicable.
+- Both files coexist in the same directory — switching format does not
+  erase the previous day's data.
+
+## Programmatic evidence
+
+Locked at the EasyLog level on every CI build:
+
+- `JsonDailyLoggerEncryptionTests` (4 cases): `EncryptionTimeMs` survives
+  `Append`, the v1 file shape is preserved when null, multiple appends
+  accumulate.
+- `XmlDailyLoggerTests` (7 cases, added in this PR): daily file extension,
+  `EncryptionTimeMs` omit/include, append-only across calls, XSD
+  validation of the produced document, corrupted-file quarantine, and
+  JSON/XML coexistence in the same directory.
+- `JsonFormatterTests` and `XmlFormatterTests` cover the formatter level
+  including v1-reader compat and special-character escaping.
+
+## Pre-requisites
+
+- Build the UI: `dotnet build src/EasySave.UI/EasySave.UI.csproj`.
+- A working CryptoSoft binary, with its absolute path either in
+  `appsettings.json:crypto_soft.path` or set later via the Settings GUI.
+- A source directory containing at least one **encryption-eligible**
+  file (default extensions: `.docx`, `.pdf`, `.xlsx`) AND one plain file
+  (e.g. a `.txt` outside the encrypted-extensions list).
+- A writable target directory.
+- For a clean reading, delete the today's daily files in the user log
+  directory before each run:
+  - Windows: `%APPDATA%\ProSoft\EasySave\Logs\`
+  - Linux: `~/.config/ProSoft/EasySave/Logs/`
+  - macOS: `~/Library/Application Support/ProSoft/EasySave/Logs/`
+
+## Manual scenario
+
+### Phase 1 — JSON format
+
+1. Launch the GUI: `dotnet run --project src/EasySave.UI`.
+2. Open **Settings**, set `Log Format` to `json`, click **Save**, close
+   the app.
+3. Inspect `settings.json`: `log_format` must be `"json"`.
+4. Relaunch the app. Open **Backups**, define a job pointing at the
+   source/target prepared above.
+5. Run the job and wait for completion.
+6. Open `Logs/yyyy-MM-dd.json` and confirm:
+   - The encryption-eligible file's entry has `EncryptionTimeMs > 0`.
+   - The plain file's entry has **no** `EncryptionTimeMs` field at all
+     (omitted, not `null`).
+   - Every entry has the v1 fields: `Timestamp`, `JobName`, `SourceFile`,
+     `TargetFile`, `FileSize`, `FileTransferTimeMs`.
+
+### Phase 2 — XML format
+
+7. Reopen the GUI. Open **Settings**, switch `Log Format` to `xml`,
+   click **Save**, close the app.
+8. Inspect `settings.json`: `log_format` must be `"xml"`.
+9. Relaunch the app and run the same job again.
+10. Confirm `Logs/yyyy-MM-dd.xml` has been created **alongside** the
+    `.json` file from Phase 1 (no overwrite).
+11. Open `Logs/yyyy-MM-dd.xml` and confirm:
+    - Root element `<Logs>` with one `<Entry>` per logged operation.
+    - The encryption-eligible file's entry carries `<EncryptionTimeMs>`
+      with a positive integer.
+    - The plain file's entry has **no** `<EncryptionTimeMs>` element.
+12. Validate the file against the embedded schema (optional, command-line
+    via xmllint or the .NET test suite already does this):
+    ```bash
+    xmllint --noout --schema docs/schemas/easysave-log.xsd "Logs/yyyy-MM-dd.xml"
+    ```
+    Expected output: `Logs/yyyy-MM-dd.xml validates`.
+
+### Expected result
+
+- Two daily files coexist in the log directory: one `.json`, one `.xml`.
+- Both contain `EncryptionTimeMs > 0` for the encrypted file's entry.
+- Both omit the field for the plain file's entry.
+- The XML file passes XSD validation.
+
+## Known scope
+
+- Switching `log_format` requires restarting the app. The `IDailyLogger`
+  is a singleton snapshotted at startup; live-reload would require
+  exposing the logger behind a getter. Documented for the team — not
+  in scope for v2.0.
+- `appsettings.json` ships `log_format: "json"` as the default. The
+  Settings GUI persists the user choice into `settings.json` which
+  takes precedence on next launch.
+
+## Result (filled by tester)
+
+| Field | Value |
+|---|---|
+| Tester | _to fill_ |
+| Date | _to fill_ |
+| App version | _v2.0-staging @ <commit>_ |
+| Operating system | _to fill_ |
+| CryptoSoft path | _to fill_ |
+| JSON Phase outcome | ☐ PASS  ☐ FAIL |
+| XML Phase outcome | ☐ PASS  ☐ FAIL |
+| Coexistence verified | ☐ Yes  ☐ No |
+| XSD validation | ☐ PASS  ☐ FAIL |
+| Notes | _to fill_ |
+
+If any phase fails, attach the relevant daily log file and the
+`settings.json` content to the ClickUp task.

--- a/tests/EasySave.Tests.V2/XmlDailyLoggerTests.cs
+++ b/tests/EasySave.Tests.V2/XmlDailyLoggerTests.cs
@@ -23,6 +23,56 @@ public class XmlDailyLoggerTests : IDisposable
     private string DailyFilePath() => Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.xml");
 
     [Fact]
+    public void Constructor_NullOrEmptyDirectory_Throws()
+    {
+        // Mirrors JsonDailyLogger's contract: a missing log directory must
+        // be rejected loudly at construction, not at the first Append.
+        Assert.Throws<ArgumentException>(() => new XmlDailyLogger(""));
+        Assert.Throws<ArgumentException>(() => new XmlDailyLogger("   "));
+    }
+
+    [Fact]
+    public void Append_NullEntry_Throws()
+    {
+        IDailyLogger logger = new XmlDailyLogger(_tempDir);
+
+        Assert.Throws<ArgumentNullException>(() => logger.Append(null!));
+    }
+
+    [Fact]
+    public void Append_FromMultipleThreads_NoEntryLost()
+    {
+        // XmlDailyLogger uses a write lock for the same reason JsonDailyLogger
+        // does: backup jobs run concurrently and must not corrupt the daily
+        // file or drop entries. Two threads x 25 entries each is enough to
+        // surface a regression on the lock without making the test slow.
+        IDailyLogger logger = new XmlDailyLogger(_tempDir);
+        const int perThread = 25;
+
+        var threads = new[]
+        {
+            new Thread(() => { for (int i = 0; i < perThread; i++) logger.Append(NewEntry($"A-{i}")); }),
+            new Thread(() => { for (int i = 0; i < perThread; i++) logger.Append(NewEntry($"B-{i}")); }),
+        };
+
+        foreach (var t in threads) t.Start();
+        foreach (var t in threads) t.Join();
+
+        var doc = XDocument.Load(DailyFilePath());
+        Assert.Equal(perThread * 2, doc.Root!.Elements("Entry").Count());
+    }
+
+    private static LogEntry NewEntry(string jobName) => new()
+    {
+        Timestamp = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss"),
+        JobName = jobName,
+        SourceFile = "/tmp/src",
+        TargetFile = "/tmp/dst",
+        FileSize = 1,
+        FileTransferTimeMs = 1,
+    };
+
+    [Fact]
     public void Append_CreatesDailyFileWithXmlExtension()
     {
         var logger = new XmlDailyLogger(_tempDir);

--- a/tests/EasySave.Tests.V2/XmlDailyLoggerTests.cs
+++ b/tests/EasySave.Tests.V2/XmlDailyLoggerTests.cs
@@ -1,0 +1,137 @@
+using System.Xml.Linq;
+using System.Xml.Schema;
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+public class XmlDailyLoggerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public XmlDailyLoggerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "easylog-xml-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private string DailyFilePath() => Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.xml");
+
+    [Fact]
+    public void Append_CreatesDailyFileWithXmlExtension()
+    {
+        var logger = new XmlDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry { JobName = "ext-test", FileTransferTimeMs = 1 });
+
+        Assert.True(File.Exists(DailyFilePath()));
+    }
+
+    [Fact]
+    public void Append_OmitsEncryptionTimeMs_WhenNull()
+    {
+        // Mirrors JsonDailyLogger: a non-encrypted entry must produce the v1
+        // element set so consumers using the schema without the v2 field
+        // (or scanning the file by hand) see the same shape they always saw.
+        var logger = new XmlDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry { JobName = "no-encrypt", FileTransferTimeMs = 1 });
+
+        var doc = XDocument.Load(DailyFilePath());
+        var entry = doc.Root!.Element("Entry");
+        Assert.NotNull(entry);
+        Assert.Null(entry!.Element("EncryptionTimeMs"));
+    }
+
+    [Fact]
+    public void Append_IncludesEncryptionTimeMs_WhenSet()
+    {
+        var logger = new XmlDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry { JobName = "encrypt", EncryptionTimeMs = 17 });
+
+        var doc = XDocument.Load(DailyFilePath());
+        var encryption = doc.Root!.Element("Entry")?.Element("EncryptionTimeMs");
+        Assert.NotNull(encryption);
+        Assert.Equal("17", encryption!.Value);
+    }
+
+    [Fact]
+    public void Append_AccumulatesEntriesAcrossMultipleCalls()
+    {
+        // Append-only contract: every Append must extend the daily file,
+        // never replace it. A regression here would silently drop earlier
+        // entries on the same business day.
+        var logger = new XmlDailyLogger(_tempDir);
+
+        logger.Append(new LogEntry { JobName = "first", FileTransferTimeMs = 1 });
+        logger.Append(new LogEntry { JobName = "second", FileTransferTimeMs = 2 });
+        logger.Append(new LogEntry { JobName = "third", FileTransferTimeMs = 3, EncryptionTimeMs = 10 });
+
+        var doc = XDocument.Load(DailyFilePath());
+        var jobNames = doc.Root!.Elements("Entry")
+            .Select(e => e.Element("JobName")?.Value)
+            .ToArray();
+
+        Assert.Equal(new[] { "first", "second", "third" }, jobNames);
+    }
+
+    [Fact]
+    public void Append_ProducesXsdValidDocument()
+    {
+        // Mixed v1-shaped and v2-shaped entries must both pass the schema
+        // shipped in the EasyLog assembly. This locks the contract that
+        // external ProSoft consumers will validate against.
+        var logger = new XmlDailyLogger(_tempDir);
+        logger.Append(new LogEntry { JobName = "plain", FileTransferTimeMs = 1 });
+        logger.Append(new LogEntry { JobName = "encrypted", EncryptionTimeMs = 42 });
+
+        var doc = XDocument.Load(DailyFilePath());
+
+        var schemas = new XmlSchemaSet();
+        schemas.Add(XmlFormatter.LoadSchema());
+        doc.Validate(schemas, (sender, e) =>
+            throw new XmlSchemaValidationException(e.Message));
+    }
+
+    [Fact]
+    public void Append_QuarantinesCorruptedFile_AndStartsFresh()
+    {
+        // A corrupted daily file must be moved aside (not overwritten) so
+        // operators can investigate. The next Append must succeed against
+        // a brand-new daily file.
+        var dailyFile = DailyFilePath();
+        File.WriteAllText(dailyFile, "not valid xml <<");
+
+        var logger = new XmlDailyLogger(_tempDir);
+        logger.Append(new LogEntry { JobName = "after-corruption", FileTransferTimeMs = 1 });
+
+        var doc = XDocument.Load(dailyFile);
+        Assert.Equal("after-corruption", doc.Root!.Element("Entry")?.Element("JobName")?.Value);
+
+        var quarantined = Directory.GetFiles(_tempDir, "*.corrupted-*");
+        Assert.Single(quarantined);
+    }
+
+    [Fact]
+    public void JsonAndXmlDailyFiles_CoexistInTheSameDirectory()
+    {
+        // The recette spec requires that switching format does not erase
+        // the previous run's log. Different extensions guarantee that.
+        var jsonLogger = new JsonDailyLogger(_tempDir);
+        var xmlLogger = new XmlDailyLogger(_tempDir);
+
+        jsonLogger.Append(new LogEntry { JobName = "json-side", FileTransferTimeMs = 1 });
+        xmlLogger.Append(new LogEntry { JobName = "xml-side", FileTransferTimeMs = 2 });
+
+        var jsonFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        var xmlFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.xml");
+        Assert.True(File.Exists(jsonFile));
+        Assert.True(File.Exists(xmlFile));
+    }
+}


### PR DESCRIPTION
## Summary

Closes ClickUp task **869d036gw** — `[Recette V2] Log : EncryptionTimeMs présent + format XML vs JSON switchable` (priority **urgent**).

The task spans two deliverables:

1. **Programmatic regression guard for `XmlDailyLogger`** — none existed before, while `JsonDailyLogger` had its own test suite. This PR adds 7 cases covering the daily-file extension contract, `EncryptionTimeMs` omit/include matching the JSON formatter shape, append-only across multiple calls, XSD validation of mixed v1/v2 entries against the embedded schema, corrupted-file quarantine + recovery, and the JSON/XML coexistence the recette spec requires.
2. **Manual recette deliverable** — `docs/recettes/v2-log-format-switch.md` walks the tester through Phase 1 (JSON) / Phase 2 (XML), including an `xmllint` validation step against `docs/schemas/easysave-log.xsd`. The known-scope note documents that switching `log_format` requires an app restart since `IDailyLogger` is a startup-snapshotted singleton.

## Grille v2 coverage

- Log journalier au format JSON (already covered) and **XML**
- **Temps de cryptage** (`EncryptionTimeMs`) — present when applicable, omitted otherwise (v1 byte-shape compat)
- XSD validation of the produced XML

## Test plan

- [x] 7 new tests in `XmlDailyLoggerTests` — all green
- [x] Full suite green: 154/160 (6 pre-existing skipped, no regressions)
- [x] `dotnet format --verify-no-changes` clean
- [ ] Manual recette to be executed by the tester (CryptoSoft binary required)