### PR TITLE
fix(scheduler): skip Tick when business software is running (closes #116)

### DIFF
--- a/src/EasySave.UI/Services/BusinessWatcherService.cs
+++ b/src/EasySave.UI/Services/BusinessWatcherService.cs
@@ -32,6 +32,14 @@ public sealed class BusinessWatcherService : IDisposable
 
     public void Stop() => _detector?.Stop();
 
+    /// <summary>
+    /// True when at least one watched business software is currently running.
+    /// Polled by SchedulerDispatchService.Tick to skip dispatch — the
+    /// edge-triggered Detected/Gone events alone are not sufficient because
+    /// they don't fire when a process is already running at watcher startup.
+    /// </summary>
+    public bool IsBusinessSoftwareRunning => _detector?.IsAnyBusinessSoftwareRunning == true;
+
     private void OnDetected(object? sender, string softwareName) =>
         Dispatcher.UIThread.Post(() => BusinessSoftwareDetected?.Invoke(this, softwareName));
 

--- a/src/EasySave.UI/Services/SchedulerDispatchService.cs
+++ b/src/EasySave.UI/Services/SchedulerDispatchService.cs
@@ -11,15 +11,21 @@ public sealed class SchedulerDispatchService : IDisposable
 {
     private readonly ISchedulerService _scheduler;
     private readonly IBackupManagerAdapter _backup;
+    private readonly BusinessWatcherService _watcher;
     private System.Threading.Timer? _timer;
     private bool _disposed;
 
-    public SchedulerDispatchService(ISchedulerService scheduler, IBackupManagerAdapter backup)
+    public SchedulerDispatchService(
+        ISchedulerService scheduler,
+        IBackupManagerAdapter backup,
+        BusinessWatcherService watcher)
     {
         ArgumentNullException.ThrowIfNull(scheduler);
         ArgumentNullException.ThrowIfNull(backup);
+        ArgumentNullException.ThrowIfNull(watcher);
         _scheduler = scheduler;
         _backup = backup;
+        _watcher = watcher;
     }
 
     /// <summary>
@@ -37,6 +43,11 @@ public sealed class SchedulerDispatchService : IDisposable
 
     private void Tick(object? _)
     {
+        // Cahier v2.0: a backup must not run while a watched business software
+        // is open. Skip the whole tick — LastRunTime stays untouched so the
+        // schedule fires on the next clear minute, not after a full interval.
+        if (_watcher.IsBusinessSoftwareRunning) return;
+
         var now = DateTimeOffset.Now;
 
         List<ScheduledJob> schedules;


### PR DESCRIPTION
## Summary

Closes #116. The cahier v2.0 mandates that no backup runs while a watched business software is open. The current gate sits only at the UI command level (`JobsViewModel.RunJobAsync`) and on the watcher's *Detected/Gone* events — both miss `SchedulerDispatchService.Tick` because:

- `Tick` calls `_backup.RunJobAsync` directly, bypassing the UI gate.
- `BusinessSoftwareDetector.ComputeTransitions` is **edge-triggered** — if `calc.exe` was already running before the watcher started, no `Detected` event fires and the reactive pause hook is never invoked.

## Fix (Option A from the issue)

- `BusinessWatcherService` exposes a polling getter `IsBusinessSoftwareRunning => _detector?.IsAnyBusinessSoftwareRunning == true`.
- `SchedulerDispatchService` now takes `BusinessWatcherService` in its constructor and short-circuits `Tick` when the gate is closed. `LastRunTime` stays untouched on skip so the schedule fires on the next clear minute, not after a full interval.
- DI : both services are already singletons (`App.axaml.cs:103,106`), the constructor wiring resolves automatically — no `App` change.

Option B (gate at `BackupManager`) noted in the issue is left for v3 — out of scope here.

## Test plan

- [x] `dotnet build EasySave.sln` — 0 erreur
- [x] `dotnet test EasySave.sln` — 164 / 164 passants
- [x] `dotnet format --verify-no-changes` — clean
- [ ] Manuel : add `calc.exe` to business_software, schedule a job at 1 min, leave Calculator open, restart app, wait > 1 min — schedule should NOT fire. Close Calculator → next tick fires the job.