### PR TITLE
fix(ui): runtime FR/EN switch, persisted JobEdit, completed state, visual contrast

### DIFF
--- a/src/EasySave.UI/App.axaml
+++ b/src/EasySave.UI/App.axaml
@@ -3,7 +3,7 @@
              x:Class="EasySave.UI.App"
              xmlns:local="using:EasySave.UI"
              xmlns:converters="using:EasySave.UI.Converters"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
 
     <Application.DataTemplates>
         <local:ViewLocator />
@@ -43,7 +43,9 @@
                                 CornerRadius="{TemplateBinding CornerRadius}"
                                 Padding="{TemplateBinding Padding}">
                             <ContentPresenter Content="{TemplateBinding Content}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              TextElement.Foreground="{TemplateBinding Foreground}"
+                                              TextElement.FontSize="{TemplateBinding FontSize}" />
                         </Border>
                     </ControlTemplate>
                 </Setter>

--- a/src/EasySave.UI/Assets/i18n/en.json
+++ b/src/EasySave.UI/Assets/i18n/en.json
@@ -48,7 +48,6 @@
   "edit.error_required": "Name, source and destination are required.",
   "logs.title": "Logs",
   "logs.empty": "No log files yet.",
-  "logs.coming_soon": "Log viewer — available in phase 4.",
   "logs.refresh": "Refresh",
   "progress.title": "Backup Progress",
   "progress.files_remaining": "Files remaining:",

--- a/src/EasySave.UI/Assets/i18n/en.json
+++ b/src/EasySave.UI/Assets/i18n/en.json
@@ -18,6 +18,7 @@
   "jobs.state.active": "Running",
   "jobs.state.paused": "Paused",
   "jobs.state.idle": "Idle",
+  "jobs.state.done": "Done",
   "settings.title": "Settings",
   "settings.save": "Save",
   "settings.log_format": "Log Format",
@@ -44,9 +45,11 @@
   "edit.browse": "Browse...",
   "edit.type_full": "Full",
   "edit.type_diff": "Differential",
+  "edit.error_required": "Name, source and destination are required.",
   "logs.title": "Logs",
-  "logs.empty": "No logs available.",
+  "logs.empty": "No log files yet.",
   "logs.coming_soon": "Log viewer — available in phase 4.",
+  "logs.refresh": "Refresh",
   "progress.title": "Backup Progress",
   "progress.files_remaining": "Files remaining:",
   "progress.business_pause": "Jobs paused — business software detected:",
@@ -70,5 +73,6 @@
   "schedule.col_enabled": "Enabled",
   "schedule.col_interval": "Interval",
   "schedule.col_next": "Next run",
-  "schedule.minutes": "min"
+  "schedule.minutes": "min",
+  "common.ok": "OK"
 }

--- a/src/EasySave.UI/Assets/i18n/fr.json
+++ b/src/EasySave.UI/Assets/i18n/fr.json
@@ -18,6 +18,7 @@
   "jobs.state.active": "En cours",
   "jobs.state.paused": "En pause",
   "jobs.state.idle": "Prêt",
+  "jobs.state.done": "Fait",
   "settings.title": "Paramètres",
   "settings.save": "Enregistrer",
   "settings.log_format": "Format des logs",
@@ -44,9 +45,11 @@
   "edit.browse": "Parcourir...",
   "edit.type_full": "Complète",
   "edit.type_diff": "Différentielle",
+  "edit.error_required": "Nom, source et destination sont obligatoires.",
   "logs.title": "Journaux",
-  "logs.empty": "Aucun journal disponible.",
+  "logs.empty": "Aucun fichier de journal pour le moment.",
   "logs.coming_soon": "Affichage des journaux — disponible en phase 4.",
+  "logs.refresh": "Actualiser",
   "progress.title": "Progression des sauvegardes",
   "progress.files_remaining": "Fichiers restants :",
   "progress.business_pause": "Jobs en pause — logiciel métier détecté :",
@@ -70,5 +73,6 @@
   "schedule.col_enabled": "Activé",
   "schedule.col_interval": "Intervalle",
   "schedule.col_next": "Prochaine exécution",
-  "schedule.minutes": "min"
+  "schedule.minutes": "min",
+  "common.ok": "OK"
 }

--- a/src/EasySave.UI/Assets/i18n/fr.json
+++ b/src/EasySave.UI/Assets/i18n/fr.json
@@ -48,7 +48,6 @@
   "edit.error_required": "Nom, source et destination sont obligatoires.",
   "logs.title": "Journaux",
   "logs.empty": "Aucun fichier de journal pour le moment.",
-  "logs.coming_soon": "Affichage des journaux — disponible en phase 4.",
   "logs.refresh": "Actualiser",
   "progress.title": "Progression des sauvegardes",
   "progress.files_remaining": "Fichiers restants :",

--- a/src/EasySave.UI/Converters/StateToColorConverter.cs
+++ b/src/EasySave.UI/Converters/StateToColorConverter.cs
@@ -10,9 +10,10 @@ public sealed class StateToColorConverter : IValueConverter
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         (UiJobState?)value switch
         {
-            UiJobState.Running => new SolidColorBrush(Colors.Green),
-            UiJobState.Paused => new SolidColorBrush(Color.Parse("#FF6B35")),
-            _ => new SolidColorBrush(Color.Parse("#6B7280")),
+            UiJobState.Running => new SolidColorBrush(Color.Parse("#3B82F6")),    // blue
+            UiJobState.Paused => new SolidColorBrush(Color.Parse("#FF6B35")),     // orange
+            UiJobState.Completed => new SolidColorBrush(Color.Parse("#22C55E")),  // green
+            _ => new SolidColorBrush(Color.Parse("#6B7280")),                     // gray (idle)
         };
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/EasySave.UI/Markup/TExtension.cs
+++ b/src/EasySave.UI/Markup/TExtension.cs
@@ -1,14 +1,23 @@
-using Avalonia.Data;
 using Avalonia.Markup.Xaml;
-using EasySave.UI.Services;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 
 namespace EasySave.UI.Markup;
 
 /// <summary>
 /// XAML markup extension that provides reactive translated strings.
-/// Binds to <see cref="TranslationSource.Instance"/> so the UI refreshes
-/// automatically when the active locale changes without restarting the app.
+/// Returns a <see cref="DynamicResourceExtension"/> so the UI refreshes
+/// automatically when <see cref="EasySave.UI.Services.LanguageService"/>
+/// updates <c>Application.Current.Resources</c> on locale change.
 /// </summary>
+/// <remarks>
+/// We previously bound through an indexer on a <c>TranslationSource</c>
+/// singleton, but Avalonia's binding engine did not consistently refresh
+/// indexer paths (notably inside button content templated through a
+/// custom <c>ControlTheme</c>) when <see cref="System.ComponentModel.PropertyChangedEventArgs"/>
+/// was raised with the WPF "Item[]" sentinel. <see cref="DynamicResourceExtension"/>
+/// is the documented Avalonia mechanism for runtime resource swap and is
+/// guaranteed to re-evaluate every consumer.
+/// </remarks>
 /// <example>
 /// <code>&lt;TextBlock Text="{markup:T Key=menu.jobs}" /&gt;</code>
 /// </example>
