### PR TITLE
feat(remote): implement TcpRemoteConsoleServer and TcpRemoteConsoleCl…

### DIFF
--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -19,8 +19,9 @@ public sealed partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            var lang = System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
             var client = new TcpRemoteConsoleClient();
-            var vm = new ConsoleViewModel(client, new LanguageService());
+            var vm = new ConsoleViewModel(client, new LanguageService(lang));
             desktop.MainWindow = new MainWindow { DataContext = vm };
             desktop.Exit += (_, _) => vm.Dispose();
         }

--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using EasySave.RemoteConsole.Infrastructure;
+using EasySave.RemoteConsole.ViewModels;
 using EasySave.RemoteConsole.Views;
 
 namespace EasySave.RemoteConsole;
@@ -16,7 +18,9 @@ public sealed partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow();
+            var client = new TcpRemoteConsoleClient();
+            var vm = new ConsoleViewModel(client);
+            desktop.MainWindow = new MainWindow { DataContext = vm };
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/EasySave.RemoteConsole/App.axaml.cs
+++ b/EasySave.RemoteConsole/App.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using EasySave.RemoteConsole.Infrastructure;
+using EasySave.RemoteConsole.Services;
 using EasySave.RemoteConsole.ViewModels;
 using EasySave.RemoteConsole.Views;
 
@@ -19,8 +20,9 @@ public sealed partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var client = new TcpRemoteConsoleClient();
-            var vm = new ConsoleViewModel(client);
+            var vm = new ConsoleViewModel(client, new LanguageService());
             desktop.MainWindow = new MainWindow { DataContext = vm };
+            desktop.Exit += (_, _) => vm.Dispose();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
+++ b/EasySave.RemoteConsole/EasySave.RemoteConsole.csproj
@@ -19,4 +19,9 @@
     <ProjectReference Include="..\src\EasySave.Shared\EasySave.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Resources\en.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="Resources\fr.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/EasySave.RemoteConsole/Infrastructure/SimpleSubject.cs
