### PR TITLE
fix(ui): make RunProgressViewModel disposable for symmetry

### DIFF
--- a/src/EasySave.UI/ViewModels/RunProgressViewModel.cs
+++ b/src/EasySave.UI/ViewModels/RunProgressViewModel.cs
@@ -4,9 +4,10 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace EasySave.UI.ViewModels;
 
-public sealed partial class RunProgressViewModel : ViewModelBase
+public sealed partial class RunProgressViewModel : ViewModelBase, IDisposable
 {
     private readonly JobsViewModel _jobsVm;
+    private bool _disposed;
 
     public ObservableCollection<BackupJobVM> Jobs => _jobsVm.Jobs;
 
@@ -32,4 +33,17 @@ public sealed partial class RunProgressViewModel : ViewModelBase
 
     [RelayCommand]
     private void CloseProgress() => CloseRequested?.Invoke();
+
+    // Defensive cleanup. MainWindowViewModel currently caches this VM as a
+    // navigation singleton and never disposes it (the app lives until process
+    // exit, where the OS reclaims everything), so this is not a runtime leak
+    // today. Implementing IDisposable keeps the contract symmetric with
+    // BackupJobVM / JobEditViewModel and lets a future reset/teardown path
+    // release the JobsViewModel subscription cleanly.
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _jobsVm.PropertyChanged -= OnJobsVmPropertyChanged;
+    }
 }


### PR DESCRIPTION
## Summary

Defensive cleanup. RunProgressViewModel subscribes to `JobsViewModel.PropertyChanged` in its constructor and never unsubscribes. **Not a runtime leak today** — MainWindowViewModel caches this VM as a navigation singleton, so the subscription survives until process exit and the OS reclaims everything.

Adding `IDisposable` keeps the contract symmetric with `BackupJobVM` and `JobEditViewModel` (both already implement `Dispose` for the same reason) and lets a future reset/teardown path release the `JobsViewModel` subscription cleanly without pinning it in the object graph.

## Test plan

- [x] `dotnet build EasySave.sln` — 0 erreur
- [x] `dotnet test EasySave.sln` — 166 / 166 passants
- [x] `dotnet format --verify-no-changes` — clean