### PR TITLE
feat(backup): add IParallelBackupOrchestrator skeleton and JobResult types

### DIFF
--- a/src/EasySave/Services/IParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/IParallelBackupOrchestrator.cs
@@ -11,7 +11,11 @@ namespace EasySave.Services;
 // thread (typically the UI dispatcher or the remote console handler) while
 // RunAsync is in flight. Each running job is driven through its own
 // JobExecutionContext.
-public interface IParallelBackupOrchestrator
+//
+// Implementations own per-job CancellationTokenSources and a semaphore for
+// the parallelism cap, hence the IDisposable surface for app-shutdown
+// cleanup (matching the precedent set by IBackupManagerAdapter).
+public interface IParallelBackupOrchestrator : IDisposable
 {
     // Runs every job in jobNames concurrently, bounded by MaxParallelJobs,
     // and completes when all of them have finished, failed or been
@@ -20,20 +24,25 @@ public interface IParallelBackupOrchestrator
     // JobOutcome.Cancelled in the result list.
     //
     // The returned list contains exactly one JobResult per submitted name,
-    // in the same order as jobNames.
+    // in the same order as jobNames. Throws ArgumentException when jobNames
+    // contains duplicates, since Pause/Resume/Stop target by name and would
+    // otherwise be ambiguous.
     Task<IReadOnlyList<JobResult>> RunAsync(
         IEnumerable<string> jobNames,
         CancellationToken ct);
 
     // Pauses the named running job at the next file boundary. No-op when
-    // the job is not currently running or is already paused.
+    // the orchestrator has no active context for jobName (never started or
+    // already finished) or when the job is already paused.
     void Pause(string jobName);
 
     // Resumes a previously paused job. No-op when the job is not paused.
     void Resume(string jobName);
 
-    // Stops the named job. The job exits with JobOutcome.Cancelled. No-op
-    // when the job is not currently running.
+    // Stops the named job. Works on both Running and Paused jobs — a paused
+    // job is still alive and Stop must be able to reach it. The job exits
+    // with JobOutcome.Cancelled. No-op when the orchestrator has no active
+    // context for jobName (never started or already finished).
     void Stop(string jobName);
 
     // Raised every time a running job's progress snapshot is updated.

--- a/src/EasySave/Services/IParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/IParallelBackupOrchestrator.cs
@@ -1,0 +1,43 @@
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+// Coordinates the parallel execution of multiple backup jobs in v3,
+// replacing the sequential v2 BackupManager.ExecuteJob loop. The number of
+// concurrent jobs is bounded by AppSettings.MaxParallelJobs, configured at
+// startup; jobs submitted beyond that cap queue and start as slots free up.
+//
+// All operations are thread-safe so Pause/Resume/Stop can be called from any
+// thread (typically the UI dispatcher or the remote console handler) while
+// RunAsync is in flight. Each running job is driven through its own
+// JobExecutionContext.
+public interface IParallelBackupOrchestrator
+{
+    // Runs every job in jobNames concurrently, bounded by MaxParallelJobs,
+    // and completes when all of them have finished, failed or been
+    // cancelled. ct cancels the whole batch — every running job receives
+    // the cancellation through its own JobExecutionContext and surfaces as
+    // JobOutcome.Cancelled in the result list.
+    //
+    // The returned list contains exactly one JobResult per submitted name,
+    // in the same order as jobNames.
+    Task<IReadOnlyList<JobResult>> RunAsync(
+        IEnumerable<string> jobNames,
+        CancellationToken ct);
+
+    // Pauses the named running job at the next file boundary. No-op when
+    // the job is not currently running or is already paused.
+    void Pause(string jobName);
+
+    // Resumes a previously paused job. No-op when the job is not paused.
+    void Resume(string jobName);
+
+    // Stops the named job. The job exits with JobOutcome.Cancelled. No-op
+    // when the job is not currently running.
+    void Stop(string jobName);
+
+    // Raised every time a running job's progress snapshot is updated.
+    // Subscribers must be thread-safe: handlers run on the worker thread
+    // that produced the snapshot, not on a UI dispatcher.
+    event Action<JobProgressDto> ProgressChanged;
+}

--- a/src/EasySave/Services/JobOutcome.cs
+++ b/src/EasySave/Services/JobOutcome.cs
@@ -1,0 +1,11 @@
+namespace EasySave.Services;
+
+// Final disposition of a job after a parallel orchestrator run.
+// Explicit numeric values keep telemetry and persisted result logs stable
+// across releases.
+public enum JobOutcome
+{
+    Succeeded = 0,
+    Failed = 1,
+    Cancelled = 2
+}

--- a/src/EasySave/Services/JobResult.cs
+++ b/src/EasySave/Services/JobResult.cs
@@ -2,8 +2,11 @@ namespace EasySave.Services;
 
 // Outcome of a single job run, returned by IParallelBackupOrchestrator
 // .RunAsync once every job in the batch has finished, failed or been
-// cancelled. Timestamps use the server clock; Message carries the failure
-// reason when Outcome is Failed and is null otherwise.
+// cancelled. Timestamps use the server clock. Message is human-readable
+// context: typically the failure reason when Outcome is Failed and the
+// cancellation source when Outcome is Cancelled (e.g. "stopped via remote
+// console", "batch token cancelled"); always null when Outcome is
+// Succeeded.
 public sealed record JobResult(
     string JobName,
     JobOutcome Outcome,

--- a/src/EasySave/Services/JobResult.cs
+++ b/src/EasySave/Services/JobResult.cs
@@ -1,0 +1,13 @@
+namespace EasySave.Services;
+
+// Outcome of a single job run, returned by IParallelBackupOrchestrator
+// .RunAsync once every job in the batch has finished, failed or been
+// cancelled. Timestamps use the server clock; Message carries the failure
+// reason when Outcome is Failed and is null otherwise.
+public sealed record JobResult(
+    string JobName,
+    JobOutcome Outcome,
+    DateTimeOffset StartedAt,
+    DateTimeOffset EndedAt,
+    string? Message = null
+);


### PR DESCRIPTION
## Summary

Phase 2 v3.0 skeleton task — defines the `IParallelBackupOrchestrator` interface that will replace the sequential v2 `BackupManager.ExecuteJob` loop with a parallel runner bounded by `AppSettings.MaxParallelJobs`.

Each running job is driven through its own `JobExecutionContext` (PR #131) so `Pause` / `Resume` / `Stop` calls hit the right cancellation source and pause gate without interfering with siblings.

## API

- `Task<IReadOnlyList<JobResult>> RunAsync(IEnumerable<string> jobNames, CancellationToken ct)` — completes once every submitted job has finished, failed or been cancelled. The returned list contains exactly one `JobResult` per submitted name, in the same order as `jobNames`. The token cancels the whole batch.
- `void Pause(string jobName)` / `void Resume(string jobName)` / `void Stop(string jobName)` — thread-safe, no-op when the target is not in the matching state.
- `event Action<JobProgressDto> ProgressChanged` — delivers a snapshot every time a running job advances; handlers run on the worker thread, **not** on a UI dispatcher.

## New types

- `JobResult` (record) — `JobName`, `Outcome`, `StartedAt`, `EndedAt`, optional `Message`. Returned per job from `RunAsync`.
- `JobOutcome` (enum) — `Succeeded = 0`, `Failed = 1`, `Cancelled = 2`. Explicit numeric values keep telemetry stable across releases.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet format` clean on the new files
- [ ] Concrete orchestrator wiring (semaphore, task scheduling, `JobExecutionContext` lifecycle) lands in a follow-up PR