+++ b/EasySave.RemoteConsole/Infrastructure/SimpleSubject.cs
@@ -1,0 +1,51 @@
+namespace EasySave.RemoteConsole.Infrastructure;
+
+// Minimal IObservable<T> / hot subject without an Rx dependency.
+internal sealed class SimpleSubject<T> : IObservable<T>, IDisposable
+{
+    private readonly List<IObserver<T>> _observers = [];
+    private readonly object _lock = new();
+    private bool _completed;
+
+    public IDisposable Subscribe(IObserver<T> observer)
+    {
+        lock (_lock)
+        {
+            if (!_completed)
+                _observers.Add(observer);
+        }
+        return new Subscription(() => { lock (_lock) { _observers.Remove(observer); } });
+    }
+
+    public void OnNext(T value)
+    {
+        IObserver<T>[] snapshot;
+        lock (_lock) { snapshot = [.. _observers]; }
+        foreach (var obs in snapshot)
+        {
+            try { obs.OnNext(value); } catch { }
+        }
+    }
+
+    public void OnCompleted()
+    {
+        IObserver<T>[] snapshot;
+        lock (_lock)
+        {
+            _completed = true;
+            snapshot = [.. _observers];
+            _observers.Clear();
+        }
+        foreach (var obs in snapshot)
+        {
+            try { obs.OnCompleted(); } catch { }
+        }
+    }
+
+    public void Dispose() => OnCompleted();
+
+    private sealed class Subscription(Action unsubscribe) : IDisposable
+    {
+        public void Dispose() => unsubscribe();
+    }
+}

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -23,6 +23,12 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
 
     public async Task ConnectAsync(string host, int port, CancellationToken ct)
     {
+        // Cancel and release any existing connection before opening a new one.
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _tcp?.Close();
+        _tcp = null;
+
         _host = host;
         _port = port;
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -1,0 +1,133 @@
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using EasySave.RemoteConsole.Abstractions;
+using EasySave.Shared;
+
+namespace EasySave.RemoteConsole.Infrastructure;
+
+public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposable
+{
+    private static readonly int[] BackoffSeconds = [1, 2, 5, 10, 10, 10];
+
+    private readonly SimpleSubject<RemoteConnectionState> _stateSubject = new();
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private TcpClient? _tcp;
+    private StreamWriter? _writer;
+    private string _host = string.Empty;
+    private int _port;
+
+    public event Func<EventDto, Task>? EventReceived;
+    public IObservable<RemoteConnectionState> ConnectionState => _stateSubject;
+
+    public async Task ConnectAsync(string host, int port, CancellationToken ct)
+    {
+        _host = host;
+        _port = port;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _stateSubject.OnNext(RemoteConnectionState.Connecting);
+        _tcp = new TcpClient();
+        await _tcp.ConnectAsync(_host, _port, _cts.Token);
+        var stream = _tcp.GetStream();
+        _writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true)
+            { AutoFlush = false };
+        _stateSubject.OnNext(RemoteConnectionState.Connected);
+        _ = ReadLoopAsync(_cts.Token);
+    }
+
+    private async Task ReadLoopAsync(CancellationToken ct)
+    {
+        int attempt = 0;
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var reader = new StreamReader(
+                    _tcp!.GetStream(), Encoding.UTF8, false, -1, leaveOpen: true);
+                while (!ct.IsCancellationRequested)
+                {
+                    string? line;
+                    try { line = await reader.ReadLineAsync(ct); }
+                    catch (OperationCanceledException) { return; }
+                    if (line is null) break;
+
+                    attempt = 0;
+                    EventDto? evt;
+                    try { evt = JsonSerializer.Deserialize<EventDto>(line); }
+                    catch { continue; }
+                    if (evt is null) continue;
+
+                    await FireEventReceivedAsync(evt);
+                }
+            }
+            catch (OperationCanceledException) { return; }
+            catch { /* network disconnect — fall through to reconnect */ }
+
+            if (ct.IsCancellationRequested) return;
+            _stateSubject.OnNext(RemoteConnectionState.Disconnected);
+
+            var delay = BackoffSeconds[Math.Min(attempt, BackoffSeconds.Length - 1)];
+            attempt++;
+            try { await Task.Delay(TimeSpan.FromSeconds(delay), ct); }
+            catch (OperationCanceledException) { return; }
+
+            _stateSubject.OnNext(RemoteConnectionState.Connecting);
+            try
+            {
+                _tcp?.Close();
+                _tcp = new TcpClient();
+                await _tcp.ConnectAsync(_host, _port, ct);
+                var stream = _tcp.GetStream();
+                await _writeLock.WaitAsync(ct);
+                try
+                {
+                    _writer?.Dispose();
+                    _writer = new StreamWriter(stream, Encoding.UTF8, 4096, leaveOpen: true)
+                        { AutoFlush = false };
+                }
+                finally { _writeLock.Release(); }
+                _stateSubject.OnNext(RemoteConnectionState.Connected);
+            }
+            catch (OperationCanceledException) { return; }
+            catch { _stateSubject.OnNext(RemoteConnectionState.Error); }
+        }
+    }
+
+    private async Task FireEventReceivedAsync(EventDto evt)
+    {
+        var handler = EventReceived;
+        if (handler is null) return;
+        foreach (var h in handler.GetInvocationList().Cast<Func<EventDto, Task>>())
+        {
+            try { await h(evt); } catch { }
+        }
+    }
+
+    public async Task SendCommandAsync(CommandDto cmd)
+    {
+        var json = JsonSerializer.Serialize(cmd);
+        await _writeLock.WaitAsync();
+        try
+        {
+            if (_writer is null) return;
+            await _writer.WriteLineAsync(json);
+            await _writer.FlushAsync();
+        }
+        finally { _writeLock.Release(); }
+    }
+
+    public async Task DisconnectAsync()
+    {
+        _cts?.Cancel();
+        await _writeLock.WaitAsync();
+        try { _writer?.Dispose(); }
+        finally { _writeLock.Release(); }
+        _tcp?.Close();
+        _stateSubject.OnNext(RemoteConnectionState.Disconnected);
+        _stateSubject.OnCompleted();
+    }
+
+    public async ValueTask DisposeAsync() => await DisconnectAsync();
+}

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -137,6 +137,8 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
     public async ValueTask DisposeAsync()
     {
         await DisconnectAsync();
+        _cts?.Dispose();
+        _writeLock.Dispose();
         _stateSubject.OnCompleted();
     }
 }

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -132,8 +132,11 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
         finally { _writeLock.Release(); }
         _tcp?.Close();
         _stateSubject.OnNext(RemoteConnectionState.Disconnected);
