### PR TITLE
feat(easylog): add LogEvent enum + optional EventType field for v3 events

### DIFF
--- a/docs/schemas/easysave-log.xsd
+++ b/docs/schemas/easysave-log.xsd
@@ -26,7 +26,22 @@
       <xs:element name="FileSize"           type="xs:long"/>
       <xs:element name="FileTransferTimeMs" type="xs:long"/>
       <xs:element name="EncryptionTimeMs"   type="xs:long" minOccurs="0"/>
+      <xs:element name="EventType"          type="LogEventName" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
+
+  <!-- v3+ event categories. Mirrors the EasyLog.LogEvent enum. -->
+  <xs:simpleType name="LogEventName">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="FileTransfer"/>
+      <xs:enumeration value="RemoteConsoleConnected"/>
+      <xs:enumeration value="RemoteConsoleDisconnected"/>
+      <xs:enumeration value="ParallelJobStarted"/>
+      <xs:enumeration value="ParallelJobFinished"/>
+      <xs:enumeration value="BigFileEnqueued"/>
+      <xs:enumeration value="BigFileTransferred"/>
+      <xs:enumeration value="CommandReceived"/>
+    </xs:restriction>
+  </xs:simpleType>
 
 </xs:schema>

--- a/src/EasyLog/LogEntry.cs
+++ b/src/EasyLog/LogEntry.cs
@@ -51,4 +51,14 @@ public sealed class LogEntry
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? EncryptionTimeMs { get; set; }
+
+    /// <summary>
+    /// V3 event category for this log row (EasyLog v3+). Null on v1 / v2 file-
+    /// transfer rows so existing consumers see the exact JSON / XML shape they
+    /// always have. Serialized as the enum member name (e.g. "BigFileEnqueued"),
+    /// not the numeric value, so the daily log stays human-readable.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LogEvent? EventType { get; set; }
 }

--- a/src/EasyLog/LogEvent.cs
+++ b/src/EasyLog/LogEvent.cs
@@ -1,0 +1,34 @@
+namespace EasyLog;
+
+/// <summary>
+/// V3 event categories that <see cref="LogEntry"/> can attach to a daily log
+/// row. The default v1/v2 backup-row behaviour is preserved when
+/// <see cref="LogEntry.EventType"/> is null — v1 / v2 consumers see the
+/// exact same JSON / XML shape they always have.
+/// </summary>
+public enum LogEvent
+{
+    /// <summary>A v1 / v2 file-transfer row. Emitted when no specific V3 event applies.</summary>
+    FileTransfer = 0,
+
+    /// <summary>A remote operator console opened a session against this host.</summary>
+    RemoteConsoleConnected = 1,
+
+    /// <summary>The remote operator console session was closed.</summary>
+    RemoteConsoleDisconnected = 2,
+
+    /// <summary>A backup job started in parallel with one or more other running jobs.</summary>
+    ParallelJobStarted = 3,
+
+    /// <summary>A backup job that ran in parallel completed (success or failure).</summary>
+    ParallelJobFinished = 4,
+
+    /// <summary>A file above the configured big-file threshold was queued behind the big-file gate.</summary>
+    BigFileEnqueued = 5,
+
+    /// <summary>A previously enqueued big file was released by the gate and transferred.</summary>
+    BigFileTransferred = 6,
+
+    /// <summary>A Pause / Play / Stop command arrived from the remote console.</summary>
+    CommandReceived = 7,
+}

--- a/src/EasyLog/XmlFormatter.cs
+++ b/src/EasyLog/XmlFormatter.cs
@@ -39,6 +39,14 @@ public sealed class XmlFormatter : ILogFormatter
             element.Add(new XElement("EncryptionTimeMs", entry.EncryptionTimeMs.Value));
         }
 
+        // v3+ event category — serialized as the enum member name (e.g.
+        // "BigFileEnqueued") so the XML log stays human-readable. Omitted when
+        // null so v1 / v2 consumers continue to see the exact shape they had.
+        if (entry.EventType.HasValue)
+        {
+            element.Add(new XElement("EventType", entry.EventType.Value.ToString()));
+        }
+
         return element.ToString(SaveOptions.None);
     }
 

--- a/tests/EasySave.Tests.V2/JsonFormatterTests.cs
+++ b/tests/EasySave.Tests.V2/JsonFormatterTests.cs
@@ -156,4 +156,42 @@ public class JsonFormatterTests
         public long FileSize { get; set; }
         public long FileTransferTimeMs { get; set; }
     }