@@ -24,12 +33,6 @@ public sealed class TExtension : MarkupExtension
     /// <inheritdoc/>
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        // Returns a reflection-based Binding so the target property refreshes
-        // whenever TranslationSource raises PropertyChanged("Item[]").
-        return new Binding($"[{Key}]")
-        {
-            Source = TranslationSource.Instance,
-            Mode = BindingMode.OneWay,
-        };
+        return new DynamicResourceExtension(Key).ProvideValue(serviceProvider);
     }
 }

--- a/src/EasySave.UI/Services/BackupManagerAdapter.cs
+++ b/src/EasySave.UI/Services/BackupManagerAdapter.cs
@@ -31,7 +31,17 @@ public sealed class BackupManagerAdapter : IBackupManagerAdapter
     {
         ArgumentNullException.ThrowIfNull(manager);
         _manager = manager;
+
+        // Direct subscription to the in-process state tracker. The 300 ms file
+        // poll below misses fast jobs (a 4-file copy finishes before the first
+        // tick), so the bar stayed at 0 % then jumped to Idle without any
+        // animation. This event fires synchronously on every Update() and gives
+        // the UI a real-time stream regardless of job size.
+        StateTracker.Instance.JobProgressChanged += OnStateTrackerProgress;
     }
+
+    private void OnStateTrackerProgress(object? sender, StateEntry entry)
+        => StateUpdated?.Invoke(this, entry);
 
     public IReadOnlyList<BackupJob> GetJobs() => _manager.ListJobs();
     public void AddJob(BackupJob job) => _manager.AddJob(job);
@@ -162,6 +172,7 @@ public sealed class BackupManagerAdapter : IBackupManagerAdapter
     {
         if (_disposed) return;
         _disposed = true;
+        StateTracker.Instance.JobProgressChanged -= OnStateTrackerProgress;
         StopPolling();
         lock (_lock)
         {

--- a/src/EasySave.UI/Services/LanguageService.cs
+++ b/src/EasySave.UI/Services/LanguageService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Avalonia;
 using Avalonia.Platform;
 
 namespace EasySave.UI.Services;
@@ -43,6 +44,18 @@ public sealed class LanguageService : ILanguageService
             System.Diagnostics.Trace.TraceWarning(
                 $"[LanguageService] Failed to load locale '{locale}': {ex.Message}");
             _translations = new Dictionary<string, string>();
+        }
+
+        // Push the active dictionary into Application resources so every
+        // {DynamicResource key} (built by the markup:T extension) re-resolves
+        // automatically — that's the supported Avalonia path for runtime
+        // resource swap, and unlike PropertyChanged("Item[]") it works for
+        // every binding site including buttons templated through a custom
+        // ControlTheme.
+        if (Application.Current is { } app)
+        {
+            foreach (var (key, value) in _translations)
+                app.Resources[key] = value;
         }
     }
 }

--- a/src/EasySave.UI/Services/TranslationSource.cs
+++ b/src/EasySave.UI/Services/TranslationSource.cs
@@ -27,7 +27,20 @@ public sealed class TranslationSource : INotifyPropertyChanged
 
         _service = service;
         _service.LanguageChanged += (_, _) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+        {
+            // Notify Avalonia's binding engine through every channel its
+            // IndexerNode.Listener.OnPropertyChanged accepts: a null name,
+            // the empty string (string.IsNullOrEmpty short-circuit), and
+            // the WPF-style "Item[]" sentinel. Some indexer bindings
+            // (notably the ones built by sidebar Button > TextBlock with
+            // a custom ControlTheme) only refresh on one of those, so we
+            // emit all three to be safe across Avalonia versions.
+            var handler = PropertyChanged;
+            if (handler is null) return;
+            handler(this, new PropertyChangedEventArgs(null));
+            handler(this, new PropertyChangedEventArgs(string.Empty));
+            handler(this, new PropertyChangedEventArgs("Item[]"));
+        };
     }
 
     /// <summary>Returns the translation for <paramref name="key"/> in the active locale.</summary>

--- a/src/EasySave.UI/ViewModels/BackupJobVM.cs
+++ b/src/EasySave.UI/ViewModels/BackupJobVM.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using EasySave.Models;
 using EasySave.UI.Services;
@@ -33,8 +34,25 @@ public sealed partial class BackupJobVM : ObservableObject
     {
         UiJobState.Running => TranslationSource.Instance["jobs.state.active"],
         UiJobState.Paused => TranslationSource.Instance["jobs.state.paused"],
+        UiJobState.Completed => TranslationSource.Instance["jobs.state.done"],
         _ => TranslationSource.Instance["jobs.state.idle"],
     };
 
-    public BackupJobVM(BackupJob model) => Model = model;
+    public BackupJobVM(BackupJob model)
+    {
+        Model = model;
+
+        // Localized computed properties cache the active locale at first read.
+        // When TranslationSource flips, re-raise PropertyChanged so the bindings
+        // pick up the new translation. Without this, the job-card "Full" /
+        // "Differential" label and the Idle/Running/Paused chip stay in the
+        // language they were first rendered in.
+        TranslationSource.Instance.PropertyChanged += OnLocaleChanged;
+    }
+
+    private void OnLocaleChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(BackupTypeName));
+        OnPropertyChanged(nameof(StateDisplayName));
+    }
 }

--- a/src/EasySave.UI/ViewModels/BackupJobVM.cs
+++ b/src/EasySave.UI/ViewModels/BackupJobVM.cs
@@ -5,7 +5,7 @@ using EasySave.UI.Services;
 
 namespace EasySave.UI.ViewModels;
 
-public sealed partial class BackupJobVM : ObservableObject
+public sealed partial class BackupJobVM : ObservableObject, IDisposable
 {
     public BackupJob Model { get; }
 
@@ -55,4 +55,7 @@ public sealed partial class BackupJobVM : ObservableObject
         OnPropertyChanged(nameof(BackupTypeName));
         OnPropertyChanged(nameof(StateDisplayName));
     }
+
+    public void Dispose()
+        => TranslationSource.Instance.PropertyChanged -= OnLocaleChanged;
 }

--- a/src/EasySave.UI/ViewModels/BackupTypeOption.cs
+++ b/src/EasySave.UI/ViewModels/BackupTypeOption.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using EasySave.Models;
+using EasySave.UI.Services;
+
+namespace EasySave.UI.ViewModels;
+
+/// <summary>
+/// ComboBox item for <see cref="BackupType"/> with a locale-aware display name.
+/// Avalonia's default ComboBox renders enum items via <c>ToString()</c>, which
+/// produces the raw identifier ("Full" / "Differential") regardless of the
+/// active locale. This wrapper exposes a <see cref="DisplayName"/> bound to the
+/// resource dictionary so the dropdown matches the rest of the UI.
+/// </summary>
+public sealed class BackupTypeOption : ObservableObject
+{
+    public BackupType Type { get; }
+
+    public string DisplayName => Type == BackupType.Full
+        ? TranslationSource.Instance["edit.type_full"]
+        : TranslationSource.Instance["edit.type_diff"];
+
+    public BackupTypeOption(BackupType type)
+    {
+        Type = type;
+        TranslationSource.Instance.PropertyChanged += OnLocaleChanged;
+    }
+
+    private void OnLocaleChanged(object? sender, PropertyChangedEventArgs e)
+        => OnPropertyChanged(nameof(DisplayName));
+}