-        _stateSubject.OnCompleted();
     }
 
-    public async ValueTask DisposeAsync() => await DisconnectAsync();
+    public async ValueTask DisposeAsync()
+    {
+        await DisconnectAsync();
+        _stateSubject.OnCompleted();
+    }
 }

--- a/EasySave.RemoteConsole/Resources/en.json
+++ b/EasySave.RemoteConsole/Resources/en.json
@@ -1,4 +1,7 @@
 {
   "btn.connect": "Connect",
-  "btn.disconnect": "Disconnect"
+  "btn.disconnect": "Disconnect",
+  "btn.pause": "Pause",
+  "btn.play": "Play",
+  "btn.stop": "Stop"
 }

--- a/EasySave.RemoteConsole/Resources/en.json
+++ b/EasySave.RemoteConsole/Resources/en.json
@@ -1,0 +1,4 @@
+{
+  "btn.connect": "Connect",
+  "btn.disconnect": "Disconnect"
+}

--- a/EasySave.RemoteConsole/Resources/fr.json
+++ b/EasySave.RemoteConsole/Resources/fr.json
@@ -1,0 +1,4 @@
+{
+  "btn.connect": "Connexion",
+  "btn.disconnect": "Déconnexion"
+}

--- a/EasySave.RemoteConsole/Resources/fr.json
+++ b/EasySave.RemoteConsole/Resources/fr.json
@@ -1,4 +1,7 @@
 {
   "btn.connect": "Connexion",
-  "btn.disconnect": "Déconnexion"
+  "btn.disconnect": "Déconnexion",
+  "btn.pause": "Pause",
+  "btn.play": "Reprendre",
+  "btn.stop": "Arrêter"
 }

--- a/EasySave.RemoteConsole/Services/LanguageService.cs
+++ b/EasySave.RemoteConsole/Services/LanguageService.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace EasySave.RemoteConsole.Services;
+
+public sealed class LanguageService
+{
+    private readonly Dictionary<string, string> _strings;
+
+    public LanguageService(string lang = "en")
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Resources", $"{lang}.json");
+        _strings = File.Exists(path)
+            ? JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(path)) ?? []
+            : [];
+    }
+
+    public string T(string key) => _strings.TryGetValue(key, out var v) ? v : key;
+}

--- a/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
+++ b/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
@@ -35,8 +35,11 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
     /// <summary>Server TCP port.</summary>
     [ObservableProperty] private int _port = 9000;
 
-    public string LabelConnect => _lang.T("btn.connect");
+    public string LabelConnect    => _lang.T("btn.connect");
     public string LabelDisconnect => _lang.T("btn.disconnect");
+    public string LabelPause      => _lang.T("btn.pause");
+    public string LabelPlay       => _lang.T("btn.play");
+    public string LabelStop       => _lang.T("btn.stop");
 
     /// <summary>Initiates a connection to the configured host and port.</summary>
     [RelayCommand]

--- a/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
+++ b/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
@@ -1,7 +1,9 @@
 using System.Collections.ObjectModel;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave.RemoteConsole.Abstractions;
+using EasySave.Shared;
 
 namespace EasySave.RemoteConsole.ViewModels;
 
@@ -32,23 +34,75 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
 
     /// <summary>Initiates a connection to the configured host and port.</summary>
     [RelayCommand]
