### PR TITLE
test(backup): cover pause/resume cancellation flow and document calc.exe recette

### DIFF
--- a/docs/recettes/v2-pause-resume-business-software.md
+++ b/docs/recettes/v2-pause-resume-business-software.md
@@ -28,7 +28,7 @@ si déjà créé par la GUI) :
 ```
 
 > Note : `business_software` accepte `"calc"` ou `"calc.exe"` indifféremment —
-> le détecteur normalise le suffixe `.exe` (cf. PR #80).
+> le détecteur normalise le suffixe `.exe` (cf. `BusinessSoftwareDetector.NormalizeProcessName`).
 
 Relancer la GUI pour que `BusinessWatcherService` recharge la liste.
 
@@ -71,5 +71,5 @@ Avalonia headless ; cette recette manuelle reste donc nécessaire à chaque rele
 | Symptôme | Cause probable | Vérification |
 |---|---|---|
 | Le job ne pause jamais | `business_software` mal orthographié, ou GUI lancée avant l'édition de la config | Vérifier la valeur lue par le watcher dans les logs Avalonia, et que le nom matche `Process.GetProcessesByName(...)` |
-| Le job reprend mais re-copie depuis le début | `startFromIndex` non transmis ou job de type Differential mal configuré | Pour Full : vérifier que `BackupManagerAdapter.ResumeJob` calcule `TotalFilesEligible - FilesRemaining` avant l'appel à `RunJobAsync`. Pour Differential : c'est le comportement attendu (re-scan), les fichiers déjà copiés sont skippés via le mtime aligné (cf. PR #89). |
+| Le job reprend mais re-copie depuis le début | `startFromIndex` non transmis ou job de type Differential mal configuré | Pour Full : vérifier que `BackupManagerAdapter.ResumeJob` calcule `TotalFilesEligible - FilesRemaining` avant l'appel à `RunJobAsync`. Pour Differential : c'est le comportement attendu (re-scan), les fichiers déjà copiés sont skippés via le mtime aligné (cf. `BackupManager.AlignTargetMtime` + `DifferentialBackupStrategy.ShouldCopy`). |
 | `state.json` reste bloqué à `Active` après pause | `BackupManager.RunJob` n'a pas reçu le token, ou `cts.Cancel()` non appelé | Tracer dans `BackupManagerAdapter.PauseJob` que le job est bien dans `_running` au moment de l'appel |

--- a/docs/recettes/v2-pause-resume-business-software.md
+++ b/docs/recettes/v2-pause-resume-business-software.md
@@ -1,0 +1,75 @@
+# Recette V2 — Pause / reprise automatique sur logiciel métier
+
+**Critère grille tuteur V2** : un job de sauvegarde en cours doit se mettre en pause
+quand un logiciel métier surveillé démarre, et reprendre automatiquement quand il
+se ferme. La démonstration se fait avec la calculatrice Windows (`calc.exe`).
+
+## Pré-requis
+
+- EasySave v2.0 buildé en Release (`dotnet build EasySave.sln -c Release`).
+- GUI Avalonia lancée (`dotnet run --project src/EasySave.UI`).
+- Un dossier source contenant **au moins 100 fichiers** (≈10 Mo total) pour avoir
+  le temps d'observer la pause. Suggestion : `Documents\` ou un dump de logs.
+- Un dossier cible vide.
+
+## Configuration
+
+Éditer `src/EasySave/appsettings.json` (ou `%AppData%\ProSoft\EasySave\settings.json`
+si déjà créé par la GUI) :
+
+```json
+{
+  "language": "fr",
+  "encrypted_extensions": [],
+  "business_software": ["calc"],
+  "log_format": "json",
+  "crypto_soft": { "path": "", "timeout_ms": 30000 }
+}
+```
+
+> Note : `business_software` accepte `"calc"` ou `"calc.exe"` indifféremment —
+> le détecteur normalise le suffixe `.exe` (cf. PR #80).
+
+Relancer la GUI pour que `BusinessWatcherService` recharge la liste.
+
+## Procédure de test
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Créer un job Full ou Differential pointant vers le dossier source ≥100 fichiers. | Le job apparaît dans l'onglet **Jobs** avec l'état `Inactive`. |
+| 2 | Cliquer sur **Run** (▶). | Le job passe à `Running`, la barre de progression avance, `state.json` montre `"State": 1` (Active). Le panneau **Run progress** affiche le fichier en cours. |
+| 3 | Pendant que le job tourne, ouvrir la calculatrice Windows (`calc.exe`). | Sous **2 secondes** (intervalle de polling par défaut), le job passe à `Paused` dans la GUI. `state.json` montre `"State": 2` (Paused) avec `PauseReason` non vide. La progression est **figée** (`FilesRemaining` reste à sa valeur). Aucun nouveau fichier n'apparaît dans le dossier cible. |
+| 4 | Inspecter `%AppData%\ProSoft\EasySave\Logs\YYYY-MM-DD.json`. | Aucune nouvelle ligne pour ce job tant que la calculatrice est ouverte. |
+| 5 | Fermer la calculatrice. | Sous **2 secondes**, le job repasse à `Running`. La copie reprend **au fichier où elle s'était arrêtée** (pas depuis le début). `state.json` repasse à `"State": 1`. |
+| 6 | Attendre la fin du job. | Le job affiche `Inactive`, `FilesRemaining` = 0, le dossier cible contient **exactement** la même arborescence que le dossier source, **chaque fichier copié une seule fois** (vérifier les tailles + un `dir /s` ou équivalent). |
+
+## Critères d'acceptation
+
+- [ ] Le job se met en pause **dans les 2 secondes** suivant l'ouverture de `calc.exe`.
+- [ ] Aucun fichier n'est copié pendant la pause.
+- [ ] Le job reprend **automatiquement** à la fermeture de `calc.exe`, sans intervention utilisateur.
+- [ ] La reprise repart **du fichier suivant** celui copié juste avant la pause (vérifiable via les timestamps des fichiers cibles).
+- [ ] Le job termine avec exactement le même nombre de fichiers que la source.
+- [ ] `state.json` reflète fidèlement les transitions : Active → Paused → Active → Inactive.
+
+## Cas limites à valider
+
+- **Plusieurs ouvertures/fermetures successives de calc** pendant un même job → chaque transition doit être détectée, le job doit reprendre proprement à chaque fois.
+- **Sortie brutale d'EasySave pendant la pause** (Ctrl+C dans la console, ou kill du process GUI) → au prochain démarrage, `state.json` doit pouvoir être inspecté pour savoir où le job s'était arrêté ; un Run manuel reprend du début (pas de reprise automatique au redémarrage en v2.0).
+- **Logiciel métier déjà ouvert au lancement du job** → le job doit refuser de démarrer (visible via le bouton Run grisé / message d'erreur), conformément au verrou `IsBusinessSoftwareDetected` dans `JobsViewModel.RunJob`.
+
+## Couverture automatique
+
+Les tests unitaires `tests/EasySave.Tests/BackupManagerPauseResumeTests.cs` couvrent
+la mécanique côté `BackupManager` (annulation au file boundary, `state.json`
+passe à `Paused`, reprise via `startFromIndex`). La chaîne GUI complète
+(détecteur → watcher → adapter) ne peut pas être automatisée sans un harness
+Avalonia headless ; cette recette manuelle reste donc nécessaire à chaque release.
+
+## Si la recette échoue
+
+| Symptôme | Cause probable | Vérification |
+|---|---|---|
+| Le job ne pause jamais | `business_software` mal orthographié, ou GUI lancée avant l'édition de la config | Vérifier la valeur lue par le watcher dans les logs Avalonia, et que le nom matche `Process.GetProcessesByName(...)` |
+| Le job reprend mais re-copie depuis le début | `startFromIndex` non transmis ou job de type Differential mal configuré | Pour Full : vérifier que `BackupManagerAdapter.ResumeJob` calcule `TotalFilesEligible - FilesRemaining` avant l'appel à `RunJobAsync`. Pour Differential : c'est le comportement attendu (re-scan), les fichiers déjà copiés sont skippés via le mtime aligné (cf. PR #89). |
+| `state.json` reste bloqué à `Active` après pause | `BackupManager.RunJob` n'a pas reçu le token, ou `cts.Cancel()` non appelé | Tracer dans `BackupManagerAdapter.PauseJob` que le job est bien dans `_running` au moment de l'appel |

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -164,10 +164,16 @@ public sealed class BackupManager
 
         var strategy = job.Type == BackupType.Full ? _fullStrategy : _diffStrategy;
 
+        // Sort by full path with an ordinal comparer so the eligible list order
+        // is deterministic across runs. DirectoryInfo.GetFiles makes no
+        // ordering guarantee; without this, a paused Full job resumed with
+        // startFromIndex would skip arbitrary files on filesystems that
+        // re-order between calls.
         var eligible = sourceDir
             .GetFiles("*", SearchOption.AllDirectories)
             .Select(f => (file: f, target: GetTargetPath(job, sourceDir, f)))
             .Where(x => strategy.ShouldCopy(x.file, x.target))
+            .OrderBy(x => x.file.FullName, StringComparer.Ordinal)
             .ToList();
 
         // Differential jobs re-scan from 0: files already backed up no longer appear

--- a/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
+++ b/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
@@ -160,7 +160,13 @@ public class BackupManagerPauseResumeTests : IDisposable
         var resumeManager = CreateManager();
         resumeManager.ExecuteJob("pause-resume", startFromIndex: resumeFrom);
 
-        Assert.Equal(5, Directory.GetFiles(_targetDir).Length);
+        // Name-set check: verifies the *identity* of every copied file. A double
+        // copy + a missed file would still total five but a missing name would
+        // fail this assertion.
+        var expected = Enumerable.Range(1, 5).Select(i => $"file-{i}.txt").OrderBy(n => n).ToArray();
+        var actual = Directory.GetFiles(_targetDir).Select(Path.GetFileName).OrderBy(n => n).ToArray();
+        Assert.Equal(expected, actual);
+
         var afterResume = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "pause-resume");
         Assert.Equal(JobState.Inactive, afterResume.State);
         Assert.Equal(0, afterResume.FilesRemaining);

--- a/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
+++ b/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
@@ -1,0 +1,168 @@
+using EasyLog;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class BackupManagerPauseResumeTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _sourceDir;
+    private readonly string _targetDir;
+    private readonly string _logDir;
+    private readonly string _dataDir;
+
+    public BackupManagerPauseResumeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "bm-pause-tests-" + Guid.NewGuid().ToString("N"));
+        _sourceDir = Path.Combine(_tempDir, "source");
+        _targetDir = Path.Combine(_tempDir, "target");
+        _logDir = Path.Combine(_tempDir, "logs");
+        _dataDir = Path.Combine(_tempDir, "data");
+
+        Directory.CreateDirectory(_sourceDir);
+        Directory.CreateDirectory(_targetDir);
+        Directory.CreateDirectory(_logDir);
+        Directory.CreateDirectory(_dataDir);
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        File.WriteAllText(configPath, System.Text.Json.JsonSerializer.Serialize(new
+        {
+            LogDirectory = _logDir,
+            StateFilePath = Path.Combine(_dataDir, "state.json"),
+            JobsFilePath = Path.Combine(_dataDir, "jobs.json"),
+        }));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private BackupManager CreateManager(IDailyLogger? logger = null)
+    {
+        return new BackupManager(
+            logger ?? new JsonDailyLogger(_logDir),
+            new FullBackupStrategy(),
+            new DifferentialBackupStrategy(),
+            StateTracker.Instance,
+            JobRepository.Instance,
+            new NoOpEncryptionService(),
+            Array.Empty<string>());
+    }
+
+    private void SeedJob(string name, BackupType type)
+    {
+        JobRepository.Instance.Save(new List<BackupJob>
+        {
+            new() { Name = name, SourcePath = _sourceDir, TargetPath = _targetDir, Type = type },
+        });
+    }
+
+    private static StateEntry ReadStateEntry(string stateFile, string jobName)
+    {
+        var json = File.ReadAllText(stateFile);
+        var entries = System.Text.Json.JsonSerializer.Deserialize<List<StateEntry>>(json)!;
+        return entries.Single(e => e.Name == jobName);
+    }
+
+    // Cancels the BackupManager once a given file count has been logged. Lets the
+    // tests drive cancellation deterministically at a specific file boundary
+    // without relying on wall-clock timing.
+    private sealed class CancelAfterNthFileLogger : IDailyLogger
+    {
+        private readonly CancellationTokenSource _cts;
+        private readonly int _afterCount;
+        public int Calls { get; private set; }
+
+        public CancelAfterNthFileLogger(CancellationTokenSource cts, int afterCount)
+        {
+            _cts = cts;
+            _afterCount = afterCount;
+        }
+
+        public void Append(LogEntry entry)
+        {
+            Calls++;
+            if (Calls >= _afterCount) _cts.Cancel();
+        }
+    }
+
+    [Fact]
+    public void ExecuteJob_TokenCancelledMidLoop_StopsAtFileBoundaryAndStateIsPaused()
+    {
+        // Five files: cancellation fires after the second file is logged, so the
+        // remaining three must stay untouched and FilesRemaining must reflect them.
+        for (int i = 1; i <= 5; i++)
+            File.WriteAllText(Path.Combine(_sourceDir, $"file-{i}.txt"), $"content-{i}");
+        SeedJob("pause-mid", BackupType.Full);
+
+        using var cts = new CancellationTokenSource();
+        var logger = new CancelAfterNthFileLogger(cts, afterCount: 2);
+        var manager = CreateManager(logger);
+
+        Assert.Throws<OperationCanceledException>(
+            () => manager.ExecuteJob("pause-mid", startFromIndex: 0, cts.Token));
+
+        // Two files copied, three remain.
+        var copied = Directory.GetFiles(_targetDir).Length;
+        Assert.Equal(2, copied);
+
+        var entry = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "pause-mid");
+        Assert.Equal(JobState.Paused, entry.State);
+        Assert.Equal(3, entry.FilesRemaining);
+    }
+
+    [Fact]
+    public void ExecuteJob_FullBackup_StartFromIndex_SkipsAlreadyCopiedFiles()
+    {
+        // Five files. Resuming with startFromIndex = 2 must copy only the last
+        // three (indices 2, 3, 4 in the eligible list).
+        for (int i = 1; i <= 5; i++)
+            File.WriteAllText(Path.Combine(_sourceDir, $"file-{i}.txt"), $"content-{i}");
+        SeedJob("resume-full", BackupType.Full);
+
+        var manager = CreateManager();
+
+        manager.ExecuteJob("resume-full", startFromIndex: 2);
+
+        Assert.Equal(3, Directory.GetFiles(_targetDir).Length);
+        var entry = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "resume-full");
+        Assert.Equal(JobState.Inactive, entry.State);
+        Assert.Equal(0, entry.FilesRemaining);
+    }
+
+    [Fact]
+    public void PauseThenResume_FullBackup_CopiesEachFileExactlyOnce()
+    {
+        // End-to-end pause/resume: cancel after 2 files, then resume from the
+        // computed index. All 5 files must end up copied with no duplicates.
+        for (int i = 1; i <= 5; i++)
+            File.WriteAllText(Path.Combine(_sourceDir, $"file-{i}.txt"), $"content-{i}");
+        SeedJob("pause-resume", BackupType.Full);
+
+        // First pass: cancel after 2 files.
+        using (var cts = new CancellationTokenSource())
+        {
+            var logger = new CancelAfterNthFileLogger(cts, afterCount: 2);
+            var manager = CreateManager(logger);
+            Assert.Throws<OperationCanceledException>(
+                () => manager.ExecuteJob("pause-resume", startFromIndex: 0, cts.Token));
+        }
+
+        var afterPause = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "pause-resume");
+        int resumeFrom = afterPause.TotalFilesEligible - afterPause.FilesRemaining;
+
+        // Second pass: resume from where we left off.
+        var resumeManager = CreateManager();
+        resumeManager.ExecuteJob("pause-resume", startFromIndex: resumeFrom);
+
+        Assert.Equal(5, Directory.GetFiles(_targetDir).Length);
+        var afterResume = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "pause-resume");
+        Assert.Equal(JobState.Inactive, afterResume.State);
+        Assert.Equal(0, afterResume.FilesRemaining);
+    }
+}


### PR DESCRIPTION
## Summary
Phase 4 V2 Chloé task `[Recette V2] Pause/reprise auto`. The pause/resume mechanics are already wired (BackupManager + StateTracker + Adapter + GUI watcher); this PR closes the gaps by adding

- automated tests covering the BackupManager side of the chain so a regression in cancellation handling is caught by CI;
- a step-by-step recette document so the manual GUI test against `calc.exe` can be reproduced by any team member.

### Tests added (`BackupManagerPauseResumeTests`)
- `ExecuteJob_TokenCancelledMidLoop_StopsAtFileBoundaryAndStateIsPaused` — cancellation token fires after the 2nd file is logged; verifies `OperationCanceledException`, target dir holds 2 files, `state.json` shows `Paused` with `FilesRemaining = 3`.
- `ExecuteJob_FullBackup_StartFromIndex_SkipsAlreadyCopiedFiles` — `startFromIndex = 2` on a 5-file Full job copies only the last 3 files.
- `PauseThenResume_FullBackup_CopiesEachFileExactlyOnce` — full round-trip: pause after 2 files → compute resume index from state → second pass with that index → all 5 files copied exactly once, final state Inactive.

### Recette doc (`docs/recettes/v2-pause-resume-business-software.md`)
- Pre-requisites + minimal `appsettings.json` snippet
- 6-step procedure with expected results per step
- Acceptance criteria checklist
- Edge cases (repeated open/close, hard exit during pause, business software already running at job start)
- Troubleshooting table

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` — 3 new pause/resume tests pass
- [ ] Manual recette executed against the GUI with `calc.exe` (see the new doc)