### PR TITLE
feat(state): extend AppSettings schema with V3 fields

### DIFF
--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -21,6 +21,18 @@ public sealed class AppSettings
 
     [JsonPropertyName("crypto_soft")]
     public CryptoSoftSettings CryptoSoft { get; init; } = new();
+
+    [JsonPropertyName("large_file_threshold_kb")]
+    public int LargeFileThresholdKb { get; init; } = 4096;
+
+    [JsonPropertyName("remote_console_enabled")]
+    public bool RemoteConsoleEnabled { get; init; } = false;
+
+    [JsonPropertyName("remote_console_port")]
+    public int RemoteConsolePort { get; init; } = 9000;
+
+    [JsonPropertyName("max_parallel_jobs")]
+    public int MaxParallelJobs { get; init; } = 4;
 }
 
 public sealed class CryptoSoftSettings

--- a/src/EasySave/appsettings.json
+++ b/src/EasySave/appsettings.json
@@ -6,5 +6,9 @@
   "crypto_soft": {
     "path": "",
     "timeout_ms": 30000
-  }
+  },
+  "large_file_threshold_kb": 4096,
+  "remote_console_enabled": false,
+  "remote_console_port": 9000,
+  "max_parallel_jobs": 4
 }

--- a/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
+++ b/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
@@ -25,6 +25,42 @@ public class AppSettingsLiveFileTests
         // cannot drift apart silently.
         Assert.Equal(string.Empty, AppConfig.Instance.Settings.CryptoSoft.Path);
         Assert.Equal(30000, AppConfig.Instance.Settings.CryptoSoft.TimeoutMs);
+        Assert.Equal(4096, AppConfig.Instance.Settings.LargeFileThresholdKb);
+        Assert.False(AppConfig.Instance.Settings.RemoteConsoleEnabled);
+        Assert.Equal(9000, AppConfig.Instance.Settings.RemoteConsolePort);
+        Assert.Equal(4, AppConfig.Instance.Settings.MaxParallelJobs);
+    }
+
+    [Fact]
+    public void Load_V2SettingsJson_UsesV3Defaults_WhenKeysAbsent()
+    {
+        // A V2 settings.json has no V3 keys — missing keys must silently fall back
+        // to defaults without throwing or corrupting the instance.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, """
+            {
+                "language": "fr",
+                "encrypted_extensions": [".pdf"],
+                "business_software": [],
+                "log_format": "json",
+                "crypto_soft": { "path": "", "timeout_ms": 30000 }
+            }
+            """);
+
+            AppConfig.Load(tempFile);
+
+            Assert.Equal("fr", AppConfig.Instance.Settings.Language);
+            Assert.Equal(4096, AppConfig.Instance.Settings.LargeFileThresholdKb);
+            Assert.False(AppConfig.Instance.Settings.RemoteConsoleEnabled);
+            Assert.Equal(9000, AppConfig.Instance.Settings.RemoteConsolePort);
+            Assert.Equal(4, AppConfig.Instance.Settings.MaxParallelJobs);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     private static string FindRepoRoot()

--- a/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
+++ b/tests/EasySave.Tests/AppSettingsLiveFileTests.cs
@@ -60,6 +60,8 @@ public class AppSettingsLiveFileTests
         finally
         {
             File.Delete(tempFile);
+            var liveFile = Path.Combine(FindRepoRoot(), "src", "EasySave", "appsettings.json");
+            AppConfig.Load(liveFile);
         }
     }
 


### PR DESCRIPTION
## Summary

Closes ClickUp task 869d5b5wp (P1 Setup V3).

Adds 4 V3 fields to `AppSettings` with backward compat — a V2 `settings.json` that omits any key silently falls back to the documented default:

| Field | JSON key | Default |
|---|---|---|
| `LargeFileThresholdKb` | `large_file_threshold_kb` | `4096` |
| `RemoteConsoleEnabled` | `remote_console_enabled` | `false` |
| `RemoteConsolePort` | `remote_console_port` | `9000` |
| `MaxParallelJobs` | `max_parallel_jobs` | `4` |

- `AppSettings.cs`: 4 new `init`-only properties with `JsonPropertyName` and defaults.
- `appsettings.json`: keys added with default values.
- `AppSettingsLiveFileTests.cs`: assertions on the 4 new fields in the live-file test; new `Load_V2SettingsJson_UsesV3Defaults_WhenKeysAbsent` test validates rétrocompat.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet test` — 114 passed, 0 failures, Windows-only skipped on macOS