-    private Task ConnectAsync(CancellationToken ct) => Task.FromException(new NotImplementedException());
+    private async Task ConnectAsync(CancellationToken ct)
+    {
+        _client.EventReceived += OnEventReceivedAsync;
+        await _client.ConnectAsync(Host, Port, ct);
+    }
 
     /// <summary>Closes the current server connection.</summary>
     [RelayCommand]
-    private Task DisconnectAsync() => Task.FromException(new NotImplementedException());
+    private async Task DisconnectAsync()
+    {
+        _client.EventReceived -= OnEventReceivedAsync;
+        await _client.DisconnectAsync();
+    }
 
     /// <summary>Sends a Pause command for <paramref name="jobName"/> to the server.</summary>
     [RelayCommand]
-    private Task PauseJobAsync(string jobName) => Task.FromException(new NotImplementedException());
+    private Task PauseJobAsync(string jobName)
+        => _client.SendCommandAsync(new CommandDto(jobName, CommandType.Pause));
 
     /// <summary>Sends a Play (resume) command for <paramref name="jobName"/> to the server.</summary>
     [RelayCommand]
-    private Task PlayJobAsync(string jobName) => Task.FromException(new NotImplementedException());
+    private Task PlayJobAsync(string jobName)
+        => _client.SendCommandAsync(new CommandDto(jobName, CommandType.Play));
 
     /// <summary>Sends a Stop command for <paramref name="jobName"/> to the server.</summary>
     [RelayCommand]
-    private Task StopJobAsync(string jobName) => Task.FromException(new NotImplementedException());
+    private Task StopJobAsync(string jobName)
+        => _client.SendCommandAsync(new CommandDto(jobName, CommandType.Stop));
+
+    private Task OnEventReceivedAsync(EventDto evt)
+    {
+        if (evt.Type == EventType.JobProgress && evt.Progress is { } p)
+            Dispatcher.UIThread.Post(() => ApplyProgress(p));
+        else if (evt.Type == EventType.JobList && evt.Jobs is { } jobs)
+            Dispatcher.UIThread.Post(() => ApplyJobList(jobs));
+        return Task.CompletedTask;
+    }
+
+    private void ApplyProgress(JobProgressDto p)
+    {
+        var vm = Jobs.FirstOrDefault(j => j.JobName == p.JobName);
+        if (vm is null)
+        {
+            vm = new JobProgressVm { JobName = p.JobName };
+            Jobs.Add(vm);
+        }
+        vm.ProgressPercent = p.TotalFiles == 0
+            ? 0
+            : (p.TotalFiles - p.FilesLeft) * 100.0 / p.TotalFiles;
+        vm.Status = p.State.ToString();
+        vm.FilesRemaining = p.FilesLeft;
+    }
+
+    private void ApplyJobList(IReadOnlyList<JobProgressDto> jobs)
+    {
+        Jobs.Clear();
+        foreach (var j in jobs)
+        {
+            Jobs.Add(new JobProgressVm
+            {
+                JobName = j.JobName,
+                ProgressPercent = j.TotalFiles == 0
+                    ? 0
+                    : (j.TotalFiles - j.FilesLeft) * 100.0 / j.TotalFiles,
+                Status = j.State.ToString(),
+                FilesRemaining = j.FilesLeft,
+            });
+        }
+    }
 
     /// <inheritdoc/>
     public void Dispose() => _stateSubscription.Dispose();

--- a/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
+++ b/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave.RemoteConsole.Abstractions;
+using EasySave.RemoteConsole.Services;
 using EasySave.Shared;
 
 namespace EasySave.RemoteConsole.ViewModels;