--- a/src/EasySave.UI/ViewModels/BackupTypeOption.cs
+++ b/src/EasySave.UI/ViewModels/BackupTypeOption.cs
@@ -12,7 +12,7 @@ namespace EasySave.UI.ViewModels;
 /// active locale. This wrapper exposes a <see cref="DisplayName"/> bound to the
 /// resource dictionary so the dropdown matches the rest of the UI.
 /// </summary>
-public sealed class BackupTypeOption : ObservableObject
+public sealed class BackupTypeOption : ObservableObject, IDisposable
 {
     public BackupType Type { get; }
 
@@ -28,4 +28,7 @@ public sealed class BackupTypeOption : ObservableObject
 
     private void OnLocaleChanged(object? sender, PropertyChangedEventArgs e)
         => OnPropertyChanged(nameof(DisplayName));
+
+    public void Dispose()
+        => TranslationSource.Instance.PropertyChanged -= OnLocaleChanged;
 }

--- a/src/EasySave.UI/ViewModels/JobEditViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobEditViewModel.cs
@@ -14,7 +14,7 @@ namespace EasySave.UI.ViewModels;
 /// Receives a nullable <see cref="BackupJob"/>: <c>null</c> means creation,
 /// non-null means edit. Calls <paramref name="onDone"/> on Save or Cancel.
 /// </summary>
-public sealed partial class JobEditViewModel : ViewModelBase
+public sealed partial class JobEditViewModel : ViewModelBase, IDisposable
 {
     private readonly Action _onDone;
     private readonly BackupJob? _originalJob;
@@ -84,6 +84,13 @@ public sealed partial class JobEditViewModel : ViewModelBase
 
     private void OnLocaleChanged(object? sender, PropertyChangedEventArgs e)
         => OnPropertyChanged(nameof(Title));
+
+    public void Dispose()
+    {
+        TranslationSource.Instance.PropertyChanged -= OnLocaleChanged;
+        foreach (var option in BackupTypes)
+            option.Dispose();
+    }
 
     // ── Commands ─────────────────────────────────────────────────────────────
 

--- a/src/EasySave.UI/ViewModels/JobEditViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobEditViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -17,6 +18,11 @@ public sealed partial class JobEditViewModel : ViewModelBase
 {
     private readonly Action _onDone;
     private readonly BackupJob? _originalJob;
+    private readonly IBackupManagerAdapter? _backup;
+    private readonly Action<BackupJob, BackupJob?>? _onSaved;
+
+    [ObservableProperty]
+    private string _errorMessage = string.Empty;
 
     /// <summary>Backup job name.</summary>
     [ObservableProperty]
@@ -34,9 +40,14 @@ public sealed partial class JobEditViewModel : ViewModelBase
     [ObservableProperty]
     private BackupType _backupType = BackupType.Full;
 
-    /// <summary>Available backup types for the ComboBox.</summary>
-    public IReadOnlyList<BackupType> BackupTypes { get; } =
-        Enum.GetValues<BackupType>().ToArray();
+    /// <summary>
+    /// Localized options shown in the BackupType ComboBox. Selecting an option
+    /// writes its <see cref="BackupTypeOption.Type"/> back into <see cref="BackupType"/>
+    /// via <c>SelectedValueBinding</c>, and each option re-raises PropertyChanged
+    /// on its DisplayName when the active locale flips.
+    /// </summary>
+    public IReadOnlyList<BackupTypeOption> BackupTypes { get; } =
+        Enum.GetValues<BackupType>().Select(t => new BackupTypeOption(t)).ToArray();
 
     /// <summary>True when editing an existing job; false for creation.</summary>
     public bool IsEditing => _originalJob is not null;
@@ -46,10 +57,16 @@ public sealed partial class JobEditViewModel : ViewModelBase
         ? TranslationSource.Instance["edit.title_edit"]
         : TranslationSource.Instance["edit.title_create"];
 
-    public JobEditViewModel(BackupJob? job, Action onDone)
+    public JobEditViewModel(
+        BackupJob? job,
+        Action onDone,
+        IBackupManagerAdapter? backup = null,
+        Action<BackupJob, BackupJob?>? onSaved = null)
     {
         _onDone = onDone;
         _originalJob = job;
+        _backup = backup;
+        _onSaved = onSaved;
 
         if (job is not null)
         {
@@ -58,7 +75,15 @@ public sealed partial class JobEditViewModel : ViewModelBase
             DestinationPath = job.TargetPath;
             BackupType = job.Type;
         }
+
+        // Refresh the form title when the user toggles FR↔EN while the JobEdit
+        // view is open. The ComboBox items refresh themselves through their own
+        // BackupTypeOption subscription.
+        TranslationSource.Instance.PropertyChanged += OnLocaleChanged;
     }
+
+    private void OnLocaleChanged(object? sender, PropertyChangedEventArgs e)
+        => OnPropertyChanged(nameof(Title));
 
     // ── Commands ─────────────────────────────────────────────────────────────
 
@@ -66,14 +91,50 @@ public sealed partial class JobEditViewModel : ViewModelBase
     [RelayCommand]
     private void Save()
     {
+        ErrorMessage = string.Empty;
+
         if (string.IsNullOrWhiteSpace(Name)
             || string.IsNullOrWhiteSpace(SourcePath)
             || string.IsNullOrWhiteSpace(DestinationPath))
         {
+            ErrorMessage = TranslationSource.Instance["edit.error_required"];
             return;
         }
 
-        // TODO: call BackupManager.AddJob() or UpdateJob() once wired
+        var job = new BackupJob
+        {
+            Name = Name.Trim(),
+            SourcePath = SourcePath.Trim(),
+            TargetPath = DestinationPath.Trim(),
+            Type = BackupType,
+        };
+
+        try
+        {
+            // Persistence happens against the running BackupManager (singleton)
+            // so the next View navigation sees the new job. Edit = remove + add
+            // because BackupManager exposes no UpdateJob; AddJob throws on a
+            // duplicate name, so we always remove the old entry first.
+            if (_backup is not null)
+            {
+                if (_originalJob is not null)
+                    _backup.RemoveJob(_originalJob.Name);
+                _backup.AddJob(job);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            ErrorMessage = ex.Message;
+            // Restore the deleted entry on a duplicate-add failure so the user
+            // doesn't lose the original definition silently.
+            if (_originalJob is not null && _backup is not null)
+            {
+                try { _backup.AddJob(_originalJob); } catch { /* best effort */ }
+            }
+            return;
+        }
+
+        _onSaved?.Invoke(job, _originalJob);
         _onDone();
     }
 

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -56,7 +56,11 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             var existing = Jobs.FirstOrDefault(j =>
                 j.Name.Equals(original.Name, StringComparison.OrdinalIgnoreCase));
-            if (existing is not null) Jobs.Remove(existing);
+            if (existing is not null)
+            {
+                Jobs.Remove(existing);
+                existing.Dispose();
+            }
         }
         Jobs.Add(new BackupJobVM(saved));
     }
@@ -135,6 +139,7 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             _backup.RemoveJob(vm.Model.Name);
             Jobs.Remove(vm);
+            vm.Dispose();
         }
         catch (Exception ex)
         {
@@ -145,7 +150,8 @@ public sealed partial class JobsViewModel : ViewModelBase
     [RelayCommand]
     private async Task RunJobAsync(BackupJobVM vm)
     {
-        if (IsBusinessSoftwareDetected || vm.UiState == UiJobState.Running) return;
+        if (IsBusinessSoftwareDetected
+            || vm.UiState is UiJobState.Running or UiJobState.Paused) return;
         vm.UiState = UiJobState.Running;
         RequestShowProgress?.Invoke();
         try
@@ -163,7 +169,13 @@ public sealed partial class JobsViewModel : ViewModelBase
             // here so we don't overwrite Completed → Idle. Only clean up the
             // transient progress fields that have no meaning between runs.
             if (vm.UiState == UiJobState.Running)
+            {
                 vm.UiState = UiJobState.Idle;
+                // The job exited mid-flight (exception or external cancel) — wipe
+                // the leftover progress so the bar doesn't stay at e.g. 47% with
+                // an Idle badge until the next run starts.
+                vm.Progress = 0;
+            }
             vm.CurrentFile = string.Empty;
             vm.FilesRemaining = 0;
         }
@@ -174,8 +186,11 @@ public sealed partial class JobsViewModel : ViewModelBase
     {
         if (IsBusinessSoftwareDetected) return;
         RequestShowProgress?.Invoke();
+        // Include Completed jobs so a second click after a successful run
+        // re-launches every job; only Running and Paused are skipped to avoid
+        // double-starting an active or user-paused backup.
         var tasks = Jobs
-            .Where(j => j.UiState == UiJobState.Idle)
+            .Where(j => j.UiState is UiJobState.Idle or UiJobState.Completed)
             .Select(RunJobInternal)
             .ToList();
         await Task.WhenAll(tasks).ConfigureAwait(true);
@@ -215,7 +230,13 @@ public sealed partial class JobsViewModel : ViewModelBase
             // here so we don't overwrite Completed → Idle. Only clean up the
             // transient progress fields that have no meaning between runs.
             if (vm.UiState == UiJobState.Running)
+            {
                 vm.UiState = UiJobState.Idle;
+                // The job exited mid-flight (exception or external cancel) — wipe
+                // the leftover progress so the bar doesn't stay at e.g. 47% with
+                // an Idle badge until the next run starts.
+                vm.Progress = 0;
+            }
             vm.CurrentFile = string.Empty;
             vm.FilesRemaining = 0;
         }

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -45,6 +45,22 @@ public sealed partial class JobsViewModel : ViewModelBase
             Jobs.Add(new BackupJobVM(job));
     }
 
