### PR TITLE
ci: pin anthropics/claude-code-action to v1.0.112 (staging)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,11 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        # Pinned: v1.0.113 (2026-05-06) regressed PR-base compare and started
+        # erroring with "404 ... compare/main...claude/pr-XXX" on every run.
+        # v1.0.112 is the last known-good release. Bump back to @v1 once the
+        # upstream regression is fixed.
+        uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # Pinned: see comment in claude-code-review.yml. v1.0.113 broke the
+        # PR-base compare; v1.0.112 is the last known-good release.
+        uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Same pin as PR #140 (already on main). Required on staging too so the workflow-validation step matches when PRs target staging.