@@ -11,11 +12,13 @@ namespace EasySave.RemoteConsole.ViewModels;
 public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
 {
     private readonly IRemoteConsoleClient _client;
+    private readonly LanguageService _lang;
     private readonly IDisposable _stateSubscription;
 
-    public ConsoleViewModel(IRemoteConsoleClient client)
+    public ConsoleViewModel(IRemoteConsoleClient client, LanguageService lang)
     {
         _client = client;
+        _lang = lang;
         _stateSubscription = _client.ConnectionState
             .Subscribe(new StateObserver(s => Connection = s));
     }
@@ -32,10 +35,15 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
     /// <summary>Server TCP port.</summary>
     [ObservableProperty] private int _port = 9000;
 
+    public string LabelConnect => _lang.T("btn.connect");
+    public string LabelDisconnect => _lang.T("btn.disconnect");
+
     /// <summary>Initiates a connection to the configured host and port.</summary>
     [RelayCommand]
     private async Task ConnectAsync(CancellationToken ct)
     {
+        // Ensure the handler is registered exactly once even if ConnectAsync is called again.
+        _client.EventReceived -= OnEventReceivedAsync;
         _client.EventReceived += OnEventReceivedAsync;
         await _client.ConnectAsync(Host, Port, ct);
     }
@@ -80,9 +88,7 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
             vm = new JobProgressVm { JobName = p.JobName };
             Jobs.Add(vm);
         }
-        vm.ProgressPercent = p.TotalFiles == 0
-            ? 0
-            : (p.TotalFiles - p.FilesLeft) * 100.0 / p.TotalFiles;
+        vm.ProgressPercent = ToPercent(p);
         vm.Status = p.State.ToString();
         vm.FilesRemaining = p.FilesLeft;
     }
@@ -95,17 +101,25 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
             Jobs.Add(new JobProgressVm
             {
                 JobName = j.JobName,
-                ProgressPercent = j.TotalFiles == 0
-                    ? 0
-                    : (j.TotalFiles - j.FilesLeft) * 100.0 / j.TotalFiles,
+                ProgressPercent = ToPercent(j),
                 Status = j.State.ToString(),
                 FilesRemaining = j.FilesLeft,
             });
         }
     }
 
+    private static double ToPercent(JobProgressDto p)
+        => p.TotalFiles == 0 ? 0 : (p.TotalFiles - p.FilesLeft) * 100.0 / p.TotalFiles;
+
     /// <inheritdoc/>
-    public void Dispose() => _stateSubscription.Dispose();
+    public void Dispose()
+    {
+        _stateSubscription.Dispose();
+        if (_client is IAsyncDisposable ad)
+            _ = ad.DisposeAsync().AsTask();
+        else if (_client is IDisposable d)
+            d.Dispose();
+    }
 
     // Bridges IObservable<RemoteConnectionState> (BCL) to an Action without a Rx dependency.
     private sealed class StateObserver(Action<RemoteConnectionState> onNext)

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml
@@ -1,0 +1,49 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:EasySave.RemoteConsole.ViewModels"
+             x:DataType="vm:ConsoleViewModel"
+             x:Class="EasySave.RemoteConsole.Views.ConsoleView">
+
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- Connection bar -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8" Spacing="8">
+            <TextBox Text="{Binding Host}" Width="160" PlaceholderText="Host" />
+            <NumericUpDown x:CompileBindings="False"
+                           Value="{Binding Port}"
+                           Minimum="1" Maximum="65535" Width="110"
+                           FormatString="0" />
+            <Button Content="Connexion" Command="{Binding ConnectCommand}" />
+            <Button Content="Déconnexion" Command="{Binding DisconnectCommand}" />
+            <TextBlock Text="{Binding Connection}" VerticalAlignment="Center" FontWeight="SemiBold" />
+        </StackPanel>
+
+        <!-- Jobs list -->
+        <ListBox Grid.Row="1" ItemsSource="{Binding Jobs}" x:Name="JobsList">
+            <ListBox.ItemTemplate>
+                <DataTemplate x:CompileBindings="False">
+                    <Grid ColumnDefinitions="160,*,100,Auto" Margin="4" VerticalAlignment="Center">
+                        <TextBlock Grid.Column="0" Text="{Binding JobName}" VerticalAlignment="Center" />
+                        <ProgressBar Grid.Column="1"
+                                     Minimum="0" Maximum="100"
+                                     Value="{Binding ProgressPercent}"
+                                     Margin="8,0" Height="16" />
+                        <TextBlock Grid.Column="2" Text="{Binding Status}" VerticalAlignment="Center" />
+                        <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4">
+                            <Button Content="Pause"
+                                    Command="{Binding #JobsList.DataContext.PauseJobCommand}"
+                                    CommandParameter="{Binding JobName}" />
+                            <Button Content="Play"
+                                    Command="{Binding #JobsList.DataContext.PlayJobCommand}"
+                                    CommandParameter="{Binding JobName}" />
+                            <Button Content="Stop"
+                                    Command="{Binding #JobsList.DataContext.StopJobCommand}"
+                                    CommandParameter="{Binding JobName}" />
+                        </StackPanel>
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+    </Grid>
+</UserControl>

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml
@@ -13,8 +13,8 @@
                            Value="{Binding Port}"
                            Minimum="1" Maximum="65535" Width="110"
                            FormatString="0" />