+
+    [Fact]
+    public void Format_OmitsEventType_WhenNull()
+    {
+        // V1 / V2 byte-shape compatibility: a row without a V3 event must not
+        // surface the new field, so older readers see the exact shape they had.
+        var formatter = new JsonFormatter();
+        var entry = new LogEntry { JobName = "no-event", FileTransferTimeMs = 1 };
+
+        var json = formatter.Format(entry);
+
+        Assert.DoesNotContain("EventType", json);
+    }
+
+    [Fact]
+    public void Format_IncludesEventType_AsEnumName_WhenSet()
+    {
+        // V3 daily logs must stay human-readable: the event must be serialized
+        // as the enum member name, not the numeric value.
+        var formatter = new JsonFormatter();
+        var entry = new LogEntry { JobName = "big-file", EventType = LogEvent.BigFileEnqueued };
+
+        var json = formatter.Format(entry);
+
+        Assert.Contains("\"EventType\": \"BigFileEnqueued\"", json);
+        Assert.DoesNotContain("\"EventType\": 5", json);
+    }
+
+    [Fact]
+    public void Format_RoundTrip_PreservesEventType()
+    {
+        var formatter = new JsonFormatter();
+        var original = new LogEntry { JobName = "rt", EventType = LogEvent.CommandReceived };
+
+        var rebuilt = JsonSerializer.Deserialize<LogEntry>(formatter.Format(original));
+
+        Assert.Equal(LogEvent.CommandReceived, rebuilt!.EventType);
+    }
 }

--- a/tests/EasySave.Tests.V2/XmlFormatterTests.cs
+++ b/tests/EasySave.Tests.V2/XmlFormatterTests.cs
@@ -177,4 +177,29 @@ public class XmlFormatterTests
         doc.Validate(schemas, (sender, e) =>
             throw new XmlSchemaValidationException(e.Message));
     }
+
+    [Fact]
+    public void Format_OmitsEventType_WhenNull()
+    {
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "no-event", FileTransferTimeMs = 1 };
+
+        var xml = formatter.Format(entry);
+
+        Assert.DoesNotContain("EventType", xml);
+    }
+
+    [Fact]
+    public void Format_IncludesEventType_AsEnumName_AndValidates()
+    {
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry { JobName = "with-event", EventType = LogEvent.ParallelJobStarted };
+
+        var element = XElement.Parse(formatter.Format(entry));
+
+        Assert.Equal("ParallelJobStarted", element.Element("EventType")?.Value);
+
+        var doc = WrapInLogs(new[] { element });
+        ValidateAgainstSchema(doc);
+    }
 }


### PR DESCRIPTION
## Summary

Implements ClickUp task [869d5b5vf](https://app.clickup.com/t/869d5b5vf) (P1 Setup V3, dev1-easylog).

Adds a public `LogEvent` enum to `EasyLog` and an optional `LogEntry.EventType` field so the v3 components (remote console, parallel runner, big-file gate, remote command receiver) can tag their daily-log rows.

### Enum values

```csharp
FileTransfer = 0           // default v1/v2 backup row
RemoteConsoleConnected     // 1
RemoteConsoleDisconnected  // 2
ParallelJobStarted         // 3
ParallelJobFinished        // 4
BigFileEnqueued            // 5
BigFileTransferred         // 6
CommandReceived            // 7
```

### Backward compatibility — v1.0 EasyLog contract stays frozen

- `LogEntry.EventType` is **nullable** and annotated `[JsonIgnore(WhenWritingNull)]` + `[JsonConverter(JsonStringEnumConverter)]`.
- v1 / v2 backup rows leave `EventType = null` → no `EventType` property in JSON, no `<EventType>` in XML. Old readers see the exact byte shape they had.
- When set, the value is serialized as the **enum member name** (e.g. `"BigFileEnqueued"`) so the daily log stays human-readable on the customer site (cahier rule: "no extra tooling needed").

### Schema

`docs/schemas/easysave-log.xsd` adds `EventType` as an optional element typed by a restricted `xs:string` enumeration mirroring the C# enum. The XSD is embedded in `EasyLog.dll` so consumers can validate logs at runtime.

## Test plan

- [x] `dotnet build EasySave.sln` — 0 erreur
- [x] `dotnet test EasySave.sln` — 171 / 171 passants (5 new)
- [x] `dotnet format --verify-no-changes` — clean

New tests:
- `JsonFormatterTests.Format_OmitsEventType_WhenNull`
- `JsonFormatterTests.Format_IncludesEventType_AsEnumName_WhenSet`
- `JsonFormatterTests.Format_RoundTrip_PreservesEventType`
- `XmlFormatterTests.Format_OmitsEventType_WhenNull`
- `XmlFormatterTests.Format_IncludesEventType_AsEnumName_AndValidates` (also asserts XSD compliance)

## Out of scope

The v3 callers (remote console, parallel runner, big-file gate) are not wired here — this PR just lands the `LogEvent` vocabulary and the additive serialization. Those callers will reference `LogEvent.X` and set `EventType` on their `LogEntry` instances in the follow-up phase 2 PRs.