### PR TITLE
fix(state): propagate IOException in SchedulerService.GetAll to prevent silent overwrite

### DIFF
--- a/src/EasySave.UI/Assets/i18n/en.json
+++ b/src/EasySave.UI/Assets/i18n/en.json
@@ -73,5 +73,6 @@
   "schedule.col_interval": "Interval",
   "schedule.col_next": "Next run",
   "schedule.minutes": "min",
-  "common.ok": "OK"
+  "common.ok": "OK",
+  "error.persistence_unavailable": "Could not read schedule file. Saving is disabled until the file becomes accessible."
 }

--- a/src/EasySave.UI/Assets/i18n/fr.json
+++ b/src/EasySave.UI/Assets/i18n/fr.json
@@ -73,5 +73,6 @@
   "schedule.col_interval": "Intervalle",
   "schedule.col_next": "Prochaine exécution",
   "schedule.minutes": "min",
-  "common.ok": "OK"
+  "common.ok": "OK",
+  "error.persistence_unavailable": "Impossible de lire le fichier de planification. L'enregistrement est désactivé jusqu'à ce que le fichier soit accessible."
 }

--- a/src/EasySave.UI/Services/SchedulerDispatchService.cs
+++ b/src/EasySave.UI/Services/SchedulerDispatchService.cs
@@ -1,3 +1,5 @@
+using EasySave.UI.Models;
+
 namespace EasySave.UI.Services;
 
 /// <summary>
@@ -36,7 +38,18 @@ public sealed class SchedulerDispatchService : IDisposable
     private void Tick(object? _)
     {
         var now = DateTimeOffset.Now;
-        var schedules = _scheduler.GetAll().ToList();
+
+        List<ScheduledJob> schedules;
+        try
+        {
+            schedules = _scheduler.GetAll().ToList();
+        }
+        catch (IOException)
+        {
+            // Transient lock on schedules.json — skip this minute, the next tick will retry.
+            return;
+        }
+
         bool anyDispatched = false;
 
         foreach (var schedule in schedules.Where(s => s.IsEnabled))

--- a/src/EasySave.UI/Services/SchedulerService.cs
+++ b/src/EasySave.UI/Services/SchedulerService.cs
@@ -19,6 +19,11 @@ public sealed class SchedulerService : ISchedulerService
             "schedules.json");
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Transient IOException is propagated to the caller. Swallowing it and returning
+    /// an empty list would let the next SaveAll() write the empty list over the existing
+    /// file and silently wipe every persisted schedule (issue #111, same trap as #69 / #97).
+    /// </remarks>
     public IReadOnlyList<ScheduledJob> GetAll()
     {
         var path = SchedulesFilePath;
@@ -29,8 +34,9 @@ public sealed class SchedulerService : ISchedulerService
             var json = File.ReadAllText(path);
             return JsonSerializer.Deserialize<List<ScheduledJob>>(json) ?? new List<ScheduledJob>();
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (JsonException ex)
         {
+            FileHelpers.QuarantineCorruptedFile(path, ex, "SchedulerService");
             return Array.Empty<ScheduledJob>();
         }
     }

--- a/src/EasySave.UI/ViewModels/ScheduleViewModel.cs
+++ b/src/EasySave.UI/ViewModels/ScheduleViewModel.cs
@@ -15,6 +15,11 @@ public sealed partial class ScheduleViewModel : ViewModelBase
 
     [ObservableProperty] private string _saveConfirmation = string.Empty;
 
+    // Set to true when LoadSchedules() failed because of a transient IOException.
+    // Save() short-circuits while this flag is set so the user cannot wipe schedules.json
+    // by clicking Save on an empty grid that is empty only because the load failed.
+    private bool _persistenceFailed;
+
     public ScheduleViewModel(IBackupManagerAdapter backup, ISchedulerService scheduler)
     {
         _backup = backup;
@@ -31,8 +36,9 @@ public sealed partial class ScheduleViewModel : ViewModelBase
         }
         catch (IOException)
         {
-            // Transient lock on schedules.json: leave the grid empty so a Save click
-            // cannot wipe the file with default rows. Surface the error to the user.
+            // Transient lock on schedules.json: leave the grid empty AND mark persistence
+            // as failed so Save cannot overwrite the file with the empty list.
+            _persistenceFailed = true;
             SaveConfirmation = TranslationSource.Instance["error.persistence_unavailable"];
             return;
         }
