### PR TITLE
feat(shared): align v3 protocol DTOs with phase 2 spec

### DIFF
--- a/src/EasySave.Shared/CommandDto.cs
+++ b/src/EasySave.Shared/CommandDto.cs
@@ -1,9 +1,9 @@
 namespace EasySave.Shared;
 
 // Request frame sent by the remote console to the engine over the v3 socket.
-// JobName is required for per-job actions (RunJob, PauseJob, ResumeJob, StopJob)
-// and ignored for ListJobs.
+// Every action in this version of the protocol targets a specific job, so
+// JobName is required.
 public sealed record CommandDto(
-    CommandType Type,
-    string? JobName = null
+    string JobName,
+    CommandType Action
 );

--- a/src/EasySave.Shared/CommandType.cs
+++ b/src/EasySave.Shared/CommandType.cs
@@ -1,13 +1,12 @@
 namespace EasySave.Shared;
 
 // Discriminator for CommandDto: identifies what action the remote console is
-// asking the engine to perform. Explicit numeric values keep the JSON payload
-// stable across versions.
+// asking the engine to perform. Play covers both starting an idle/finished job
+// and resuming a paused one — the engine inspects the current JobState to
+// decide which path to take.
 public enum CommandType
 {
-    ListJobs = 0,
-    RunJob = 1,
-    PauseJob = 2,
-    ResumeJob = 3,
-    StopJob = 4
+    Pause = 0,
+    Play = 1,
+    Stop = 2
 }

--- a/src/EasySave.Shared/EventDto.cs
+++ b/src/EasySave.Shared/EventDto.cs
@@ -1,6 +1,9 @@
 namespace EasySave.Shared;
 
-// Notification frame pushed by the engine to the remote console.
+// Notification frame pushed by the engine to the remote console. Timestamp is
+// the moment the engine emitted the event (server clock); System.Text.Json
+// encodes DateTimeOffset as the round-trip ISO-8601 form.
+//
 // Which payload field is populated depends on Type. To keep a single source of
 // truth for the job identity, JobName is ONLY set on events that don't carry a
 // per-job snapshot; when Progress is set, JobName must be null and consumers
@@ -9,8 +12,10 @@ namespace EasySave.Shared;
 //   JobProgress -> Progress is set, JobName is null
 //   JobStarted / JobPaused / JobResumed / JobFinished -> JobName is set
 //   JobFailed   -> JobName is set, Message carries the failure reason
+//   LogEvent    -> Message carries the log line; JobName is set when scoped
 //   Error       -> Message is set, JobName is set only if scoped to a job
 public sealed record EventDto(
+    DateTimeOffset Timestamp,
     EventType Type,
     string? JobName = null,
     JobProgressDto? Progress = null,

--- a/src/EasySave.Shared/EventType.cs
+++ b/src/EasySave.Shared/EventType.cs
@@ -12,5 +12,6 @@ public enum EventType
     JobResumed = 4,
     JobFinished = 5,
     JobFailed = 6,
-    Error = 7
+    Error = 7,
+    LogEvent = 8
 }

--- a/src/EasySave.Shared/JobProgressDto.cs
+++ b/src/EasySave.Shared/JobProgressDto.cs
@@ -1,17 +1,16 @@
 namespace EasySave.Shared;
 
 // Snapshot of a single job's progress, serialized to JSON and pushed by the
-// engine to the remote console. Mirrors the persisted EasySave.StateEntry so a
-// client can render the full status (file counts, bytes, current file) without
-// touching state.json directly. Sizes are bytes; Percent is 0..100 derived
-// from file counters.
+// engine to the remote console as the Progress payload of a JobProgress event.
+// Field names match the v3 protocol spec verbatim so the JSON wire format is
+// stable across client and server. Byte counters are int64 to support files
+// larger than 2 GiB.
 public sealed record JobProgressDto(
     string JobName,
     JobStateEnum State,
     string CurrentFile,
-    int FilesRemaining,
-    int TotalFilesEligible,
-    long SizeRemaining,
-    long TotalSize,
-    double Percent
+    int FilesLeft,
+    int TotalFiles,
+    long BytesLeft,
+    long BytesTotal
 );

--- a/src/EasySave.Shared/JobStateEnum.cs
+++ b/src/EasySave.Shared/JobStateEnum.cs
@@ -1,11 +1,15 @@
 namespace EasySave.Shared;
 