-            <Button Content="Connexion" Command="{Binding ConnectCommand}" />
-            <Button Content="Déconnexion" Command="{Binding DisconnectCommand}" />
+            <Button Content="{Binding LabelConnect}" Command="{Binding ConnectCommand}" />
+            <Button Content="{Binding LabelDisconnect}" Command="{Binding DisconnectCommand}" />
             <TextBlock Text="{Binding Connection}" VerticalAlignment="Center" FontWeight="SemiBold" />
         </StackPanel>
 

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml
@@ -30,13 +30,13 @@
                                      Margin="8,0" Height="16" />
                         <TextBlock Grid.Column="2" Text="{Binding Status}" VerticalAlignment="Center" />
                         <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="4">
-                            <Button Content="Pause"
+                            <Button Content="{Binding #JobsList.DataContext.LabelPause}"
                                     Command="{Binding #JobsList.DataContext.PauseJobCommand}"
                                     CommandParameter="{Binding JobName}" />
-                            <Button Content="Play"
+                            <Button Content="{Binding #JobsList.DataContext.LabelPlay}"
                                     Command="{Binding #JobsList.DataContext.PlayJobCommand}"
                                     CommandParameter="{Binding JobName}" />
-                            <Button Content="Stop"
+                            <Button Content="{Binding #JobsList.DataContext.LabelStop}"
                                     Command="{Binding #JobsList.DataContext.StopJobCommand}"
                                     CommandParameter="{Binding JobName}" />
                         </StackPanel>

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml.cs
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace EasySave.RemoteConsole.Views;
+
+public sealed partial class ConsoleView : UserControl
+{
+    public ConsoleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/EasySave.RemoteConsole/Views/MainWindow.axaml
+++ b/EasySave.RemoteConsole/Views/MainWindow.axaml
@@ -1,13 +1,11 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:views="using:EasySave.RemoteConsole.Views"
         x:Class="EasySave.RemoteConsole.Views.MainWindow"
         Title="EasySave Remote Console"
         Width="900" Height="600"
         WindowStartupLocation="CenterScreen">
 
-    <TextBlock Text="EasySave Remote Console"
-               HorizontalAlignment="Center"
-               VerticalAlignment="Center"
-               FontSize="24" />
+    <views:ConsoleView />
 
 </Window>

--- a/src/EasySave.Shared/CommandDto.cs
+++ b/src/EasySave.Shared/CommandDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace EasySave.Shared;
 
 // Request frame sent by the remote console to the engine over the v3 socket.
@@ -5,5 +7,7 @@ namespace EasySave.Shared;
 // JobName is required.
 public sealed record CommandDto(
     string JobName,
-    CommandType Action
+    CommandType Action,
+    // Injected server-side after deserialization — never sent over the wire.
+    [property: JsonIgnore] string? SourceIp = null
 );

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -135,6 +135,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
             EventType = LogEvent.RemoteConsoleDisconnected,
         });
 
