### PR TITLE
feat(remote-console): implement TCP server, client and ConsoleView

### DIFF
--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using EasySave.RemoteConsole.Infrastructure;
+using EasySave.RemoteConsole.ViewModels;
 using EasySave.RemoteConsole.Views;
 
 namespace EasySave.RemoteConsole;
@@ -16,7 +18,11 @@ public sealed partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow();
+            var client = new TcpRemoteConsoleClient();
+            var vm = new ConsoleViewModel(client);
+            desktop.MainWindow = new MainWindow { DataContext = vm };
+
+            desktop.Exit += (_, _) => vm.Dispose();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Platform;
 using EasySave.RemoteConsole.Infrastructure;
 using EasySave.RemoteConsole.ViewModels;
 using EasySave.RemoteConsole.Views;
@@ -16,15 +18,42 @@ public sealed partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        LoadLocale("en");
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var client = new TcpRemoteConsoleClient();
             var vm = new ConsoleViewModel(client);
             desktop.MainWindow = new MainWindow { DataContext = vm };
 
-            desktop.Exit += (_, _) => vm.Dispose();
+            desktop.Exit += (_, _) =>
+            {
+                vm.Dispose();
+                client.Dispose();
+            };
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    // Loads translation keys from the embedded asset and pushes them into
+    // Application.Resources so {DynamicResource key} (via {rc:T Key=...}) resolves.
+    private void LoadLocale(string locale)
+    {
+        var uri = new Uri($"avares://EasySave.RemoteConsole/Assets/i18n/{locale}.json");
+        try
+        {
+            using var stream = AssetLoader.Open(uri);
+            using var reader = new StreamReader(stream);
+            var translations = JsonSerializer.Deserialize<Dictionary<string, string>>(reader.ReadToEnd())
+                               ?? new Dictionary<string, string>();
+            foreach (var (key, value) in translations)
+                Resources[key] = value;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                $"[App] Failed to load locale '{locale}': {ex.Message}");
+        }
     }
 }

--- a/EasySave.RemoteConsole/Assets/i18n/en.json
+++ b/EasySave.RemoteConsole/Assets/i18n/en.json
@@ -1,0 +1,8 @@
+{
+  "console.host_placeholder": "Host / IP",
+  "console.connect": "Connect",
+  "console.disconnect": "Disconnect",
+  "console.pause": "Pause",
+  "console.play": "Play",
+  "console.stop": "Stop"
+}

--- a/EasySave.RemoteConsole/Assets/i18n/fr.json
+++ b/EasySave.RemoteConsole/Assets/i18n/fr.json
@@ -1,0 +1,8 @@
+{
+  "console.host_placeholder": "Hôte / IP",
+  "console.connect": "Connexion",
+  "console.disconnect": "Déconnexion",
+  "console.pause": "Pause",
+  "console.play": "Lecture",
+  "console.stop": "Arrêt"
+}

--- a/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
+++ b/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AvaloniaResource Include="Assets\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia" Version="12.0.1" />
     <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />

--- a/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
+++ b/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <RootNamespace>EasySave.RemoteConsole</RootNamespace>
     <AssemblyName>EasySave.RemoteConsole</AssemblyName>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -1,0 +1,193 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using EasySave.RemoteConsole.Abstractions;