+    /// <summary>
+    /// Updates the observable Jobs collection after JobEditViewModel persists
+    /// a new or edited job. Called via callback so the list stays in sync
+    /// without a full reload.
+    /// </summary>
+    public void OnJobSaved(BackupJob saved, BackupJob? original)
+    {
+        if (original is not null)
+        {
+            var existing = Jobs.FirstOrDefault(j =>
+                j.Name.Equals(original.Name, StringComparison.OrdinalIgnoreCase));
+            if (existing is not null) Jobs.Remove(existing);
+        }
+        Jobs.Add(new BackupJobVM(saved));
+    }
+
     // ── State polling callbacks ───────────────────────────────────────────────
 
     private void OnStateUpdated(object? sender, StateEntry entry)
@@ -58,14 +74,18 @@ public sealed partial class JobsViewModel : ViewModelBase
             vm.FilesRemaining = entry.FilesRemaining;
             if (entry.State == JobState.Active)
             {
-                // Only promote Idle → Running; don't touch a user-paused job.
-                if (vm.UiState == UiJobState.Idle) vm.UiState = UiJobState.Running;
+                // Promote Idle/Completed → Running on a new run; don't touch a user-paused job.
+                if (vm.UiState is UiJobState.Idle or UiJobState.Completed)
+                    vm.UiState = UiJobState.Running;
             }
             else
             {
-                // Backend finished (Inactive): always reset to Idle so a job that
-                // ran to completion while "paused" doesn't stay stuck on Paused.
-                vm.UiState = UiJobState.Idle;
+                // Backend finished (Inactive): mark Completed when the job ran to
+                // its end (no remaining files), otherwise fall back to Idle so a
+                // job that exited via pause/cancel doesn't claim success.
+                vm.UiState = entry.FilesRemaining == 0 && entry.TotalFilesEligible > 0
+                    ? UiJobState.Completed
+                    : UiJobState.Idle;
                 _watcherPausedJobs.Remove(vm.Name);
             }
         });
@@ -138,13 +158,14 @@ public sealed partial class JobsViewModel : ViewModelBase
         }
         finally
         {
-            if (vm.UiState != UiJobState.Paused)
-            {
+            // Final state (Completed vs Idle) is set by OnStateUpdated when the
+            // backend writes its last Inactive snapshot. Leave the UiState alone
+            // here so we don't overwrite Completed → Idle. Only clean up the
+            // transient progress fields that have no meaning between runs.
+            if (vm.UiState == UiJobState.Running)
                 vm.UiState = UiJobState.Idle;
-                vm.Progress = 0;
-                vm.CurrentFile = string.Empty;
-                vm.FilesRemaining = 0;
-            }
+            vm.CurrentFile = string.Empty;
+            vm.FilesRemaining = 0;
         }
     }
 
@@ -189,13 +210,14 @@ public sealed partial class JobsViewModel : ViewModelBase
         }
         finally
         {
-            if (vm.UiState != UiJobState.Paused)
-            {
+            // Final state (Completed vs Idle) is set by OnStateUpdated when the
+            // backend writes its last Inactive snapshot. Leave the UiState alone
+            // here so we don't overwrite Completed → Idle. Only clean up the
+            // transient progress fields that have no meaning between runs.
+            if (vm.UiState == UiJobState.Running)
                 vm.UiState = UiJobState.Idle;
-                vm.Progress = 0;
-                vm.CurrentFile = string.Empty;
-                vm.FilesRemaining = 0;
-            }
+            vm.CurrentFile = string.Empty;
+            vm.FilesRemaining = 0;
         }
     }
 }

