### PR TITLE
feat(backup): add IBigFileGate interface for global large-file throttling

### DIFF
--- a/src/EasySave/Services/IBigFileGate.cs
+++ b/src/EasySave/Services/IBigFileGate.cs
@@ -18,8 +18,13 @@ namespace EasySave.Services;
 public interface IBigFileGate
 {
     // Threshold above which (>=) a file is considered "large" and gated.
-    // Loaded from settings by the concrete implementation.
-    int LargeFileThresholdBytes { get; }
+    // Expressed in bytes for direct comparison with fileSizeBytes; the
+    // concrete implementation is responsible for reading AppSettings
+    // .LargeFileThresholdKb and multiplying by 1024 to land here. long
+    // matches the parameter type below and the rest of the codebase
+    // (FileInfo.Length, LogEntry.FileSize) so the comparison never loses
+    // bits on multi-GB thresholds.
+    long LargeFileThresholdBytes { get; }
 
     // Acquires a slot for the file about to be transferred. Returns
     // immediately if fileSizeBytes < LargeFileThresholdBytes (small file —

--- a/src/EasySave/Services/IBigFileGate.cs
+++ b/src/EasySave/Services/IBigFileGate.cs
@@ -1,0 +1,34 @@
+namespace EasySave.Services;
+
+// Global gate that limits concurrent transfers of "large" files to one at a
+// time across the whole engine, regardless of how many jobs are running in
+// parallel. Without it, two parallel jobs each starting a multi-GB copy would
+// saturate the disk or the network and slow each other down. Files smaller
+// than LargeFileThresholdBytes are not gated and copy freely.
+//
+// Usage:
+//
+//     using (await gate.AcquireAsync(fileSize, ct))
+//     {
+//         CopyFile(source, target);
+//     }
+//
+// The IDisposable returned by AcquireAsync releases the slot for the next
+// waiter when Dispose() runs.
+public interface IBigFileGate
+{
+    // Threshold above which (>=) a file is considered "large" and gated.
+    // Loaded from settings by the concrete implementation.
+    int LargeFileThresholdBytes { get; }
+
+    // Acquires a slot for the file about to be transferred. Returns
+    // immediately if fileSizeBytes < LargeFileThresholdBytes (small file —
+    // never gated). Otherwise waits asynchronously until the single large-
+    // file slot is free.
+    //
+    // The returned IDisposable must be kept alive for the duration of the
+    // copy and released (Dispose) once the file has finished transferring.
+    // Cancelling the token while waiting throws OperationCanceledException
+    // and does not consume the slot.
+    Task<IDisposable> AcquireAsync(long fileSizeBytes, CancellationToken ct);
+}


### PR DESCRIPTION
## Summary

Phase 2 v3.0 skeleton task — defines the `IBigFileGate` contract.

In v3 the engine will run multiple backup jobs in parallel. Without coordination, two simultaneous multi-GB file copies would compete for the same disk/network bandwidth and slow each other down. The gate enforces **one large-file transfer at a time** globally (across all jobs); files below the configured threshold are never gated and copy freely.

## API

- `int LargeFileThresholdBytes { get; }` — threshold loaded from settings by the concrete implementation.
- `Task<IDisposable> AcquireAsync(long fileSizeBytes, CancellationToken ct)` — returns immediately for small files; waits asynchronously for the single large-file slot otherwise. The returned `IDisposable` releases the slot in `Dispose()`, so callers wrap each large-file copy in a `using` block. Cancelling the token while waiting throws `OperationCanceledException` and does not consume the slot.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet format EasySave.sln --verify-no-changes` → clean
- [ ] Concrete implementation (semaphore-based) and integration into the parallel orchestrator land in follow-up PRs