+using EasySave.Shared;
+
+namespace EasySave.RemoteConsole.Infrastructure;
+
+public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IDisposable
+{
+    private readonly ConnectionStateSubject _stateSubject = new();
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    private CancellationTokenSource _cts = new();
+    private TcpClient? _tcp;
+    private StreamWriter? _writer;
+    private string _host = string.Empty;
+    private int _port;
+    private int _reconnectAttempt;
+
+    private static readonly int[] BackoffDelaysMs = [1000, 2000, 5000, 10000];
+
+    public event Func<EventDto, Task> EventReceived = _ => Task.CompletedTask;
+    public IObservable<RemoteConnectionState> ConnectionState => _stateSubject;
+
+    public async Task ConnectAsync(string host, int port, CancellationToken ct)
+    {
+        _host = host;
+        _port = port;
+        _reconnectAttempt = 0;
+
+        _cts.Cancel();
+        _cts.Dispose();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        await ConnectInternalAsync(_cts.Token).ConfigureAwait(false);
+    }
+
+    public async Task DisconnectAsync()
+    {
+        _cts.Cancel();
+        try { _tcp?.Close(); } catch { }
+        _stateSubject.Publish(RemoteConnectionState.Disconnected);
+        await Task.CompletedTask;
+    }
+
+    public async Task SendCommandAsync(CommandDto cmd)
+    {
+        await _writeLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_writer is null) return;
+            var json = JsonSerializer.Serialize(cmd);
+            await _writer.WriteLineAsync(json).ConfigureAwait(false);
+            await _writer.FlushAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException) { }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private async Task ConnectInternalAsync(CancellationToken ct)
+    {
+        _stateSubject.Publish(RemoteConnectionState.Connecting);
+
+        var tcp = new TcpClient();
+        await tcp.ConnectAsync(_host, _port, ct).ConfigureAwait(false);
+
+        var stream = tcp.GetStream();
+        var writer = new StreamWriter(stream, leaveOpen: true) { AutoFlush = false };
+
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _tcp?.Close();
+            _tcp = tcp;
+            _writer = writer;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+
+        _stateSubject.Publish(RemoteConnectionState.Connected);
+
+        _ = Task.Run(() => ReadLoopAsync(new StreamReader(stream, leaveOpen: true), ct), ct);
+    }
+
+    private async Task ReadLoopAsync(StreamReader reader, CancellationToken ct)
+    {
+        using (reader)
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+                    if (line is null) break;
+
+                    EventDto? evt;
+                    try { evt = JsonSerializer.Deserialize<EventDto>(line); }
+                    catch (JsonException) { continue; }
+
+                    if (evt is null) continue;
+
+                    foreach (var handler in EventReceived.GetInvocationList().Cast<Func<EventDto, Task>>())
+                    {
+                        try { await handler(evt).ConfigureAwait(false); }
+                        catch { }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException) { }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { return; }
+        }
+
+        if (ct.IsCancellationRequested) return;
+
+        _stateSubject.Publish(RemoteConnectionState.Disconnected);
+        _ = Task.Run(() => ReconnectAsync(ct), ct);
+    }
+
+    private async Task ReconnectAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var delay = BackoffDelaysMs[Math.Min(_reconnectAttempt, BackoffDelaysMs.Length - 1)];
+            _reconnectAttempt++;
+
+            try { await Task.Delay(delay, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+
+            try
+            {
+                await ConnectInternalAsync(ct).ConfigureAwait(false);
+                _reconnectAttempt = 0;
+                return;
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception ex) when (ex is SocketException or IOException or ObjectDisposedException)
+            {
+                _stateSubject.Publish(RemoteConnectionState.Disconnected);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _tcp?.Dispose();
+        _writeLock.Dispose();
+        _cts.Dispose();
+    }
+
+    // Minimal IObservable<T> subject — no System.Reactive dependency.
+    private sealed class ConnectionStateSubject : IObservable<RemoteConnectionState>
+    {
+        private readonly List<IObserver<RemoteConnectionState>> _observers = [];
+        private readonly object _lock = new();
+        private RemoteConnectionState _current = RemoteConnectionState.Disconnected;
+
+        public void Publish(RemoteConnectionState state)
+        {
+            IObserver<RemoteConnectionState>[] snapshot;
+            lock (_lock)
+            {
+                _current = state;
+                snapshot = [.. _observers];
+            }
+            foreach (var o in snapshot)
+                try { o.OnNext(state); } catch { }
+        }
+
+        public IDisposable Subscribe(IObserver<RemoteConnectionState> observer)
+        {
+            lock (_lock)
+            {
+                _observers.Add(observer);
+                observer.OnNext(_current);
+            }
+            return new Subscription(() =>
+            {
+                lock (_lock) { _observers.Remove(observer); }
+            });
+        }
+
+        private sealed class Subscription(Action onDispose) : IDisposable
+        {
+            public void Dispose() => onDispose();
+        }
+    }
+}

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -35,12 +35,12 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IDisposable
         await ConnectInternalAsync(_cts.Token).ConfigureAwait(false);
     }
 
-    public async Task DisconnectAsync()
+    public Task DisconnectAsync()
     {
         _cts.Cancel();
-        try { _tcp?.Close(); } catch { }
+        try { _tcp?.Close(); } catch (Exception) { }
         _stateSubject.Publish(RemoteConnectionState.Disconnected);
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     public async Task SendCommandAsync(CommandDto cmd)
@@ -107,7 +107,7 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IDisposable
                     foreach (var handler in EventReceived.GetInvocationList().Cast<Func<EventDto, Task>>())
                     {
                         try { await handler(evt).ConfigureAwait(false); }
-                        catch { }
+                        catch (Exception) { }
                     }
                 }
             }