--- a/src/EasySave.UI/ViewModels/LogFileItem.cs
+++ b/src/EasySave.UI/ViewModels/LogFileItem.cs
@@ -1,0 +1,27 @@
+namespace EasySave.UI.ViewModels;
+
+/// <summary>
+/// Single daily log file entry shown in the LogsView list.
+/// </summary>
+public sealed class LogFileItem
+{
+    public string FullPath { get; }
+    public string DisplayName => Path.GetFileName(FullPath);
+    public string SizeDisplay
+    {
+        get
+        {
+            try
+            {
+                var bytes = new FileInfo(FullPath).Length;
+                return bytes < 1024 ? $"{bytes} B" : $"{bytes / 1024.0:0.#} KB";
+            }
+            catch (IOException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+
+    public LogFileItem(string fullPath) => FullPath = fullPath;
+}

--- a/src/EasySave.UI/ViewModels/LogsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/LogsViewModel.cs
@@ -84,25 +84,3 @@ public sealed partial class LogsViewModel : ViewModelBase
     }
 }
 
-public sealed class LogFileItem
-{
-    public string FullPath { get; }
-    public string DisplayName => Path.GetFileName(FullPath);
-    public string SizeDisplay
-    {
-        get
-        {
-            try
-            {
-                var bytes = new FileInfo(FullPath).Length;
-                return bytes < 1024 ? $"{bytes} B" : $"{bytes / 1024.0:0.#} KB";
-            }
-            catch (IOException)
-            {
-                return string.Empty;
-            }
-        }
-    }
-
-    public LogFileItem(string fullPath) => FullPath = fullPath;
-}

--- a/src/EasySave.UI/ViewModels/LogsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/LogsViewModel.cs
@@ -1,10 +1,108 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using EasySave.Services;
+
 namespace EasySave.UI.ViewModels;
 
 /// <summary>
-/// View model for the logs viewer screen.
-/// Phase-2 stub — log display will be implemented in Phase 3.
+/// View model for the logs viewer screen. Lists daily log files written by
+/// EasyLog (JSON or XML) and shows the raw content of the selected file in
+/// a read-only panel.
 /// </summary>
-public sealed class LogsViewModel : ViewModelBase
+public sealed partial class LogsViewModel : ViewModelBase
 {
-    // TODO: load and expose log entries from IDailyLogger in Phase 3
+    public ObservableCollection<LogFileItem> Files { get; } = new();
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSelection))]
+    [NotifyPropertyChangedFor(nameof(IsEmpty))]
+    private LogFileItem? _selectedFile;
+
+    [ObservableProperty]
+    private string _selectedContent = string.Empty;
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    public bool HasSelection => SelectedFile is not null;
+    public bool IsEmpty => Files.Count == 0;
+
+    public LogsViewModel()
+    {
+        Refresh();
+    }
+
+    [RelayCommand]
+    private void Refresh()
+    {
+        Files.Clear();
+        StatusMessage = string.Empty;
+        SelectedContent = string.Empty;
+        SelectedFile = null;
+
+        var dir = AppConfig.Instance.LogDirectory;
+        if (!Directory.Exists(dir))
+        {
+            StatusMessage = $"({dir})";
+            OnPropertyChanged(nameof(IsEmpty));
+            return;
+        }
+
+        // Show JSON and XML daily files, newest first. The .yyyy-MM-dd prefix
+        // sorts lexicographically so a string sort gives the desired order.
+        var paths = Directory.GetFiles(dir, "*.json")
+            .Concat(Directory.GetFiles(dir, "*.xml"))
+            .OrderByDescending(p => p, StringComparer.Ordinal);
+
+        foreach (var path in paths)
+            Files.Add(new LogFileItem(path));
+
+        if (Files.Count > 0)
+            SelectedFile = Files[0];
+
+        OnPropertyChanged(nameof(IsEmpty));
+    }
+
+    partial void OnSelectedFileChanged(LogFileItem? value)
+    {
+        if (value is null)
+        {
+            SelectedContent = string.Empty;
+            return;
+        }
+
+        try
+        {
+            SelectedContent = File.ReadAllText(value.FullPath);
+        }
+        catch (IOException ex)
+        {
+            SelectedContent = string.Empty;
+            StatusMessage = ex.Message;
+        }
+    }
+}
+
+public sealed class LogFileItem
+{
+    public string FullPath { get; }
+    public string DisplayName => Path.GetFileName(FullPath);
+    public string SizeDisplay
+    {
+        get
+        {
+            try
+            {
+                var bytes = new FileInfo(FullPath).Length;
+                return bytes < 1024 ? $"{bytes} B" : $"{bytes / 1024.0:0.#} KB";
+            }
+            catch (IOException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+
+    public LogFileItem(string fullPath) => FullPath = fullPath;
 }

--- a/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
@@ -67,7 +67,12 @@ public sealed partial class MainWindowViewModel : ViewModelBase
 
     private void ShowJobEdit(BackupJob? job)
     {
-        CurrentView = new JobEditViewModel(job, onDone: NavigateToJobs);
+        var jobsVm = GetOrCreateJobsVm();
+        CurrentView = new JobEditViewModel(
+            job,
+            onDone: NavigateToJobs,
+            backup: _backup,
+            onSaved: jobsVm.OnJobSaved);
     }
 
     private void ShowRunProgress()

--- a/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,25 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     [ObservableProperty]
     private ViewModelBase _currentView = null!;
 
+    /// <summary>
+    /// Replaces <see cref="CurrentView"/> and disposes the previous one when it
+    /// owns native resources (i18n event subscriptions on <c>JobEditViewModel</c>,
+    /// timers on <c>RunProgressViewModel</c>, etc.). The two cached singletons
+    /// (<see cref="_jobsVm"/>, <see cref="_progressVm"/>) are skipped because
+    /// navigation cycles through them repeatedly — disposing them would
+    /// cripple the next navigation.
+    /// </summary>
+    private void SetCurrentView(ViewModelBase next)
+    {
+        if (CurrentView is IDisposable disposable
+            && !ReferenceEquals(CurrentView, _jobsVm)
+            && !ReferenceEquals(CurrentView, _progressVm))
+        {
+            disposable.Dispose();
+        }
+        CurrentView = next;
+    }
+
     public MainWindowViewModel(
         IBackupManagerAdapter backup,
         BusinessWatcherService watcher,
@@ -36,31 +55,31 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void NavigateToJobs()
     {
-        CurrentView = GetOrCreateJobsVm();
+        SetCurrentView(GetOrCreateJobsVm());
     }
 
     [RelayCommand]
     private void NavigateToSettings()
     {
-        CurrentView = new SettingsViewModel();
+        SetCurrentView(new SettingsViewModel());
     }
 
     [RelayCommand]
     private void NavigateToLogs()
     {
-        CurrentView = new LogsViewModel();
+        SetCurrentView(new LogsViewModel());
     }
 
     [RelayCommand]
     private void NavigateToRestore()
     {
-        CurrentView = new RestoreViewModel(_backup, _restoreService);
+        SetCurrentView(new RestoreViewModel(_backup, _restoreService));
     }
 
     [RelayCommand]
     private void NavigateToSchedule()
     {
-        CurrentView = new ScheduleViewModel(_backup, _scheduler);
+        SetCurrentView(new ScheduleViewModel(_backup, _scheduler));
     }
 
     // ── Sub-navigation ────────────────────────────────────────────────────────
@@ -68,11 +87,11 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private void ShowJobEdit(BackupJob? job)
     {
         var jobsVm = GetOrCreateJobsVm();
-        CurrentView = new JobEditViewModel(
+        SetCurrentView(new JobEditViewModel(
             job,
             onDone: NavigateToJobs,
             backup: _backup,
-            onSaved: jobsVm.OnJobSaved);
+            onSaved: jobsVm.OnJobSaved));
     }
 
     private void ShowRunProgress()
@@ -81,9 +100,9 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         if (_progressVm is null)
         {
             _progressVm = new RunProgressViewModel(jobsVm);
-            _progressVm.CloseRequested = () => CurrentView = jobsVm;
+            _progressVm.CloseRequested = () => SetCurrentView(jobsVm);
         }
-        CurrentView = _progressVm;
+        SetCurrentView(_progressVm);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/EasySave.UI/ViewModels/UiJobState.cs
+++ b/src/EasySave.UI/ViewModels/UiJobState.cs
@@ -1,3 +1,3 @@
 namespace EasySave.UI.ViewModels;
 
-public enum UiJobState { Idle, Running, Paused }
+public enum UiJobState { Idle, Running, Paused, Completed }

--- a/src/EasySave.UI/Views/AboutWindow.axaml
+++ b/src/EasySave.UI/Views/AboutWindow.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:markup="using:EasySave.UI.Markup"
         x:Class="EasySave.UI.Views.AboutWindow"
-        Title="About EasySave"
+        Title="{markup:T Key=about.title}"
         Width="420" Height="280"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
@@ -45,7 +45,7 @@
                 Padding="20,8"
                 Margin="0,12,0,0"
                 Click="OnCloseClick">
-            <TextBlock Text="OK" />
+            <TextBlock Text="{markup:T Key=common.ok}" />
         </Button>
 
     </StackPanel>

--- a/src/EasySave.UI/Views/JobEditView.axaml
+++ b/src/EasySave.UI/Views/JobEditView.axaml
@@ -13,6 +13,7 @@
             <TextBlock Text="{Binding Title}"
                        FontSize="22"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,28" />
 
             <!-- Job Name -->
@@ -64,9 +65,23 @@
                        FontWeight="Medium"
                        Margin="0,0,0,6" />
             <ComboBox ItemsSource="{Binding BackupTypes}"
-                      SelectedItem="{Binding BackupType}"
+                      SelectedValue="{Binding BackupType}"
+                      SelectedValueBinding="{Binding Type}"
                       HorizontalAlignment="Stretch"
-                      Margin="0,0,0,32" />
+                      Margin="0,0,0,32">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding DisplayName}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
+            <!-- Error message -->
+            <TextBlock Text="{Binding ErrorMessage}"
+                       Foreground="#EF4444"
+                       FontSize="13"
+                       Margin="0,0,0,12"
+                       IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
 
             <!-- Action buttons -->
             <StackPanel Orientation="Horizontal"
@@ -80,7 +95,7 @@
                         Background="{StaticResource AccentBrush}"
                         Foreground="White"
                         Padding="16,10">
-                    <TextBlock Text="{markup:T Key=edit.save}" />
+                    <TextBlock Text="{markup:T Key=edit.save}" Foreground="White" />
                 </Button>
             </StackPanel>
 

--- a/src/EasySave.UI/Views/JobsView.axaml
+++ b/src/EasySave.UI/Views/JobsView.axaml
@@ -17,13 +17,14 @@
                        Text="{markup:T Key=jobs.title}"
                        FontSize="22"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        VerticalAlignment="Center" />
 
             <Button Grid.Column="1"
                     Command="{Binding RunAllCommand}"
                     Margin="0,0,8,0"
                     Padding="14,8">
-                <TextBlock Text="{markup:T Key=jobs.run_all}" />
+                <TextBlock Text="{markup:T Key=jobs.run_all}" Foreground="#111827" />
             </Button>
 
             <Button Grid.Column="2"
@@ -31,7 +32,7 @@
                     Background="{StaticResource AccentBrush}"
                     Foreground="White"
                     Padding="14,8">
-                <TextBlock Text="{markup:T Key=jobs.add}" />
+                <TextBlock Text="{markup:T Key=jobs.add}" Foreground="White" />
             </Button>
         </Grid>
 
@@ -42,13 +43,10 @@
                 CornerRadius="6"
                 Padding="14,10"
                 Margin="0,0,0,12">
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock Text="⚠" Foreground="White" FontSize="14" VerticalAlignment="Center" />
-                <TextBlock Foreground="White" VerticalAlignment="Center">
-                    <Run Text="{markup:T Key=progress.business_pause}" />
-                    <Run Text="{Binding DetectedSoftwareName}" FontWeight="Bold" />
-                </TextBlock>
-            </StackPanel>
+            <TextBlock Foreground="White" VerticalAlignment="Center">
+                <Run Text="{markup:T Key=progress.business_pause}" />
+                <Run Text="{Binding DetectedSoftwareName}" FontWeight="Bold" />
+            </TextBlock>
         </Border>
 
         <!-- Status message -->
@@ -84,22 +82,31 @@
 
                                     <Grid ColumnDefinitions="*,Auto">
 
-                                        <!-- Job info -->
+                                        <!-- Job info — Grid columns clamp paths so Delete cannot overlap -->
                                         <StackPanel Grid.Column="0" Spacing="3">
                                             <TextBlock Text="{Binding Name}"
                                                        FontSize="15"
-                                                       FontWeight="SemiBold" />
-                                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                                <TextBlock Text="{Binding SourcePath}"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="#111827" />
+                                            <Grid ColumnDefinitions="*,Auto,*">
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{Binding SourcePath}"
                                                            FontSize="12"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           ToolTip.Tip="{Binding SourcePath}"
                                                            Foreground="{StaticResource MutedTextBrush}" />
-                                                <TextBlock Text="→"
+                                                <TextBlock Grid.Column="1"
+                                                           Text="-&gt;"
                                                            FontSize="12"
+                                                           Margin="6,0"
                                                            Foreground="{StaticResource MutedTextBrush}" />
-                                                <TextBlock Text="{Binding TargetPath}"
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding TargetPath}"
                                                            FontSize="12"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           ToolTip.Tip="{Binding TargetPath}"
                                                            Foreground="{StaticResource MutedTextBrush}" />
-                                            </StackPanel>
+                                            </Grid>
                                             <TextBlock Text="{Binding BackupTypeName}"
                                                        FontSize="11"
                                                        Foreground="{StaticResource AccentBrush}" />

--- a/src/EasySave.UI/Views/LogsView.axaml
+++ b/src/EasySave.UI/Views/LogsView.axaml
@@ -3,18 +3,93 @@
              xmlns:vm="using:EasySave.UI.ViewModels"
              xmlns:markup="using:EasySave.UI.Markup"
              x:Class="EasySave.UI.Views.LogsView"
-             x:DataType="vm:LogsViewModel">
+             x:DataType="vm:LogsViewModel"
+             x:CompileBindings="False">
 
-    <StackPanel HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Spacing="12">
-        <TextBlock Text="{markup:T Key=logs.title}"
-                   FontSize="22"
-                   FontWeight="SemiBold"
-                   HorizontalAlignment="Center" />
-        <TextBlock Text="{markup:T Key=logs.coming_soon}"
+    <DockPanel Margin="32,28,32,24">
+
+        <!-- Header -->
+        <Grid DockPanel.Dock="Top"
+              ColumnDefinitions="*,Auto"
+              Margin="0,0,0,20">
+            <TextBlock Grid.Column="0"
+                       Text="{markup:T Key=logs.title}"
+                       FontSize="22"
+                       FontWeight="SemiBold"
+                       Foreground="#111827"
+                       VerticalAlignment="Center" />
+            <Button Grid.Column="1"
+                    Command="{Binding RefreshCommand}"
+                    Padding="14,8">
+                <TextBlock Text="{markup:T Key=logs.refresh}" Foreground="#111827" />
+            </Button>
+        </Grid>
+
+        <!-- Empty state -->
+        <TextBlock DockPanel.Dock="Top"
+                   Text="{markup:T Key=logs.empty}"
                    Foreground="{StaticResource MutedTextBrush}"
-                   HorizontalAlignment="Center" />
-    </StackPanel>
+                   HorizontalAlignment="Center"
+                   Margin="0,40,0,0"
+                   IsVisible="{Binding IsEmpty}" />
 
+        <!-- Status / error line -->
+        <TextBlock DockPanel.Dock="Top"
+                   Text="{Binding StatusMessage}"
+                   FontSize="12"
+                   Foreground="{StaticResource MutedTextBrush}"
+                   Margin="0,0,0,8"
+                   IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+        <!-- File list + content side-by-side -->
+        <Grid ColumnDefinitions="260,16,*"
+              IsVisible="{Binding !IsEmpty}">
+
+            <!-- File list -->
+            <Border Grid.Column="0"
+                    Background="{StaticResource CardBackgroundBrush}"
+                    CornerRadius="8"
+                    BoxShadow="0 1 4 0 #10000000">
+                <ListBox ItemsSource="{Binding Files}"
+                         SelectedItem="{Binding SelectedFile}"
+                         Background="Transparent"
+                         BorderThickness="0">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="vm:LogFileItem">
+                            <StackPanel Spacing="2" Margin="4,2">
+                                <TextBlock Text="{Binding DisplayName}"
+                                           FontSize="13"
+                                           FontWeight="Medium"
+                                           Foreground="#111827" />
+                                <TextBlock Text="{Binding SizeDisplay}"
+                                           FontSize="11"
+                                           Foreground="{StaticResource MutedTextBrush}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <!-- Content viewer -->
+            <Border Grid.Column="2"
+                    Background="{StaticResource CardBackgroundBrush}"
+                    CornerRadius="8"
+                    Padding="14"
+                    BoxShadow="0 1 4 0 #10000000">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto">
+                    <TextBox Text="{Binding SelectedContent, Mode=OneWay}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="NoWrap"
+                             FontFamily="Cascadia Code, Consolas, monospace"
+                             FontSize="12"
+                             Foreground="#111827"
+                             Background="Transparent"
+                             BorderThickness="0" />
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+    </DockPanel>
 </UserControl>

--- a/src/EasySave.UI/Views/LogsView.axaml
+++ b/src/EasySave.UI/Views/LogsView.axaml
@@ -3,8 +3,7 @@
              xmlns:vm="using:EasySave.UI.ViewModels"
              xmlns:markup="using:EasySave.UI.Markup"
              x:Class="EasySave.UI.Views.LogsView"
-             x:DataType="vm:LogsViewModel"
-             x:CompileBindings="False">
+             x:DataType="vm:LogsViewModel">
 
     <DockPanel Margin="32,28,32,24">
 

--- a/src/EasySave.UI/Views/MainWindow.axaml
+++ b/src/EasySave.UI/Views/MainWindow.axaml
@@ -69,42 +69,27 @@
                             Margin="0,16,0,0">
                     <Button Theme="{StaticResource SidebarButtonTheme}"
                             Command="{Binding NavigateToJobsCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="10">
-                            <TextBlock Text="📁" FontSize="16" />
-                            <TextBlock Text="{markup:T Key=menu.jobs}" />
-                        </StackPanel>
+                        <TextBlock Text="{markup:T Key=menu.jobs}" />
                     </Button>
 
                     <Button Theme="{StaticResource SidebarButtonTheme}"
                             Command="{Binding NavigateToRestoreCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="10">
-                            <TextBlock Text="🔄" FontSize="16" />
-                            <TextBlock Text="{markup:T Key=menu.restore}" />
-                        </StackPanel>
+                        <TextBlock Text="{markup:T Key=menu.restore}" />
                     </Button>
 
                     <Button Theme="{StaticResource SidebarButtonTheme}"
                             Command="{Binding NavigateToScheduleCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="10">
-                            <TextBlock Text="🕐" FontSize="16" />
-                            <TextBlock Text="{markup:T Key=menu.schedule}" />
-                        </StackPanel>
+                        <TextBlock Text="{markup:T Key=menu.schedule}" />
                     </Button>
 
                     <Button Theme="{StaticResource SidebarButtonTheme}"
                             Command="{Binding NavigateToSettingsCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="10">
-                            <TextBlock Text="⚙" FontSize="16" />
-                            <TextBlock Text="{markup:T Key=menu.settings}" />
-                        </StackPanel>
+                        <TextBlock Text="{markup:T Key=menu.settings}" />
                     </Button>
 
                     <Button Theme="{StaticResource SidebarButtonTheme}"
                             Command="{Binding NavigateToLogsCommand}">
-                        <StackPanel Orientation="Horizontal" Spacing="10">
-                            <TextBlock Text="📋" FontSize="16" />
-                            <TextBlock Text="{markup:T Key=menu.logs}" />
-                        </StackPanel>
+                        <TextBlock Text="{markup:T Key=menu.logs}" />
                     </Button>
                 </StackPanel>
 

--- a/src/EasySave.UI/Views/RestoreView.axaml
+++ b/src/EasySave.UI/Views/RestoreView.axaml
@@ -14,12 +14,14 @@
             <TextBlock Text="{markup:T Key=restore.title}"
                        FontSize="22"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,24" />
 
             <!-- ── Select Job ─────────────────────────────────────────────── -->
             <TextBlock Text="{markup:T Key=restore.select_job}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,8" />
 
             <ComboBox ItemsSource="{Binding Jobs}"
@@ -38,6 +40,7 @@
             <TextBlock Text="{markup:T Key=restore.select_point}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,8" />
 
             <Border Background="{StaticResource CardBackgroundBrush}"
@@ -95,6 +98,7 @@
             <TextBlock Text="{markup:T Key=restore.destination}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,8" />
 
             <Border Background="{StaticResource CardBackgroundBrush}"
@@ -144,7 +148,7 @@
                     Padding="20,10"
                     HorizontalAlignment="Right"
                     IsEnabled="{Binding !IsRestoring}">
-                <TextBlock Text="{markup:T Key=restore.restore}" />
+                <TextBlock Text="{markup:T Key=restore.restore}" Foreground="White" />
             </Button>
 
         </StackPanel>

--- a/src/EasySave.UI/Views/RunProgressView.axaml
+++ b/src/EasySave.UI/Views/RunProgressView.axaml
@@ -14,6 +14,7 @@
                    Text="{markup:T Key=progress.title}"
                    FontSize="22"
                    FontWeight="SemiBold"
+                   Foreground="#111827"
                    Margin="0,0,0,20" />
 
         <!-- Business software banner -->
@@ -23,13 +24,10 @@
                 CornerRadius="6"
                 Padding="14,10"
                 Margin="0,0,0,16">
-            <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock Text="⚠" Foreground="White" FontSize="16" VerticalAlignment="Center" />
-                <TextBlock Foreground="White" VerticalAlignment="Center">
-                    <Run Text="{markup:T Key=progress.business_pause}" />
-                    <Run Text="{Binding DetectedSoftwareName}" FontWeight="Bold" />
-                </TextBlock>
-            </StackPanel>
+            <TextBlock Foreground="White" VerticalAlignment="Center">
+                <Run Text="{markup:T Key=progress.business_pause}" />
+                <Run Text="{Binding DetectedSoftwareName}" FontWeight="Bold" />
+            </TextBlock>
         </Border>
 
         <!-- Close button -->
@@ -58,6 +56,7 @@
                                                Text="{Binding Name}"
                                                FontSize="15"
                                                FontWeight="SemiBold"
+                                               Foreground="#111827"
                                                VerticalAlignment="Center" />
                                     <Border Grid.Column="1"
                                             CornerRadius="12"

--- a/src/EasySave.UI/Views/ScheduleView.axaml
+++ b/src/EasySave.UI/Views/ScheduleView.axaml
@@ -13,6 +13,7 @@
                    Text="{markup:T Key=schedule.title}"
                    FontSize="22"
                    FontWeight="SemiBold"
+                   Foreground="#111827"
                    Margin="0,0,0,24" />
 
         <!-- Save button + confirmation at bottom -->
@@ -29,13 +30,13 @@
                     Background="{StaticResource AccentBrush}"
                     Foreground="White"
                     Padding="20,10">
-                <TextBlock Text="{markup:T Key=schedule.save}" />
+                <TextBlock Text="{markup:T Key=schedule.save}" Foreground="White" />
             </Button>
         </StackPanel>
 
         <!-- Column headers -->
         <Grid DockPanel.Dock="Top"
-              ColumnDefinitions="*,Auto,150,180"
+              ColumnDefinitions="*,Auto,170,180"
               Margin="16,0,16,6">
             <TextBlock Grid.Column="0" Text="{markup:T Key=schedule.col_job}"
                        FontSize="12" FontWeight="SemiBold"
@@ -62,13 +63,14 @@
                                 Padding="16,12"
                                 Margin="0,0,0,6"
                                 BoxShadow="0 1 4 0 #10000000">
-                            <Grid ColumnDefinitions="*,Auto,150,180">
+                            <Grid ColumnDefinitions="*,Auto,170,180">
 
                                 <!-- Job name -->
                                 <TextBlock Grid.Column="0"
                                            Text="{Binding JobName}"
                                            FontSize="14"
                                            FontWeight="Medium"
+                                           Foreground="#111827"
                                            VerticalAlignment="Center" />
 
                                 <!-- Enable toggle -->
@@ -85,8 +87,11 @@
                                     <NumericUpDown Value="{Binding IntervalMinutes}"
                                                    Minimum="1"
                                                    Maximum="10080"
-                                                   Width="90"
-                                                   IsEnabled="{Binding IsEnabled}" />
+                                                   Width="120"
+                                                   FormatString="0"
+                                                   ShowButtonSpinner="True"
+                                                   Foreground="#111827"
+                                                   Background="White" />
                                     <TextBlock Text="{markup:T Key=schedule.minutes}"
                                                FontSize="12"
                                                Foreground="{StaticResource MutedTextBrush}"

--- a/src/EasySave.UI/Views/SettingsView.axaml
+++ b/src/EasySave.UI/Views/SettingsView.axaml
@@ -13,12 +13,14 @@
             <TextBlock Text="{markup:T Key=settings.title}"
                        FontSize="22"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,28" />
 
             <!-- ── Section: Encrypted Extensions ───────────────────────────── -->
             <TextBlock Text="{markup:T Key=settings.encrypted_extensions}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,0,0,10" />
 
             <Border Background="{StaticResource CardBackgroundBrush}"
@@ -68,6 +70,7 @@
             <TextBlock Text="{markup:T Key=settings.business_software}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,16,0,10" />
 
             <Border Background="{StaticResource CardBackgroundBrush}"
@@ -117,6 +120,7 @@
             <TextBlock Text="{markup:T Key=settings.log_format}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,16,0,10" />
 
             <Border Background="{StaticResource CardBackgroundBrush}"
@@ -134,6 +138,7 @@
             <TextBlock Text="{markup:T Key=settings.cryptosoft_path}"
                        FontSize="15"
                        FontWeight="SemiBold"
+                       Foreground="#111827"
                        Margin="0,16,0,10" />
 
             <Border Background="{StaticResource CardBackgroundBrush}"
@@ -164,7 +169,7 @@
                         Background="{StaticResource AccentBrush}"
                         Foreground="White"
                         Padding="20,10">
-                    <TextBlock Text="{markup:T Key=settings.save}" />
+                    <TextBlock Text="{markup:T Key=settings.save}" Foreground="White" />
                 </Button>
             </StackPanel>
 


### PR DESCRIPTION
## Summary

End-to-end pass on the Avalonia GUI after manual testing on macOS. Resolves seven user-reported issues + cleanups.

### Fixed

- **Runtime FR↔EN switch** didn't refresh sidebar buttons (and a few other controls templated through a custom `ControlTheme`). The indexer-binding via `TranslationSource` is unreliable in Avalonia 12 for templated content. `TExtension` now returns a `DynamicResourceExtension`; `LanguageService` pushes the active dictionary into `Application.Resources` on every locale change — Avalonia's documented runtime-resource-swap path. `BackupJobVM`, `JobEditViewModel`, and the new `BackupTypeOption` also subscribe to `TranslationSource` so their imperative computed strings (`BackupTypeName`, `Title`, `DisplayName`) re-evaluate on switch.
- **JobEditViewModel.Save() did nothing** (TODO from #82). Save now persists the job through `IBackupManagerAdapter` (Add for create, Remove+Add for edit) and notifies `JobsViewModel` to update the observable collection. Errors (empty fields, duplicate name) surface in the form via a new `edit.error_required` key.
- **Titles invisible on macOS dark mode**. `RequestedThemeVariant=\"Default\"` inherited the OS theme and FluentTheme rendered `TextBlock`s near-white on the hard-coded light grey content brush. Forced to `\"Light\"` and titles + accent-button TextBlocks now set `Foreground` explicitly so the layout cannot regress on any default.
- **Job-card paths overlapped the Delete button** when paths were long. Replaced `StackPanel` with a `Grid` (two `*` columns) and added `TextTrimming=\"CharacterEllipsis\"` (full path on hover via `ToolTip.Tip`).
- **Progress bar didn't move on small jobs**. The 300 ms `state.json` poll missed fast runs entirely. `BackupManagerAdapter` now subscribes directly to `StateTracker.JobProgressChanged` (in-process synchronous event) so the UI gets an update on every file boundary regardless of job size.
- **Job state stayed at \"Idle/Prêt\" after a successful run**. New `UiJobState.Completed` maps to a green \"Done/Fait\" badge, set from `OnStateUpdated` when the backend writes its final `Inactive` snapshot with `FilesRemaining=0` (distinct from an interrupted run).
- **LogsView placeholder** replaced by a real viewer: list of daily log files (`.json`/`.xml`), selected file content shown in a read-only monospaced panel, `Refresh` command.
- **Schedule grid**: `NumericUpDown` widened from 90→120 px so the value isn't hidden behind the spinners; the `IsEnabled={Binding IsEnabled}` coupling was removed so the user can configure the interval before activating the schedule.
- **AboutWindow.Title** now bound to `{markup:T Key=about.title}`; OK button bound to a new `common.ok` key.

### i18n keys added

- `common.ok`, `logs.refresh`, `edit.error_required`, `jobs.state.done` (EN + FR).

### Test plan

- [x] `dotnet build EasySave.sln` — 0 error
- [x] `dotnet test EasySave.sln` — 157/163 (6 pre-existing skipped, 0 regressions)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Manual GUI walk-through on macOS dark mode: titles readable, sidebar FR↔EN flips instantly across every onglet + open About modal, Job creation persists, progress bar animates on a 50-file/100MB job, state ends on \"Fait\" green chip, Logs viewer lists daily files