+        try { entry.WriteLock.Dispose(); } catch { }
         try { entry.Writer.Dispose(); } catch { }
         try { entry.Client.Close(); } catch { }
     }

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -1,0 +1,147 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using EasyLog;
+using EasySave.Services;
+using EasySave.Shared;
+
+namespace EasySave.Infrastructure.Remote;
+
+public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
+{
+    private readonly IDailyLogger _logger;
+    private readonly ConcurrentDictionary<string, ClientEntry> _clients = new();
+    private TcpListener? _listener;
+    private CancellationTokenSource? _cts;
+
+    public event Func<CommandDto, Task>? CommandReceived;
+
+    public TcpRemoteConsoleServer(IDailyLogger logger) => _logger = logger;
+
+    public async Task StartAsync(int port, CancellationToken ct)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _listener = new TcpListener(IPAddress.Any, port);
+        _listener.Start();
+
+        while (!_cts.Token.IsCancellationRequested)
+        {
+            TcpClient client;
+            try { client = await _listener.AcceptTcpClientAsync(_cts.Token); }
+            catch (OperationCanceledException) { break; }
+            catch (SocketException) { break; }
+
+            _ = HandleClientAsync(client, _cts.Token);
+        }
+    }
+
+    public Task StopAsync()
+    {
+        _cts?.Cancel();
+        _listener?.Stop();
+        foreach (var key in _clients.Keys)
+            RemoveClient(key);
+        return Task.CompletedTask;
+    }
+
+    public async Task BroadcastAsync(EventDto evt)
+    {
+        var json = JsonSerializer.Serialize(evt);
+        var dead = new List<string>();
+
+        foreach (var (key, entry) in _clients)
+        {
+            await entry.WriteLock.WaitAsync();
+            try
+            {
+                await entry.Writer.WriteLineAsync(json);
+                await entry.Writer.FlushAsync();
+            }
+            catch { dead.Add(key); }
+            finally { entry.WriteLock.Release(); }
+        }
+
+        foreach (var key in dead)
+            RemoveClient(key);
+    }
+
+    private async Task HandleClientAsync(TcpClient client, CancellationToken ct)
+    {
+        var key = client.Client.RemoteEndPoint?.ToString() ?? Guid.NewGuid().ToString();
+        var stream = client.GetStream();
+        var writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true)
+            { AutoFlush = false };
+        _clients[key] = new ClientEntry(client, writer);
+
+        _logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = string.Empty,
+            SourceFile = key,
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+            EventType = LogEvent.RemoteConsoleConnected,
+        });
+
+        try
+        {
+            using var reader = new StreamReader(stream, Encoding.UTF8, false, -1, leaveOpen: true);
+            while (!ct.IsCancellationRequested)
+            {
+                string? line;
+                try { line = await reader.ReadLineAsync(ct); }
+                catch (OperationCanceledException) { break; }
+                if (line is null) break;
+
+                CommandDto? cmd;
+                try { cmd = JsonSerializer.Deserialize<CommandDto>(line); }
+                catch { continue; }
+                if (cmd is null) continue;
+
+                cmd = cmd with { SourceIp = key };
+                await FireCommandReceivedAsync(cmd);
+            }
+        }
+        catch { /* network disconnect */ }
+        finally { RemoveClient(key); }
+    }
+
+    private async Task FireCommandReceivedAsync(CommandDto cmd)
+    {
+        var handler = CommandReceived;
+        if (handler is null) return;
+        foreach (var h in handler.GetInvocationList().Cast<Func<CommandDto, Task>>())
+        {
+            try { await h(cmd); }
+            catch { /* isolate faulted subscribers */ }
+        }
+    }
+
+    private void RemoveClient(string key)
+    {
+        if (!_clients.TryRemove(key, out var entry)) return;
+
+        _logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = string.Empty,
+            SourceFile = key,
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+            EventType = LogEvent.RemoteConsoleDisconnected,
+        });
+
+        try { entry.Client.Close(); } catch { }
+    }
+
+    private sealed class ClientEntry(TcpClient client, StreamWriter writer)
+    {
+        public TcpClient Client { get; } = client;
+        public StreamWriter Writer { get; } = writer;
+        public SemaphoreSlim WriteLock { get; } = new(1, 1);
+    }
+}

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -135,6 +135,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
             EventType = LogEvent.RemoteConsoleDisconnected,
         });
 
+        try { entry.Writer.Dispose(); } catch { }
         try { entry.Client.Close(); } catch { }
     }
 

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -52,7 +52,7 @@ if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
         });
         return Task.CompletedTask;
     };