@@ -169,16 +169,21 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IDisposable
                 snapshot = [.. _observers];
             }
             foreach (var o in snapshot)
-                try { o.OnNext(state); } catch { }
+                try { o.OnNext(state); } catch (Exception) { }
         }
 
         public IDisposable Subscribe(IObserver<RemoteConnectionState> observer)
         {
+            RemoteConnectionState current;
             lock (_lock)
             {
                 _observers.Add(observer);
-                observer.OnNext(_current);
+                current = _current;
             }
+            // Call outside the lock: observer.OnNext may set Avalonia properties
+            // that trigger re-entrant Subscribe calls, causing a deadlock if called
+            // while _lock is held.
+            observer.OnNext(current);
             return new Subscription(() =>
             {
                 lock (_lock) { _observers.Remove(observer); }

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -32,7 +32,16 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IDisposable
         _cts.Dispose();
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        await ConnectInternalAsync(_cts.Token).ConfigureAwait(false);
+        try
+        {
+            await ConnectInternalAsync(_cts.Token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Publish so the UI exits the Connecting state even on the first attempt.
+            _stateSubject.Publish(RemoteConnectionState.Disconnected);
+            throw;
+        }
     }
 
     public Task DisconnectAsync()

--- a/EasySave.RemoteConsole/Markup/TExtension.cs
+++ b/EasySave.RemoteConsole/Markup/TExtension.cs
@@ -1,0 +1,20 @@
+using Avalonia.Markup.Xaml;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+
+namespace EasySave.RemoteConsole.Markup;
+
+/// <summary>
+/// XAML markup extension that resolves a translation key via Application.Current.Resources.
+/// Uses DynamicResourceExtension so every consumer refreshes on locale change.
+/// </summary>
+/// <example><code>&lt;TextBlock Text="{rc:T Key=console.connect}" /&gt;</code></example>
+public sealed class TExtension : MarkupExtension
+{
+    public string Key { get; set; } = string.Empty;
+
+    public TExtension() { }
+    public TExtension(string key) => Key = key;
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+        => new DynamicResourceExtension(Key).ProvideValue(serviceProvider);
+}

--- a/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
+++ b/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
@@ -1,7 +1,9 @@
 using System.Collections.ObjectModel;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave.RemoteConsole.Abstractions;
+using EasySave.Shared;
 
 namespace EasySave.RemoteConsole.ViewModels;
 
@@ -10,12 +12,15 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
 {
     private readonly IRemoteConsoleClient _client;
     private readonly IDisposable _stateSubscription;
+    private readonly Func<EventDto, Task> _eventHandler;
 
     public ConsoleViewModel(IRemoteConsoleClient client)
     {
         _client = client;
         _stateSubscription = _client.ConnectionState
             .Subscribe(new StateObserver(s => Connection = s));
+        _eventHandler = OnEventReceived;
+        _client.EventReceived += _eventHandler;
     }
 
     /// <summary>Live list of backup jobs reported by the server.</summary>
@@ -32,26 +37,88 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
 
     /// <summary>Initiates a connection to the configured host and port.</summary>
     [RelayCommand]
-    private Task ConnectAsync(CancellationToken ct) => Task.FromException(new NotImplementedException());
+    private async Task ConnectAsync(CancellationToken ct)
+    {
+        try
+        {
+            await _client.ConnectAsync(Host, Port, ct);
+        }
+        catch (Exception)
+        {
+            // Connection state is updated via the observable stream.
+        }
+    }
 
     /// <summary>Closes the current server connection.</summary>
     [RelayCommand]
-    private Task DisconnectAsync() => Task.FromException(new NotImplementedException());
+    private Task DisconnectAsync() => _client.DisconnectAsync();
 
     /// <summary>Sends a Pause command for <paramref name="jobName"/> to the server.</summary>
     [RelayCommand]
-    private Task PauseJobAsync(string jobName) => Task.FromException(new NotImplementedException());
+    private Task PauseJobAsync(string jobName) =>
+        _client.SendCommandAsync(new CommandDto(jobName, CommandType.Pause));
 
     /// <summary>Sends a Play (resume) command for <paramref name="jobName"/> to the server.</summary>
     [RelayCommand]
-    private Task PlayJobAsync(string jobName) => Task.FromException(new NotImplementedException());
+    private Task PlayJobAsync(string jobName) =>
+        _client.SendCommandAsync(new CommandDto(jobName, CommandType.Play));
 
     /// <summary>Sends a Stop command for <paramref name="jobName"/> to the server.</summary>
     [RelayCommand]
-    private Task StopJobAsync(string jobName) => Task.FromException(new NotImplementedException());
+    private Task StopJobAsync(string jobName) =>
+        _client.SendCommandAsync(new CommandDto(jobName, CommandType.Stop));
 
     /// <inheritdoc/>
-    public void Dispose() => _stateSubscription.Dispose();
+    public void Dispose()
+    {
+        _stateSubscription.Dispose();
+        _client.EventReceived -= _eventHandler;
+    }
+
+    private Task OnEventReceived(EventDto evt)
+    {
+        switch (evt.Type)
+        {
+            case EventType.JobList when evt.Jobs is not null:
+                Dispatcher.UIThread.Post(() =>
+                {
+                    Jobs.Clear();
+                    foreach (var j in evt.Jobs)
+                        Jobs.Add(BuildVm(j));
+                });
+                break;
+
+            case EventType.JobProgress when evt.Progress is not null:
+                var progress = evt.Progress;
+                Dispatcher.UIThread.Post(() =>
+                {
+                    var existing = Jobs.FirstOrDefault(j => j.JobName == progress.JobName);
+                    if (existing is not null)
+                    {
+                        existing.ProgressPercent = ComputePercent(progress);
+                        existing.Status = progress.State.ToString();
+                        existing.FilesRemaining = progress.FilesLeft;
+                    }
+                    else
+                    {
+                        Jobs.Add(BuildVm(progress));
+                    }
+                });
+                break;
+        }
+        return Task.CompletedTask;
+    }
+
+    private static JobProgressVm BuildVm(JobProgressDto dto) => new()
+    {
+        JobName = dto.JobName,
+        ProgressPercent = ComputePercent(dto),
+        Status = dto.State.ToString(),
+        FilesRemaining = dto.FilesLeft,
+    };
+
+    private static double ComputePercent(JobProgressDto dto) =>
+        dto.TotalFiles == 0 ? 0.0 : 100.0 * (dto.TotalFiles - dto.FilesLeft) / dto.TotalFiles;
 
     // Bridges IObservable<RemoteConnectionState> (BCL) to an Action without a Rx dependency.
     private sealed class StateObserver(Action<RemoteConnectionState> onNext)

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml
@@ -1,0 +1,92 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:EasySave.RemoteConsole.ViewModels"
+             x:Class="EasySave.RemoteConsole.Views.ConsoleView"
+             x:DataType="vm:ConsoleViewModel"
+             x:CompileBindings="False">
+
+    <DockPanel>
+
+        <!-- Connection bar -->
+        <Border DockPanel.Dock="Top"
+                Background="#F3F4F6"
+                Padding="12,10"
+                BorderBrush="#E5E7EB"
+                BorderThickness="0,0,0,1">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBox Text="{Binding Host}"
+                         Width="180"
+                         PlaceholderText="Host / IP" />
+                <NumericUpDown Value="{Binding Port}"
+                               Minimum="1"
+                               Maximum="65535"
+                               Width="110"
+                               FormatString="0" />
+                <Button Content="Connexion"
+                        Command="{Binding ConnectCommand}"
+                        Padding="12,6" />
+                <Button Content="Déconnexion"
+                        Command="{Binding DisconnectCommand}"
+                        Padding="12,6" />
+                <TextBlock Text="{Binding Connection}"
+                           VerticalAlignment="Center"
+                           FontWeight="SemiBold"
+                           Margin="8,0,0,0" />
+            </StackPanel>
+        </Border>
+
+        <!-- Jobs list -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Jobs}" Margin="12,8">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="vm:JobProgressVm">
+                        <Border Background="White"
+                                CornerRadius="6"
+                                Padding="12,10"
+                                Margin="0,0,0,6"
+                                BoxShadow="0 1 4 0 #18000000">
+                            <Grid ColumnDefinitions="180,*,90,Auto,Auto,Auto"
+                                  RowDefinitions="Auto">
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding JobName}"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis" />
+                                <ProgressBar Grid.Column="1"
+                                             Value="{Binding ProgressPercent}"
+                                             Minimum="0"
+                                             Maximum="100"
+                                             Height="8"
+                                             CornerRadius="4"
+                                             Margin="10,0" />
+                                <TextBlock Grid.Column="2"
+                                           Text="{Binding Status}"
+                                           VerticalAlignment="Center"
+                                           HorizontalAlignment="Center" />
+                                <Button Grid.Column="3"
+                                        Content="Pause"
+                                        Command="{Binding $parent[ItemsControl].DataContext.PauseJobCommand}"
+                                        CommandParameter="{Binding JobName}"
+                                        Padding="10,5"
+                                        Margin="4,0,0,0" />
+                                <Button Grid.Column="4"
+                                        Content="Play"
+                                        Command="{Binding $parent[ItemsControl].DataContext.PlayJobCommand}"
+                                        CommandParameter="{Binding JobName}"
+                                        Padding="10,5"
+                                        Margin="4,0,0,0" />
+                                <Button Grid.Column="5"
+                                        Content="Stop"
+                                        Command="{Binding $parent[ItemsControl].DataContext.StopJobCommand}"
+                                        CommandParameter="{Binding JobName}"
+                                        Padding="10,5"
+                                        Margin="4,0,0,0" />
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+    </DockPanel>
+</UserControl>

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml
@@ -1,9 +1,9 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:EasySave.RemoteConsole.ViewModels"
+             xmlns:rc="using:EasySave.RemoteConsole.Markup"
              x:Class="EasySave.RemoteConsole.Views.ConsoleView"
-             x:DataType="vm:ConsoleViewModel"
-             x:CompileBindings="False">
+             x:DataType="vm:ConsoleViewModel">
 
     <DockPanel>
 
@@ -16,18 +16,18 @@
             <StackPanel Orientation="Horizontal" Spacing="8">
                 <TextBox Text="{Binding Host}"
                          Width="180"
-                         PlaceholderText="Host / IP" />
+                         PlaceholderText="{DynamicResource console.host_placeholder}" />
                 <NumericUpDown Value="{Binding Port}"
                                Minimum="1"
                                Maximum="65535"
                                Width="110"
                                FormatString="0" />
-                <Button Content="Connexion"
-                        Command="{Binding ConnectCommand}"
-                        Padding="12,6" />
-                <Button Content="Déconnexion"
-                        Command="{Binding DisconnectCommand}"
-                        Padding="12,6" />
+                <Button Command="{Binding ConnectCommand}" Padding="12,6">
+                    <TextBlock Text="{rc:T Key=console.connect}" />
+                </Button>
+                <Button Command="{Binding DisconnectCommand}" Padding="12,6">
+                    <TextBlock Text="{rc:T Key=console.disconnect}" />
+                </Button>
                 <TextBlock Text="{Binding Connection}"
                            VerticalAlignment="Center"
                            FontWeight="SemiBold"
@@ -39,14 +39,13 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <ItemsControl ItemsSource="{Binding Jobs}" Margin="12,8">
                 <ItemsControl.ItemTemplate>
-                    <DataTemplate DataType="vm:JobProgressVm">
+                    <DataTemplate x:DataType="vm:JobProgressVm">
                         <Border Background="White"
                                 CornerRadius="6"
                                 Padding="12,10"
                                 Margin="0,0,0,6"
                                 BoxShadow="0 1 4 0 #18000000">
-                            <Grid ColumnDefinitions="180,*,90,Auto,Auto,Auto"
-                                  RowDefinitions="Auto">
+                            <Grid ColumnDefinitions="180,*,90,Auto,Auto,Auto">
                                 <TextBlock Grid.Column="0"
                                            Text="{Binding JobName}"
                                            FontWeight="SemiBold"
@@ -64,23 +63,26 @@
                                            VerticalAlignment="Center"
                                            HorizontalAlignment="Center" />
                                 <Button Grid.Column="3"
-                                        Content="Pause"
-                                        Command="{Binding $parent[ItemsControl].DataContext.PauseJobCommand}"
+                                        Command="{ReflectionBinding $parent[ItemsControl].DataContext.PauseJobCommand}"
                                         CommandParameter="{Binding JobName}"
                                         Padding="10,5"
-                                        Margin="4,0,0,0" />
+                                        Margin="4,0,0,0">
+                                    <TextBlock Text="{rc:T Key=console.pause}" />
+                                </Button>
                                 <Button Grid.Column="4"
-                                        Content="Play"
-                                        Command="{Binding $parent[ItemsControl].DataContext.PlayJobCommand}"
+                                        Command="{ReflectionBinding $parent[ItemsControl].DataContext.PlayJobCommand}"
                                         CommandParameter="{Binding JobName}"
                                         Padding="10,5"
-                                        Margin="4,0,0,0" />
+                                        Margin="4,0,0,0">
+                                    <TextBlock Text="{rc:T Key=console.play}" />
+                                </Button>
                                 <Button Grid.Column="5"
-                                        Content="Stop"
-                                        Command="{Binding $parent[ItemsControl].DataContext.StopJobCommand}"
+                                        Command="{ReflectionBinding $parent[ItemsControl].DataContext.StopJobCommand}"
                                         CommandParameter="{Binding JobName}"
                                         Padding="10,5"
-                                        Margin="4,0,0,0" />
+                                        Margin="4,0,0,0">
+                                    <TextBlock Text="{rc:T Key=console.stop}" />
+                                </Button>
                             </Grid>
                         </Border>
                     </DataTemplate>

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml.cs
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace EasySave.RemoteConsole.Views;
+
+public sealed partial class ConsoleView : UserControl
+{
+    public ConsoleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/EasySave.RemoteConsole/Views/MainWindow.axaml
+++ b/EasySave.RemoteConsole/Views/MainWindow.axaml
@@ -1,13 +1,11 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="using:EasySave.RemoteConsole.Views"
         x:Class="EasySave.RemoteConsole.Views.MainWindow"
         Title="EasySave Remote Console"
         Width="900" Height="600"
         WindowStartupLocation="CenterScreen">
 
-    <TextBlock Text="EasySave Remote Console"
-               HorizontalAlignment="Center"
-               VerticalAlignment="Center"
-               FontSize="24" />
+    <views:ConsoleView />
 
 </Window>

--- a/src/EasySave.Shared/CommandDto.cs
+++ b/src/EasySave.Shared/CommandDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace EasySave.Shared;
 
 // Request frame sent by the remote console to the engine over the v3 socket.
@@ -6,4 +8,10 @@ namespace EasySave.Shared;
 public sealed record CommandDto(
     string JobName,
     CommandType Action
-);
+)
+{
+    // Populated server-side from the socket endpoint after deserialization.
+    // Not transmitted over the wire — only used for server-side logging.
+    [JsonIgnore]
+    public string SourceIp { get; init; } = string.Empty;
+}

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -57,7 +57,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
 
         foreach (var (key, entry) in _clients)
         {
-            try { entry.Client.Close(); } catch { }
+            try { entry.Client.Close(); } catch (Exception) { }
             _clients.TryRemove(key, out _);
         }
         return Task.CompletedTask;
@@ -90,7 +90,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         {
             if (_clients.TryRemove(key, out var removed))
             {
-                try { removed.Client.Close(); } catch { }
+                try { removed.Client.Close(); } catch (Exception) { }
             }
         }
     }
@@ -99,7 +99,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
     {
         var endpoint = client.Client.RemoteEndPoint?.ToString() ?? "unknown";
         var stream = client.GetStream();
-        var writer = new StreamWriter(stream, leaveOpen: true) { AutoFlush = false };
+        var writer = new StreamWriter(stream) { AutoFlush = false };
         var entry = new ClientEntry(client, writer);
         _clients[endpoint] = entry;
 
@@ -123,7 +123,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
                 foreach (var handler in CommandReceived.GetInvocationList().Cast<Func<CommandDto, Task>>())
                 {
                     try { await handler(cmd).ConfigureAwait(false); }
-                    catch { }
+                    catch (Exception) { }
                 }
             }
         }