-// Wire-format mirror of EasySave.JobState for the v3 client/server protocol.
-// Explicit numeric values protect the JSON payload against future reordering and
-// keep parity with the engine's enum so a numeric round-trip is loss-free.
+// Wire-format job state for the v3 client/server protocol. Numeric values
+// are aligned with EasySave.JobState so a numeric round-trip is loss-free:
+//   engine.Inactive (0) -> dto.Done    (the engine has no separate completion
+//                                       state; Inactive covers both never-run
+//                                       and finished jobs)
+//   engine.Active   (1) -> dto.Running
+//   engine.Paused   (2) -> dto.Paused
 public enum JobStateEnum
 {
-    Inactive = 0,
-    Active = 1,
+    Done = 0,
+    Running = 1,
     Paused = 2
 }

--- a/src/EasySave.Shared/README.md
+++ b/src/EasySave.Shared/README.md
@@ -1,0 +1,32 @@
+# EasySave.Shared
+
+Wire-format DTOs shared between the EasySave engine (server) and the
+EasySave.RemoteConsole (client) in v3. This assembly has **no dependency on
+the engine or the UI** — both sides depend on it, but it depends on neither.
+
+## Wire format
+
+The v3 socket protocol is **NDJSON**: one message per line, each line a
+single JSON object terminated by `\n`. This lets the receiver use
+`StreamReader.ReadLineAsync()` for framing instead of carrying its own
+length-prefix or buffering layer, and matches the rest of the codebase's
+choice of `System.Text.Json` (no `Newtonsoft.Json`).
+
+## Types
+
+| Direction | Type | Purpose |
+|---|---|---|
+| client → server | `CommandDto` | Pause / Play / Stop a specific job |
+| server → client | `EventDto` | All notifications: job state changes, progress snapshots, log lines, errors |
+
+`JobProgressDto` is the per-job payload nested inside a `JobProgress` event.
+`JobStateEnum` mirrors `EasySave.JobState` numerically (so a cast on the
+server is loss-free) but with client-friendly labels.
+
+## Adding a new event or command
+
+1. Append a new entry at the **end** of `EventType` / `CommandType` (never
+   reorder — the numeric values are part of the wire format).
+2. If the new event has its own payload shape, add a nullable field on
+   `EventDto` and document which `Type` populates it in the inline comment
+   block.

--- a/src/EasySave.Shared/README.md
+++ b/src/EasySave.Shared/README.md
@@ -23,6 +23,11 @@ choice of `System.Text.Json` (no `Newtonsoft.Json`).
 `JobStateEnum` mirrors `EasySave.JobState` numerically (so a cast on the
 server is loss-free) but with client-friendly labels.
 
+`Done` deliberately conflates "never run yet" and "completed": the engine
+keeps a single `Inactive` state for both. A client that needs to tell them
+apart must track whether a `JobFinished` event has been seen for that job
+during the current session — `JobStateEnum` alone cannot disambiguate.
+
 ## Adding a new event or command
 
 1. Append a new entry at the **end** of `EventType` / `CommandType` (never


### PR DESCRIPTION
## Summary

Phase 2 v3.0 task — alignment of the DTOs in `src/EasySave.Shared` (introduced in PR #122) with the v3 socket protocol spec for the remote console.

The assembly is brand new and has no consumer yet, so the renames and the dropped fields are safe — no wire format is being broken in the wild.

### `JobProgressDto`
- Rename `TotalFilesEligible` → `TotalFiles`, `FilesRemaining` → `FilesLeft`, `TotalSize` → `BytesTotal`, `SizeRemaining` → `BytesLeft` (match the protocol spec verbatim).
- Drop `Percent` — redundant, the client can derive it.

### `JobStateEnum`
- Rename `Inactive` → `Done`, `Active` → `Running`. Numeric values still mirror `EasySave.JobState` (`Done=0, Running=1, Paused=2`) so a server-side cast stays loss-free; only the labels move to client-friendly wording.

### `CommandType` / `CommandDto`
- Reduce to the three control verbs `Pause` / `Play` / `Stop`. `Play` covers both starting an idle job and resuming a paused one — the engine inspects the current `JobState` to pick the right path.
- Drop `ListJobs` (the server pushes the initial `JobList` event on connect; no explicit client request is needed) and the `*Job` suffixes.
- Make `JobName` non-nullable and put it first; every action in this version targets a specific job.
- Rename `CommandDto.Type` → `Action` to match the spec wording.

### `EventDto`
- Add `Timestamp` (`DateTimeOffset`, ISO-8601 round-trip via `System.Text.Json`) so the remote console can render events with the server's clock.

### `EventType`
- Add `LogEvent` for streaming individual log lines to the console.

### `README.md`
- New short doc inside the project that records the NDJSON framing rule (one message per line, `\n`-terminated) and the evolution rule for the enums (always append, never reorder — numeric values are part of the wire format).

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet format EasySave.sln --verify-no-changes` → clean
- [x] No project references the renamed members yet, so nothing else needed in the solution to compile
- [ ] Follow-up PRs (engine TCP server, `EasySave.RemoteConsole` client) will exercise these DTOs end-to-end