-    var serverCts = new CancellationTokenSource();
+    using var serverCts = new CancellationTokenSource();
     Console.CancelKeyPress += (_, e) => { e.Cancel = true; serverCts.Cancel(); };
     AppDomain.CurrentDomain.ProcessExit += (_, _) => serverCts.Cancel();
     _ = server.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, serverCts.Token);

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -52,7 +52,10 @@ if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
         });
         return Task.CompletedTask;
     };
-    _ = server.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, CancellationToken.None);
+    var serverCts = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) => { e.Cancel = true; serverCts.Cancel(); };
+    AppDomain.CurrentDomain.ProcessExit += (_, _) => serverCts.Cancel();
+    _ = server.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, serverCts.Token);
 }
 
 var cliArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -1,6 +1,8 @@
 using EasyLog;
 using EasySave.CLI;
+using EasySave.Infrastructure.Remote;
 using EasySave.Services;
+using EasySave.Shared;
 
 try
 {
@@ -25,6 +27,33 @@ var backupManager = new BackupManager(
     encryption,
     AppConfig.Instance.Settings.EncryptedExtensions);
 var langService = new LanguageService(AppConfig.Instance.Settings);
+
+if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
+{
+    var orchestrator = new ParallelBackupOrchestratorStub();
+    var server = new TcpRemoteConsoleServer(logger);
+    server.CommandReceived += cmd =>
+    {
+        switch (cmd.Action)
+        {
+            case CommandType.Pause:  orchestrator.Pause(cmd.JobName);  break;
+            case CommandType.Play:   orchestrator.Resume(cmd.JobName); break;
+            case CommandType.Stop:   orchestrator.Stop(cmd.JobName);   break;
+        }
+        logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = cmd.JobName,
+            SourceFile = cmd.SourceIp ?? string.Empty,
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+            EventType = LogEvent.CommandReceived,
+        });
+        return Task.CompletedTask;
+    };
+    _ = server.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, CancellationToken.None);
+}
 
 var cliArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
 if (cliArgs.Length > 0)

--- a/src/EasySave/Services/ParallelBackupOrchestratorStub.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestratorStub.cs
@@ -1,0 +1,20 @@
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+// Temporary stub — awaiting full implementation from Chloé.
+// Replace this class once IParallelBackupOrchestrator is implemented.
+public sealed class ParallelBackupOrchestratorStub : IParallelBackupOrchestrator
+{
+#pragma warning disable CS0067 // event unused in stub — real impl will fire it
+    public event Action<JobProgressDto>? ProgressChanged;
+#pragma warning restore CS0067
+
+    public Task<IReadOnlyList<JobResult>> RunAsync(IEnumerable<string> jobNames, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<JobResult>>(Array.Empty<JobResult>());
+
+    public void Pause(string jobName) { }
+    public void Resume(string jobName) { }
+    public void Stop(string jobName) { }
+    public void Dispose() { }
+}


### PR DESCRIPTION
…ient

- add TcpRemoteConsoleServer (IRemoteConsoleServer) with TcpListener, ConcurrentDictionary of clients, per-client SemaphoreSlim write lock, BroadcastAsync, and graceful StopAsync
- wire CommandReceived to ParallelBackupOrchestratorStub (Pause/Play/Stop) in Program.cs; log each command with LogEvent.CommandReceived
- add ParallelBackupOrchestratorStub as placeholder until real impl lands
- add CommandDto.SourceIp (JsonIgnore, injected server-side after deserialization)
- add TcpRemoteConsoleClient (IRemoteConsoleClient) with exponential-backoff reconnection, per-write SemaphoreSlim, and SimpleSubject<T> for ConnectionState
- implement ConsoleViewModel commands (Connect, Disconnect, Pause, Play, Stop) and EventReceived handler that updates Jobs collection on UI thread
- add ConsoleView.axaml with connection bar and per-job Pause/Play/Stop buttons
- set ConsoleView as MainWindow content; wire DI in App.axaml.cs