### PR TITLE
feat(remote-console): add Avalonia scaffold for standalone client app

### DIFF
--- a/EasySave.RemoteConsole/App.axaml
+++ b/EasySave.RemoteConsole/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="EasySave.RemoteConsole.App"
+             RequestedThemeVariant="Light">
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+
+</Application>

--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -5,7 +5,7 @@ using EasySave.RemoteConsole.Views;
 
 namespace EasySave.RemoteConsole;
 
-public partial class App : Application
+public sealed partial class App : Application
 {
     public override void Initialize()
     {

--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -1,0 +1,24 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using EasySave.RemoteConsole.Views;
+
+namespace EasySave.RemoteConsole;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
+++ b/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\EasySave.Shared\EasySave.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
+++ b/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
+++ b/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 

--- a/EasySave.RemoteConsole/Program.cs
+++ b/EasySave.RemoteConsole/Program.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+
+namespace EasySave.RemoteConsole;
+
+sealed class Program
+{
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}

--- a/EasySave.RemoteConsole/Views/MainWindow.axaml
+++ b/EasySave.RemoteConsole/Views/MainWindow.axaml
@@ -1,0 +1,13 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="EasySave.RemoteConsole.Views.MainWindow"
+        Title="EasySave Remote Console"
+        Width="900" Height="600"
+        WindowStartupLocation="CenterScreen">
+
+    <TextBlock Text="EasySave Remote Console"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               FontSize="24" />
+
+</Window>

--- a/EasySave.RemoteConsole/Views/MainWindow.axaml.cs
+++ b/EasySave.RemoteConsole/Views/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace EasySave.RemoteConsole.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/EasySave.RemoteConsole/Views/MainWindow.axaml.cs
+++ b/EasySave.RemoteConsole/Views/MainWindow.axaml.cs
@@ -2,7 +2,7 @@ using Avalonia.Controls;
 
 namespace EasySave.RemoteConsole.Views;
 
-public partial class MainWindow : Window
+public sealed partial class MainWindow : Window
 {
     public MainWindow()
     {

--- a/EasySave.sln
+++ b/EasySave.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.UI", "src\EasySave
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Shared", "src\EasySave.Shared\EasySave.Shared.csproj", "{21493C86-F8EA-4708-949E-A9542E55FD1D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.RemoteConsole", "EasySave.RemoteConsole\EasySave.RemoteConsole.csproj", "{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,18 @@ Global
 		{21493C86-F8EA-4708-949E-A9542E55FD1D}.Release|x64.Build.0 = Release|Any CPU
 		{21493C86-F8EA-4708-949E-A9542E55FD1D}.Release|x86.ActiveCfg = Release|Any CPU
 		{21493C86-F8EA-4708-949E-A9542E55FD1D}.Release|x86.Build.0 = Release|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Debug|x64.Build.0 = Debug|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Debug|x86.Build.0 = Debug|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Release|x64.ActiveCfg = Release|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Release|x64.Build.0 = Release|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B8C5E3A-7F12-4D96-B034-E58A1C7F9D25}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- new EasySave.RemoteConsole/ project at solution root (net8.0, WinExe)
- Avalonia.Desktop 12.0.1, Avalonia.Themes.Fluent, CommunityToolkit.Mvvm 8.4.1
- references EasySave.Shared for shared DTOs
- minimal App/MainWindow shell compiling with 0 errors
- wired into EasySave.sln with correct config platforms