@@ -131,7 +131,8 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         finally
         {
             _clients.TryRemove(endpoint, out _);
-            try { client.Close(); } catch { }
+            try { writer.Dispose(); } catch (Exception) { }
+            try { client.Close(); } catch (Exception) { }
         }
     }
 }

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -1,0 +1,137 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using EasyLog;
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
+{
+    private readonly IDailyLogger _logger;
+    private readonly ConcurrentDictionary<string, ClientEntry> _clients = new();
+    private TcpListener? _listener;
+    private CancellationTokenSource? _cts;
+
+    private sealed class ClientEntry(TcpClient client, StreamWriter writer)
+    {
+        public TcpClient Client { get; } = client;
+        public StreamWriter Writer { get; } = writer;
+        public SemaphoreSlim WriteLock { get; } = new(1, 1);
+    }
+
+    public event Func<CommandDto, Task> CommandReceived = _ => Task.CompletedTask;
+
+    public TcpRemoteConsoleServer(IDailyLogger logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task StartAsync(int port, CancellationToken ct)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _listener = new TcpListener(IPAddress.Any, port);
+        _listener.Start();
+
+        try
+        {
+            while (!_cts.Token.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                _ = HandleClientAsync(client, _cts.Token);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (SocketException) when (_cts.Token.IsCancellationRequested) { }
+        finally
+        {
+            _listener.Stop();
+        }
+    }
+
+    public Task StopAsync()
+    {
+        _cts?.Cancel();
+        _listener?.Stop();
+
+        foreach (var (key, entry) in _clients)
+        {
+            try { entry.Client.Close(); } catch { }
+            _clients.TryRemove(key, out _);
+        }
+        return Task.CompletedTask;
+    }
+
+    public async Task BroadcastAsync(EventDto evt)
+    {
+        var json = JsonSerializer.Serialize(evt);
+        var dead = new List<string>();
+
+        foreach (var (key, entry) in _clients)
+        {
+            await entry.WriteLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await entry.Writer.WriteLineAsync(json).ConfigureAwait(false);
+                await entry.Writer.FlushAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+            {
+                dead.Add(key);
+            }
+            finally
+            {
+                entry.WriteLock.Release();
+            }
+        }
+
+        foreach (var key in dead)
+        {
+            if (_clients.TryRemove(key, out var removed))
+            {
+                try { removed.Client.Close(); } catch { }
+            }
+        }
+    }
+
+    private async Task HandleClientAsync(TcpClient client, CancellationToken ct)
+    {
+        var endpoint = client.Client.RemoteEndPoint?.ToString() ?? "unknown";
+        var stream = client.GetStream();
+        var writer = new StreamWriter(stream, leaveOpen: true) { AutoFlush = false };
+        var entry = new ClientEntry(client, writer);
+        _clients[endpoint] = entry;
+
+        using var reader = new StreamReader(stream, leaveOpen: true);
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+                if (line is null) break;
+
+                CommandDto? cmd;
+                try { cmd = JsonSerializer.Deserialize<CommandDto>(line); }
+                catch (JsonException) { continue; }
+
+                if (cmd is null) continue;
+
+                cmd = cmd with { SourceIp = endpoint };
+
+                // Fire each handler in isolation per the interface contract.
+                foreach (var handler in CommandReceived.GetInvocationList().Cast<Func<CommandDto, Task>>())
+                {
+                    try { await handler(cmd).ConfigureAwait(false); }
+                    catch { }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or OperationCanceledException or ObjectDisposedException) { }
+        finally
+        {
+            _clients.TryRemove(endpoint, out _);
+            try { client.Close(); } catch { }
+        }
+    }
+}

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -2,14 +2,12 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Text.Json;
-using EasyLog;
 using EasySave.Shared;
 
 namespace EasySave.Services;
 
 public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
 {
-    private readonly IDailyLogger _logger;
     private readonly ConcurrentDictionary<string, ClientEntry> _clients = new();
     private TcpListener? _listener;
     private CancellationTokenSource? _cts;
@@ -22,11 +20,6 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
     }
 
     public event Func<CommandDto, Task> CommandReceived = _ => Task.CompletedTask;
-
-    public TcpRemoteConsoleServer(IDailyLogger logger)
-    {
-        _logger = logger;
-    }
 
     public async Task StartAsync(int port, CancellationToken ct)
     {
@@ -57,6 +50,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
 
         foreach (var (key, entry) in _clients)
         {
+            try { entry.WriteLock.Dispose(); } catch (Exception) { }
             try { entry.Client.Close(); } catch (Exception) { }
             _clients.TryRemove(key, out _);
         }
@@ -90,6 +84,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         {
             if (_clients.TryRemove(key, out var removed))
             {
+                try { removed.WriteLock.Dispose(); } catch (Exception) { }
                 try { removed.Client.Close(); } catch (Exception) { }
             }
         }
@@ -131,6 +126,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         finally
         {
             _clients.TryRemove(endpoint, out _);
+            try { entry.WriteLock.Dispose(); } catch (Exception) { }
             try { writer.Dispose(); } catch (Exception) { }
             try { client.Close(); } catch (Exception) { }
         }

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -52,7 +52,10 @@ if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
         }
     };
 
-    _ = remoteServer.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, CancellationToken.None);
+    _ = remoteServer.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, CancellationToken.None)
+        .ContinueWith(
+            t => Console.Error.WriteLine($"[Remote] Server stopped unexpectedly: {t.Exception?.GetBaseException().Message}"),
+            TaskContinuationOptions.OnlyOnFaulted);
 }
 
 var cliArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -30,10 +30,13 @@ var langService = new LanguageService(AppConfig.Instance.Settings);
 if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
 {
     IParallelBackupOrchestrator orchestrator = new NoOpParallelBackupOrchestrator();
-    var remoteServer = new TcpRemoteConsoleServer(logger);
+    var remoteServer = new TcpRemoteConsoleServer();
 
     remoteServer.CommandReceived += async cmd =>
     {
+        // Audit log reusing LogEntry. SourceFile prefix "[remote-cmd]" marks this as
+        // a control event, not a file transfer. FileTransferTimeMs = -1 is used as an
+        // unambiguous sentinel (distinguishes from a genuine 0 ms copy).
         logger.Append(new LogEntry
         {
             Timestamp = DateTimeOffset.Now.ToString("o"),
@@ -41,7 +44,7 @@ if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
             SourceFile = $"[remote-cmd] {cmd.Action} from {cmd.SourceIp}",
             TargetFile = string.Empty,
             FileSize = 0,
-            FileTransferTimeMs = 0,
+            FileTransferTimeMs = -1,
         });
 
         switch (cmd.Action)

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -1,6 +1,7 @@
 using EasyLog;
 using EasySave.CLI;
 using EasySave.Services;
+using EasySave.Shared;
 
 try
 {
@@ -25,6 +26,34 @@ var backupManager = new BackupManager(
     encryption,
     AppConfig.Instance.Settings.EncryptedExtensions);
 var langService = new LanguageService(AppConfig.Instance.Settings);
+
+if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
+{
+    IParallelBackupOrchestrator orchestrator = new NoOpParallelBackupOrchestrator();
+    var remoteServer = new TcpRemoteConsoleServer(logger);
+
+    remoteServer.CommandReceived += async cmd =>
+    {
+        logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = cmd.JobName,
+            SourceFile = $"[remote-cmd] {cmd.Action} from {cmd.SourceIp}",
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+        });
+
+        switch (cmd.Action)
+        {
+            case CommandType.Pause: await orchestrator.PauseAsync(cmd.JobName); break;
+            case CommandType.Play:  await orchestrator.ResumeAsync(cmd.JobName); break;
+            case CommandType.Stop:  await orchestrator.StopAsync(cmd.JobName);  break;
+        }
+    };
+
+    _ = remoteServer.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, CancellationToken.None);
+}
 
 var cliArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
 if (cliArgs.Length > 0)

