### PR TITLE
fix(ui): disable Edit/Delete while job is running or paused (closes #117)

### DIFF
--- a/src/EasySave.UI/ViewModels/BackupJobVM.cs
+++ b/src/EasySave.UI/ViewModels/BackupJobVM.cs
@@ -20,6 +20,7 @@ public sealed partial class BackupJobVM : ObservableObject, IDisposable
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsRunning))]
     [NotifyPropertyChangedFor(nameof(IsPaused))]
+    [NotifyPropertyChangedFor(nameof(IsBusy))]
     [NotifyPropertyChangedFor(nameof(StateDisplayName))]
     private UiJobState _uiState = UiJobState.Idle;
 
@@ -29,6 +30,12 @@ public sealed partial class BackupJobVM : ObservableObject, IDisposable
 
     public bool IsRunning => UiState == UiJobState.Running;
     public bool IsPaused => UiState == UiJobState.Paused;
+
+    // Edit / Delete must stay disabled while the worker thread is touching the
+    // job — otherwise BackupManager.RemoveJob wipes the live state entry and
+    // the running task re-creates an orphan, re-introducing the regression
+    // that #68 closed for the v1 console.
+    public bool IsBusy => IsRunning || IsPaused;
 
     public string StateDisplayName => UiState switch
     {

--- a/src/EasySave.UI/Views/JobsView.axaml
+++ b/src/EasySave.UI/Views/JobsView.axaml
@@ -145,7 +145,8 @@
                                             <Button Command="{Binding $parent[ItemsControl].DataContext.EditJobCommand}"
                                                     CommandParameter="{Binding}"
                                                     Padding="10,6"
-                                                    FontSize="12">
+                                                    FontSize="12"
+                                                    IsEnabled="{Binding !IsBusy}">
                                                 <TextBlock Text="{markup:T Key=jobs.edit}" />
                                             </Button>
 
@@ -153,7 +154,8 @@
                                                     CommandParameter="{Binding}"
                                                     Padding="10,6"
                                                     FontSize="12"
-                                                    Foreground="#EF4444">
+                                                    Foreground="#EF4444"
+                                                    IsEnabled="{Binding !IsBusy}">
                                                 <TextBlock Text="{markup:T Key=jobs.delete}" />
                                             </Button>
 


### PR DESCRIPTION
## Summary

Closes #117.

`JobsView.axaml` already gated the **Run** button with `IsEnabled="{Binding !IsRunning}"`, but **Edit** and **Delete** had no state guard. Clicking Delete on a running job re-introduced the exact orphan-state-entry race that #68 closed for the v1 console: `BackupManager.RemoveJob` clears the `state.json` entry, then the worker thread keeps writing `_stateTracker.Update(state)` from its captured local for that name and re-creates an orphan that survives the run.

Edit had the same race plus a rename twist (`RemoveJob` + `AddJob` in `JobEditViewModel.Save`).

## Fix (minimal)

- `BackupJobVM` — new `IsBusy => IsRunning || IsPaused`, with `[NotifyPropertyChangedFor]` on `_uiState`. Paused is included because the worker still owns the cancellation token and a Delete during pause leaks it.
- `JobsView.axaml` — `IsEnabled="{Binding !IsBusy}"` on Edit and Delete buttons.

No ViewModel-level defense-in-depth, no new tests in this PR — both are listed in #117 as optional follow-ups; cost-of-fix here is two attributes and a property.

## Test plan

- [x] `dotnet build EasySave.sln` — 0 erreur
- [x] `dotnet test EasySave.sln` — 163 / 163 (113 v1 + 50 v2)
- [x] `dotnet format --verify-no-changes` — clean
- [ ] Manuel : démarrer un job lent, vérifier Edit + Delete grisés ; pause → toujours grisés ; fin du run → ré-activés. Carte de job conserve son comportement habituel quand idle.