### PR TITLE
ci: pin anthropics/claude-code-action to v1.0.112

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,11 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        # Pinned: v1.0.113 (2026-05-06) regressed PR-base compare and started
+        # erroring with "404 ... compare/main...claude/pr-XXX" on every run.
+        # v1.0.112 is the last known-good release. Bump back to @v1 once the
+        # upstream regression is fixed.
+        uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # Pinned: see comment in claude-code-review.yml. v1.0.113 broke the
+        # PR-base compare; v1.0.112 is the last known-good release.
+        uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

Upstream `anthropics/claude-code-action@v1` followed `v1.0.113` released 2026-05-06T01:41 UTC, which regressed the PR-base compare. Every PR run since errors with `HTTP 404 ... compare/main...claude/pr-XXX`.

The pin must land on **main** (not staging), because the action enforces a workflow-validation step: the workflow file on the PR must be identical to the one on the default branch, otherwise it returns `401 Workflow validation failed`. PR #138 was correctly pinned but targeted staging — main still served `@v1`, so the validation kept failing.

This PR puts the pin on main directly. Last green run on `v1.0.112`: PR #135 (2026-05-05T22:41Z). After merge, future PRs (against any base) should resume green.

## Test plan

The CI on this PR is itself the smoke test — if `claude-review` posts a Verdict here, we are back. Bump back to `@v1` once the upstream fix ships.