### PR TITLE
fix(state): propagate IOException in AppConfig.Load to prevent silent config fallback

### DIFF
--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -22,7 +22,16 @@ public partial class App : Application
     public override void OnFrameworkInitializationCompleted()
     {
         // Load appsettings.json before any service reads AppConfig.Instance.
-        AppConfig.Load();
+        try
+        {
+            AppConfig.Load();
+        }
+        catch (IOException ex)
+        {
+            System.Diagnostics.Trace.TraceError(
+                $"[App] appsettings.json read failed ({ex.Message}). Aborting startup.");
+            Environment.Exit(1);
+        }
 
         // Seed settings.json from appsettings.json defaults on first run so the
         // GUI Settings screen reflects the bootstrap configuration. After the

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -9,7 +9,7 @@ try
 catch (IOException ex)
 {
     Console.Error.WriteLine($"[Fatal] Cannot read appsettings.json: {ex.Message}");
-    return;
+    Environment.Exit(1);
 }
 
 var logger = new JsonDailyLogger(AppConfig.Instance.LogDirectory);

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -2,7 +2,15 @@ using EasyLog;
 using EasySave.CLI;
 using EasySave.Services;
 
-AppConfig.Load();
+try
+{
+    AppConfig.Load();
+}
+catch (IOException ex)
+{
+    Console.Error.WriteLine($"[Fatal] Cannot read appsettings.json: {ex.Message}");
+    return;
+}
 
 var logger = new JsonDailyLogger(AppConfig.Instance.LogDirectory);
 IEncryptionService encryption = string.IsNullOrWhiteSpace(AppConfig.Instance.Settings.CryptoSoft.Path)

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -65,9 +65,15 @@ public sealed class AppConfig
             config.Settings = JsonSerializer.Deserialize<AppSettings>(json, DeserializeOptions) ?? new AppSettings();
             Instance = config;
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (JsonException ex)
         {
+            // Corrupted appsettings.json — quarantine and fall back to defaults so the app
+            // still boots. Same convention as JobRepository / StateTracker / SettingsRepository.
+            FileHelpers.QuarantineCorruptedFile(path, ex, "AppConfig");
             Instance = new AppConfig();
         }
+        // IOException intentionally propagated — see #69 / #97 / #112 / #118.
+        // A transient lock at boot must not silently swap operator-configured paths,
+        // encrypted_extensions, or business_software for the empty defaults.
     }
 }

--- a/tests/EasySave.Tests/AppConfigTests.cs
+++ b/tests/EasySave.Tests/AppConfigTests.cs
@@ -56,7 +56,7 @@ public class AppConfigTests : IDisposable
     }
 
     [Fact]
-    public void Load_CorruptedFile_FallsBackToDefaults()
+    public void Load_CorruptedFile_QuarantinesFile_AndFallsBackToDefaults()
     {
         var file = Path.Combine(_tempDir, "corrupt.json");
         File.WriteAllText(file, "{ not valid json");
@@ -64,6 +64,21 @@ public class AppConfigTests : IDisposable
         AppConfig.Load(file);
 
         Assert.Equal("en", AppConfig.Instance.Settings.Language);
+        Assert.NotEmpty(Directory.GetFiles(_tempDir, "corrupt.json.corrupted-*"));
+    }
+
+    [SkippableFact]
+    public void Load_PropagatesIOException_WhenFileLocked()
+    {
+        Skip.IfNot(OperatingSystem.IsWindows(),
+            "Unix file locks are advisory; File.ReadAllText is not blocked by FileShare.None.");
+
+        var file = Path.Combine(_tempDir, "locked.json");
+        File.WriteAllText(file, """{"LogDirectory":"X"}""");
+
+        using var locker = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        Assert.Throws<IOException>(() => AppConfig.Load(file));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #118. Same anti-pattern as #69 / #97 / #112 / #111, this time on `AppConfig.Load()`. A transient `IOException` (antivirus, OneDrive, backup agent holding `appsettings.json` at boot) was downgraded to a silent fallback to defaults, silently swapping operator-configured paths, `encrypted_extensions`, `business_software`, and `CryptoSoft.Path` for empty defaults — no warning, no log line.

- `AppConfig.Load()`: drop `IOException` from the catch, keep `JsonException` quarantine (consistent with `JobRepository.Load` / `StateTracker.ReadCurrentEntries` / `SettingsRepository.Load` / `SchedulerService.GetAll`).
- `Program.cs`: wrap `AppConfig.Load()` in `try/catch IOException` → `Console.Error.WriteLine` + `return` so the console app aborts cleanly with a visible diagnostic.
- `App.axaml.cs`: same wrap → `Trace.TraceError` + `Environment.Exit(1)` so the GUI aborts instead of starting with wrong paths/settings.
- `AppConfigTests.cs`: replace `Load_CorruptedFile_FallsBackToDefaults` with `Load_CorruptedFile_QuarantinesFile_AndFallsBackToDefaults` (asserts the quarantine file is created); add `Load_PropagatesIOException_WhenFileLocked` (`SkippableFact`, Windows-only, mirrors `PersistenceLockPropagationTests`).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` — 113 EasySave.Tests + 53 EasySave.Tests.V2, 0 failures, Windows-only skipped on macOS