--- a/src/EasySave/Services/IParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/IParallelBackupOrchestrator.cs
@@ -1,0 +1,11 @@
+namespace EasySave.Services;
+
+// STUB: temporary interface pending Chloé's v3 parallel orchestrator implementation.
+// Defines the remote-control surface consumed by TcpRemoteConsoleServer to pause,
+// resume, and stop individual backup jobs upon command from remote clients.
+public interface IParallelBackupOrchestrator
+{
+    Task PauseAsync(string jobName);
+    Task ResumeAsync(string jobName);
+    Task StopAsync(string jobName);
+}

--- a/src/EasySave/Services/NoOpParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/NoOpParallelBackupOrchestrator.cs
@@ -1,0 +1,10 @@
+namespace EasySave.Services;
+
+// STUB: no-op orchestrator used until Chloé's v3 parallel orchestrator is merged.
+// Commands are accepted and silently ignored so the server wiring compiles and runs.
+internal sealed class NoOpParallelBackupOrchestrator : IParallelBackupOrchestrator
+{
+    public Task PauseAsync(string jobName) => Task.CompletedTask;
+    public Task ResumeAsync(string jobName) => Task.CompletedTask;
+    public Task StopAsync(string jobName) => Task.CompletedTask;
+}


### PR DESCRIPTION
- add TcpRemoteConsoleServer (IRemoteConsoleServer) with ConcurrentDictionary client tracking, per-client SemaphoreSlim write lock, and isolated CommandReceived handler dispatch
- add IParallelBackupOrchestrator stub and NoOpParallelBackupOrchestrator pending Chloe parallel orchestrator implementation
- wire CommandReceived in Program.cs: Pause/Play/Stop routed to orchestrator, each command logged via existing IDailyLogger
- add SourceIp (JsonIgnore) to CommandDto for server-side logging
- add TcpRemoteConsoleClient (IRemoteConsoleClient) with exponential-backoff reconnect [1s,2s,5s,10s], per-write SemaphoreSlim, and manual IObservable<RemoteConnectionState> subject (no System.Reactive dependency)
- complete ConsoleViewModel commands (Connect, Disconnect, Pause, Play, Stop) and EventReceived handler updating Jobs via Dispatcher.UIThread.Post
- add ConsoleView.axaml bound to ConsoleViewModel with connection bar, ItemsControl job list, ProgressBar and Pause/Play/Stop buttons per job
- wire ConsoleView as MainWindow content; App.axaml.cs instantiates TcpRemoteConsoleClient and ConsoleViewModel
- add TargetFramework net8.0 and Nullable enable to RemoteConsole.csproj