### PR TITLE
feat(backup): add JobExecutionContext skeleton for v3 parallel orchestrator

### DIFF
--- a/src/EasySave/EasySave.csproj
+++ b/src/EasySave/EasySave.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EasyLog\EasyLog.csproj" />
+    <ProjectReference Include="..\EasySave.Shared\EasySave.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EasySave/Services/JobExecutionContext.cs
+++ b/src/EasySave/Services/JobExecutionContext.cs
@@ -1,0 +1,49 @@
+using EasyLog;
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+// Per-job state container used by the v3 parallel orchestrator. One instance
+// is created per running job and lives for the duration of that single
+// execution; the orchestrator disposes it once the job ends. Each context
+// owns its own cancellation source, pause gate, progress snapshot and logger
+// reference, so jobs running side by side never share mutable state.
+//
+// Pause/Resume mechanics: PauseGate is constructed in the signaled (open)
+// state. RunJob waits on the gate at every file boundary; resetting the gate
+// stalls the job at the next boundary, setting it again resumes. Stop goes
+// through Cts.Cancel() and unblocks any thread parked on PauseGate.Wait by
+// passing the linked token into Wait.
+public sealed class JobExecutionContext : IDisposable
+{
+    public string JobName { get; }
+    public CancellationTokenSource Cts { get; }
+    public ManualResetEventSlim PauseGate { get; }
+    public IDailyLogger Logger { get; }
+    public JobProgressDto Progress { get; set; }
+
+    public JobExecutionContext(string jobName, IDailyLogger logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        JobName = jobName;
+        Logger = logger;
+        Cts = new CancellationTokenSource();
+        PauseGate = new ManualResetEventSlim(initialState: true);
+        Progress = new JobProgressDto(
+            JobName: jobName,
+            State: JobStateEnum.Done,
+            CurrentFile: string.Empty,
+            FilesLeft: 0,
+            TotalFiles: 0,
+            BytesLeft: 0,
+            BytesTotal: 0);
+    }
+
+    public void Dispose()
+    {
+        Cts.Dispose();
+        PauseGate.Dispose();
+    }
+}

--- a/src/EasySave/Services/JobExecutionContext.cs
+++ b/src/EasySave/Services/JobExecutionContext.cs
@@ -20,7 +20,20 @@ public sealed class JobExecutionContext : IDisposable
     public CancellationTokenSource Cts { get; }
     public ManualResetEventSlim PauseGate { get; }
     public IDailyLogger Logger { get; }
-    public JobProgressDto Progress { get; set; }
+
+    // Backed by a volatile field rather than an auto-property because the job
+    // thread writes Progress while a different thread (orchestrator / UI
+    // reporter) reads it concurrently. Without a memory barrier the reader
+    // can keep a stale reference cached in a register. volatile here is
+    // enough because JobProgressDto is an immutable record: once the
+    // reference is published, the contents are safe to read without further
+    // synchronization.
+    private volatile JobProgressDto _progress = null!;
+    public JobProgressDto Progress
+    {
+        get => _progress;
+        set => _progress = value;
+    }
 
     public JobExecutionContext(string jobName, IDailyLogger logger)
     {


### PR DESCRIPTION
## Summary

Phase 2 v3.0 skeleton task — defines `JobExecutionContext`, the per-job state container that the upcoming v3 parallel orchestrator will spin up for each running backup.

One context per running job means no shared mutable state across parallel executions: each context owns its own cancellation source, pause gate, progress snapshot, and logger reference.

## Fields

- `JobName` — identifies the job for logs and progress events
- `Cts: CancellationTokenSource` — stop signal (`Cts.Cancel()` aborts the job at the next safe boundary)
- `PauseGate: ManualResetEventSlim` — pause/resume mechanism. Signaled (open) on construction; resetting it stalls the job at the next file boundary, setting it again resumes
- `Progress: JobProgressDto` — current progress snapshot, replaced (immutable record) as the job advances
- `Logger: IDailyLogger` — logger reference for that job's traces

`Dispose()` releases both the `CancellationTokenSource` and the `ManualResetEventSlim`.

## Pause / Stop interplay

A typical RunJob loop will look like:

```csharp
ctx.PauseGate.Wait(ctx.Cts.Token);   // blocks while paused, throws on Stop
ctx.Cts.Token.ThrowIfCancellationRequested();
// copy current file
```

Passing `Cts.Token` into `PauseGate.Wait` is what lets a Stop request unblock a thread that is currently parked waiting for a Resume.

## Project wiring

Adds `EasySave.Shared` as a `ProjectReference` to `EasySave.csproj` because `JobExecutionContext` exposes a `JobProgressDto`. The Shared assembly is already on staging (PR #122 + #124).

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet format EasySave.sln --verify-no-changes` → clean
- [ ] Concrete usage lands when `IParallelBackupOrchestrator` is implemented in a follow-up PR