@@ -49,6 +55,12 @@ public sealed partial class ScheduleViewModel : ViewModelBase
     [RelayCommand]
     private void Save()
     {
+        if (_persistenceFailed)
+        {
+            SaveConfirmation = TranslationSource.Instance["error.persistence_unavailable"];
+            return;
+        }
+
         _scheduler.SaveAll(ScheduledJobs.Select(vm => vm.ToModel()));
         SaveConfirmation = TranslationSource.Instance["schedule.saved"];
     }

--- a/src/EasySave.UI/ViewModels/ScheduleViewModel.cs
+++ b/src/EasySave.UI/ViewModels/ScheduleViewModel.cs
@@ -24,7 +24,18 @@ public sealed partial class ScheduleViewModel : ViewModelBase
 
     private void LoadSchedules()
     {
-        var saved = _scheduler.GetAll().ToDictionary(s => s.JobName, StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, ScheduledJob> saved;
+        try
+        {
+            saved = _scheduler.GetAll().ToDictionary(s => s.JobName, StringComparer.OrdinalIgnoreCase);
+        }
+        catch (IOException)
+        {
+            // Transient lock on schedules.json: leave the grid empty so a Save click
+            // cannot wipe the file with default rows. Surface the error to the user.
+            SaveConfirmation = TranslationSource.Instance["error.persistence_unavailable"];
+            return;
+        }
 
         foreach (var job in _backup.GetJobs())
         {

--- a/tests/EasySave.Tests.V2/AppConfigMutationCollection.cs
+++ b/tests/EasySave.Tests.V2/AppConfigMutationCollection.cs
@@ -1,0 +1,8 @@
+namespace EasySave.Tests.V2;
+
+// Tests that mutate AppConfig.Instance via AppConfig.Load(...) must run sequentially:
+// xUnit parallelizes test classes within an assembly by default, and AppConfig is a
+// process-wide singleton. Without this gate, SmokeTests.EasySave_AppConfig_HasDefaults
+// can race with SchedulerServiceLockPropagationTests and observe temp-dir paths.
+[CollectionDefinition("AppConfigMutation", DisableParallelization = true)]
+public class AppConfigMutationCollection { }

--- a/tests/EasySave.Tests.V2/EasySave.Tests.V2.csproj
+++ b/tests/EasySave.Tests.V2/EasySave.Tests.V2.csproj
@@ -11,10 +11,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\EasySave\EasySave.csproj" />
+    <ProjectReference Include="..\..\src\EasySave.UI\EasySave.UI.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EasySave.Tests.V2/SchedulerServiceLockPropagationTests.cs
+++ b/tests/EasySave.Tests.V2/SchedulerServiceLockPropagationTests.cs
@@ -13,6 +13,7 @@ namespace EasySave.Tests.V2;
 //
 // Windows-only because Unix file locks are advisory; File.ReadAllText is not blocked
 // by FileShare.None on macOS / Linux.
+[Collection("AppConfigMutation")]
 public class SchedulerServiceLockPropagationTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/EasySave.Tests.V2/SchedulerServiceLockPropagationTests.cs
+++ b/tests/EasySave.Tests.V2/SchedulerServiceLockPropagationTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using EasySave.Services;
+using EasySave.UI.Models;
+using EasySave.UI.Services;
+
+namespace EasySave.Tests.V2;
+
+// Issue #111: SchedulerService.GetAll() used to swallow IOException and return empty,
+// which would let the next SaveAll() write the empty list over schedules.json and
+// silently wipe the user's schedules — same trap as #69 / #97. The fix lets the
+// IOException propagate so the caller (ScheduleViewModel / SchedulerDispatchService)
+// aborts instead of overwriting.
+//
+// Windows-only because Unix file locks are advisory; File.ReadAllText is not blocked
+// by FileShare.None on macOS / Linux.
+public class SchedulerServiceLockPropagationTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _schedulesFilePath;
+
+    public SchedulerServiceLockPropagationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "scheduler-lock-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _schedulesFilePath = Path.Combine(_tempDir, "schedules.json");
+
+        // SchedulerService derives its path from the directory of AppConfig.JobsFilePath,
+        // so we point JobsFilePath at the same temp directory.
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new { JobsFilePath = Path.Combine(_tempDir, "jobs.json") };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public void GetAll_PropagatesIOException_WhenFileLocked()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var existing = new[]
+        {
+            new ScheduledJob { JobName = "Photos", IsEnabled = true, IntervalMinutes = 60 }
+        };
+        File.WriteAllText(_schedulesFilePath, JsonSerializer.Serialize(existing));
+
+        using var lockHolder = new FileStream(_schedulesFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var service = new SchedulerService();
+        Assert.Throws<IOException>(() => service.GetAll());
+    }
+
+    [SkippableFact]
+    public void GetAll_PreservesFile_WhenIOExceptionPropagates()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var existing = new[]
+        {
+            new ScheduledJob { JobName = "Photos", IsEnabled = true, IntervalMinutes = 60 },
+            new ScheduledJob { JobName = "Docs", IsEnabled = false, IntervalMinutes = 30 },
+        };
+        var originalJson = JsonSerializer.Serialize(existing);
+        File.WriteAllText(_schedulesFilePath, originalJson);
+
+        var service = new SchedulerService();
+        using (var lockHolder = new FileStream(_schedulesFilePath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            Assert.Throws<IOException>(() => service.GetAll());
+        }
+
+        Assert.Equal(originalJson, File.ReadAllText(_schedulesFilePath));
+    }
+
+    [Fact]
+    public void GetAll_QuarantinesCorruptedFile_AndReturnsEmpty()
+    {
+        File.WriteAllText(_schedulesFilePath, "{ not valid json");
+
+        var service = new SchedulerService();
+        var result = service.GetAll();
+
+        Assert.Empty(result);
+        Assert.NotEmpty(Directory.GetFiles(_tempDir, "schedules.json.corrupted-*"));
+    }
+}

--- a/tests/EasySave.Tests.V2/SmokeTests.cs
+++ b/tests/EasySave.Tests.V2/SmokeTests.cs
@@ -7,6 +7,7 @@ namespace EasySave.Tests.V2;
 // Smoke tests confirming the V2 test project is wired up against EasyLog and EasySave.
 // Real V2 test classes (V2 logger formatters, encryption time, restore, scheduler...) will
 // land here once the corresponding features are implemented.
+[Collection("AppConfigMutation")]
 public class SmokeTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
Closes #111. Same anti-pattern as #69 / #97, this time on \`SchedulerService.GetAll()\`. A transient \`IOException\` (antivirus, OneDrive, backup agent holding \`schedules.json\`) was downgraded to an empty list, which would let the next \`SaveAll()\` write the empty list over the existing file and silently wipe every persisted schedule.

- \`SchedulerService.GetAll()\`: drop the \`catch (IOException)\` branch, keep \`JsonException\` quarantine (consistent with \`JobRepository.Load\` / \`StateTracker.ReadCurrentEntries\` / \`SettingsRepository.Load\`).
- \`ScheduleViewModel.LoadSchedules()\`: catch the propagated \`IOException\`, surface \`error.persistence_unavailable\`, leave the grid empty so a Save click cannot wipe the file with default rows.
- \`SchedulerDispatchService.Tick\`: catch \`IOException\` and skip the minute — the next tick retries.
- 3 new tests in \`tests/EasySave.Tests.V2/SchedulerServiceLockPropagationTests.cs\` (lock propagation + file preservation as \`SkippableFact\` Win-only, corrupted-file quarantine on all platforms).
- Added \`Xunit.SkippableFact\` + a project reference to \`EasySave.UI\` in \`EasySave.Tests.V2.csproj\` to host the new tests.

## Test plan
- [x] \`dotnet build\` clean
- [x] \`dotnet test\` 164 total / 8 Windows-only skipped on macOS (113 EasySave.Tests + 51 EasySave.Tests.V2)