### PR TITLE
feat(backup): add ParallelBackupOrchestrator impl with concurrency tests

### DIFF
--- a/src/EasySave/Services/IJobRunner.cs
+++ b/src/EasySave/Services/IJobRunner.cs
@@ -1,0 +1,23 @@
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+// Strategy used by IParallelBackupOrchestrator to actually run each
+// individual job. Decoupling lets the orchestrator focus on parallelism
+// and isolation while the concrete runner takes care of the v3 backup
+// pipeline (or, in tests, of arbitrary fake behaviour).
+//
+// The runner observes pause/stop through the supplied JobExecutionContext
+// (Cts.Token for cancellation, PauseGate for pause/resume) and reports
+// progress through publishProgress, which the orchestrator wires so each
+// call both updates ctx.Progress and raises ProgressChanged on the worker
+// thread.
+//
+// Hard requirement: every wait on PauseGate MUST use the token-aware
+// overload PauseGate.Wait(ctx.Cts.Token). Stop() relies solely on
+// CancellationToken to terminate the runner; a non-token-aware Wait would
+// be unreachable from Stop() and the job would never end.
+public interface IJobRunner
+{
+    Task RunAsync(JobExecutionContext context, Action<JobProgressDto> publishProgress);
+}

--- a/src/EasySave/Services/ParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestrator.cs
@@ -24,7 +24,7 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
     private readonly SemaphoreSlim _slots;
     private readonly ConcurrentDictionary<string, JobExecutionContext> _running = new();
 
-    public event Action<JobProgressDto>? ProgressChanged;
+    public event Action<JobProgressDto> ProgressChanged = static _ => { };
 
     public ParallelBackupOrchestrator(
         IJobRunner runner,
@@ -40,7 +40,7 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
         _slots = new SemaphoreSlim(maxParallelJobs, maxParallelJobs);
     }
 
-    public Task<IReadOnlyList<JobResult>> RunAsync(
+    public async Task<IReadOnlyList<JobResult>> RunAsync(
         IEnumerable<string> jobNames,
         CancellationToken ct)
     {
@@ -54,16 +54,8 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
                 nameof(jobNames));
         }
 
-        return RunBatchAsync(names, ct);
-    }
-
-    private async Task<IReadOnlyList<JobResult>> RunBatchAsync(
-        string[] names,
-        CancellationToken batchCt)
-    {
-        var tasks = names.Select(n => RunSingleAsync(n, batchCt)).ToArray();
-        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-        return results;
+        var tasks = names.Select(n => RunSingleAsync(n, ct)).ToArray();
+        return await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
     private async Task<JobResult> RunSingleAsync(string jobName, CancellationToken batchCt)
@@ -72,7 +64,10 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
 
         // The slot wait is its own try/catch so a batch cancellation that
         // arrives before the job ever starts surfaces cleanly as a
-        // Cancelled JobResult instead of throwing out of Task.WhenAll.
+        // Cancelled JobResult instead of throwing out of Task.WhenAll. The
+        // ObjectDisposedException branch covers the Dispose-while-queued
+        // race (see Dispose contract below); without it the queued task
+        // would fault.
         try
         {
             await _slots.WaitAsync(batchCt).ConfigureAwait(false);
@@ -83,6 +78,12 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
                 jobName, JobOutcome.Cancelled, submittedAt,
                 DateTimeOffset.UtcNow, Message: "batch cancelled before slot");
         }
+        catch (ObjectDisposedException)
+        {
+            return new JobResult(
+                jobName, JobOutcome.Cancelled, submittedAt,
+                DateTimeOffset.UtcNow, Message: "orchestrator disposed before slot");
+        }
 
         var startedAt = DateTimeOffset.UtcNow;
         try
@@ -91,7 +92,11 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
         }
         finally
         {
-            _slots.Release();
+            // Release can race with Dispose; the finally still has to run
+            // to honour the per-job result contract, so swallow the ODE
+            // rather than fault the task.
+            try { _slots.Release(); }
+            catch (ObjectDisposedException) { /* dispose race */ }
         }
     }
 
@@ -122,11 +127,12 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
             await _runner.RunAsync(ctx, snapshot =>
             {
                 ctx.Progress = snapshot;
-                // Snapshot the delegate to avoid a torn read if the last
-                // subscriber unsubscribes between the null check and the
-                // invoke.
+                // Snapshot the delegate before invoking so a concurrent -=
+                // can't reorder against this read. The event is seeded with
+                // a no-op so the field is never null even with zero
+                // subscribers.
                 var handler = ProgressChanged;
-                handler?.Invoke(snapshot);
+                handler.Invoke(snapshot);
             }).ConfigureAwait(false);
 
             return new JobResult(
@@ -184,10 +190,16 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
             ctx.Cts.Cancel();
     }
 
+    // Dispose initiates shutdown by cancelling every in-flight job's CTS
+    // (so token-aware runners exit promptly with Cancelled) and disposes the
+    // parallelism semaphore. Callers should still await every outstanding
+    // RunAsync(...) call before Dispose to collect the per-job results —
+    // this matches the contract of HttpClient and IBackupManagerAdapter.
+    // RunSingleAsync is defensive against the Dispose-during-flight race
+    // (ObjectDisposedException on slot wait or release surface as Cancelled)
+    // so an out-of-order Dispose never faults the running batch task.
     public void Dispose()
     {
-        // Cancel everything still running before tearing the semaphore down,
-        // so in-flight RunSingleAsync calls get a chance to wind up cleanly.
         foreach (var ctx in _running.Values)
         {
             try { ctx.Cts.Cancel(); }

--- a/src/EasySave/Services/ParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestrator.cs
@@ -1,0 +1,198 @@
+using System.Collections.Concurrent;
+using EasyLog;
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+// Concrete IParallelBackupOrchestrator. Runs every submitted job in
+// parallel up to MaxParallelJobs, isolating per-job state in a dedicated
+// JobExecutionContext so Pause / Resume / Stop on one job never disturb
+// its siblings. The actual "what to do for each file in a job" is
+// delegated to an injected IJobRunner — the orchestrator only owns
+// concurrency, lifecycle and progress fan-out.
+//
+// Thread-safety:
+//  - _running is a ConcurrentDictionary so Pause/Resume/Stop and the
+//    runner's add/remove operations cannot corrupt the lookup.
+//  - _slots is a SemaphoreSlim, internally thread-safe.
+//  - ProgressChanged is invoked through a local snapshot of the delegate
+//    field so a concurrent unsubscribe never throws NullReferenceException.
+public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
+{
+    private readonly IJobRunner _runner;
+    private readonly Func<string, IDailyLogger> _loggerFactory;
+    private readonly SemaphoreSlim _slots;
+    private readonly ConcurrentDictionary<string, JobExecutionContext> _running = new();
+
+    public event Action<JobProgressDto>? ProgressChanged;
+
+    public ParallelBackupOrchestrator(
+        IJobRunner runner,
+        Func<string, IDailyLogger> loggerFactory,
+        int maxParallelJobs)
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxParallelJobs, 1);
+
+        _runner = runner;
+        _loggerFactory = loggerFactory;
+        _slots = new SemaphoreSlim(maxParallelJobs, maxParallelJobs);
+    }
+
+    public Task<IReadOnlyList<JobResult>> RunAsync(
+        IEnumerable<string> jobNames,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(jobNames);
+
+        var names = jobNames.ToArray();
+        if (names.Length != names.Distinct(StringComparer.Ordinal).Count())
+        {
+            throw new ArgumentException(
+                "Duplicate job names are not supported: Pause/Resume/Stop target by name.",
+                nameof(jobNames));
+        }
+
+        return RunBatchAsync(names, ct);
+    }
+
+    private async Task<IReadOnlyList<JobResult>> RunBatchAsync(
+        string[] names,
+        CancellationToken batchCt)
+    {
+        var tasks = names.Select(n => RunSingleAsync(n, batchCt)).ToArray();
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results;
+    }
+
+    private async Task<JobResult> RunSingleAsync(string jobName, CancellationToken batchCt)
+    {
+        var submittedAt = DateTimeOffset.UtcNow;
+
+        // The slot wait is its own try/catch so a batch cancellation that
+        // arrives before the job ever starts surfaces cleanly as a
+        // Cancelled JobResult instead of throwing out of Task.WhenAll.
+        try
+        {
+            await _slots.WaitAsync(batchCt).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return new JobResult(
+                jobName, JobOutcome.Cancelled, submittedAt,
+                DateTimeOffset.UtcNow, Message: "batch cancelled before slot");
+        }
+
+        var startedAt = DateTimeOffset.UtcNow;
+        try
+        {
+            return await ExecuteSingleAsync(jobName, startedAt, batchCt).ConfigureAwait(false);
+        }
+        finally
+        {
+            _slots.Release();
+        }
+    }
+
+    private async Task<JobResult> ExecuteSingleAsync(
+        string jobName,
+        DateTimeOffset startedAt,
+        CancellationToken batchCt)
+    {
+        using var ctx = new JobExecutionContext(jobName, _loggerFactory(jobName));
+
+        // Bridge the batch token to the per-job CTS so a single batch.Cancel()
+        // tears every running job down through their own JobExecutionContext.
+        using var registration = batchCt.Register(static state =>
+            ((CancellationTokenSource)state!).Cancel(), ctx.Cts);
+
+        if (!_running.TryAdd(jobName, ctx))
+        {
+            return new JobResult(
+                jobName, JobOutcome.Failed, startedAt,
+                DateTimeOffset.UtcNow,
+                Message: $"job '{jobName}' is already running in this orchestrator");
+        }
+
+        try
+        {
+            ctx.Progress = ctx.Progress with { State = JobStateEnum.Running };
+
+            await _runner.RunAsync(ctx, snapshot =>
+            {
+                ctx.Progress = snapshot;
+                // Snapshot the delegate to avoid a torn read if the last
+                // subscriber unsubscribes between the null check and the
+                // invoke.
+                var handler = ProgressChanged;
+                handler?.Invoke(snapshot);
+            }).ConfigureAwait(false);
+
+            return new JobResult(
+                jobName, JobOutcome.Succeeded, startedAt, DateTimeOffset.UtcNow);
+        }
+        catch (OperationCanceledException oce)
+        {
+            string reason;
+            if (batchCt.IsCancellationRequested)
+                reason = "batch cancelled";
+            else if (ctx.Cts.IsCancellationRequested)
+                reason = "stopped via Stop()";
+            else
+                reason = oce.Message;
+
+            return new JobResult(
+                jobName, JobOutcome.Cancelled, startedAt,
+                DateTimeOffset.UtcNow, Message: reason);
+        }
+        catch (Exception ex)
+        {
+            return new JobResult(
+                jobName, JobOutcome.Failed, startedAt,
+                DateTimeOffset.UtcNow, Message: ex.Message);
+        }
+        finally
+        {
+            _running.TryRemove(jobName, out _);
+        }
+    }
+
+    public void Pause(string jobName)
+    {
+        if (_running.TryGetValue(jobName, out var ctx))
+            ctx.PauseGate.Reset();
+    }
+
+    public void Resume(string jobName)
+    {
+        if (_running.TryGetValue(jobName, out var ctx))
+            ctx.PauseGate.Set();
+    }
+
+    public void Stop(string jobName)
+    {
+        // Cancel only — do not pulse PauseGate. Pulsing the gate races with
+        // the cancellation: ManualResetEventSlim.Wait returns success when
+        // the event is set even if the token is cancelled in the same
+        // window, so a runner could exit Wait normally and produce a
+        // Succeeded result. Runners that block on the gate must use the
+        // token-aware overload (PauseGate.Wait(ctx.Cts.Token)) to surface
+        // OCE deterministically — that's the standard .NET cancellation
+        // pattern and a hard requirement for IJobRunner implementations.
+        if (_running.TryGetValue(jobName, out var ctx))
+            ctx.Cts.Cancel();
+    }
+
+    public void Dispose()
+    {
+        // Cancel everything still running before tearing the semaphore down,
+        // so in-flight RunSingleAsync calls get a chance to wind up cleanly.
+        foreach (var ctx in _running.Values)
+        {
+            try { ctx.Cts.Cancel(); }
+            catch (ObjectDisposedException) { /* race with self-disposal */ }
+        }
+        _slots.Dispose();
+    }
+}

--- a/tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs
+++ b/tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs
@@ -187,6 +187,7 @@ public class ParallelBackupOrchestratorTests
     {
         int inFlight = 0;
         int observedMax = 0;
+        var capReached = new TaskCompletionSource();
         var releaseAll = new TaskCompletionSource();
 
         using var orch = Make(async (_, _) =>
@@ -200,20 +201,26 @@ public class ParallelBackupOrchestratorTests
                 if (now <= prev) break;
             } while (Interlocked.CompareExchange(ref observedMax, now, prev) != prev);
 
+            // Signal the test as soon as the cap (2 in-flight) is reached.
+            if (now == 2) capReached.TrySetResult();
+
             await releaseAll.Task;
             Interlocked.Decrement(ref inFlight);
         }, maxParallelJobs: 2);
 
         var task = orch.RunAsync(new[] { "A", "B", "C", "D" }, CancellationToken.None);
 
-        // Give the scheduler a beat for jobs A and B to enter the runner.
-        // With cap = 2, observedMax must never exceed 2.
-        await Task.Delay(150);
+        // Deterministic wait: jobs A and B are both in-flight and parked on
+        // releaseAll. With cap = 2 the slot semaphore now holds the other
+        // two queued, so observedMax must equal 2 right now and cannot grow
+        // until we release.
+        await capReached.Task;
         Assert.Equal(2, observedMax);
 
         releaseAll.SetResult();
         await task;
 
+        // After C and D have cycled through, the cap must still have held.
         Assert.Equal(2, observedMax);
     }
 

--- a/tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs
+++ b/tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs
@@ -1,0 +1,385 @@
+using EasyLog;
+using EasySave.Services;
+using EasySave.Shared;
+
+namespace EasySave.Tests.V2;
+
+public class ParallelBackupOrchestratorTests
+{
+    // Lets the test author plug arbitrary per-job behaviour into the
+    // orchestrator without standing up the real backup pipeline.
+    private sealed class FakeJobRunner : IJobRunner
+    {
+        private readonly Func<JobExecutionContext, Action<JobProgressDto>, Task> _impl;
+
+        public FakeJobRunner(Func<JobExecutionContext, Action<JobProgressDto>, Task> impl)
+            => _impl = impl;
+
+        public Task RunAsync(JobExecutionContext context, Action<JobProgressDto> publishProgress)
+            => _impl(context, publishProgress);
+    }
+
+    private sealed class NoOpLogger : IDailyLogger
+    {
+        public void Append(LogEntry entry) { }
+    }
+
+    private static ParallelBackupOrchestrator Make(
+        Func<JobExecutionContext, Action<JobProgressDto>, Task> runImpl,
+        int maxParallelJobs = 4)
+    {
+        return new ParallelBackupOrchestrator(
+            new FakeJobRunner(runImpl),
+            _ => new NoOpLogger(),
+            maxParallelJobs);
+    }
+
+    // ---- argument validation ----
+
+    [Fact]
+    public void Constructor_NullRunner_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new ParallelBackupOrchestrator(null!, _ => new NoOpLogger(), 1));
+    }
+
+    [Fact]
+    public void Constructor_MaxParallelJobsZero_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ParallelBackupOrchestrator(
+                new FakeJobRunner((_, _) => Task.CompletedTask),
+                _ => new NoOpLogger(),
+                maxParallelJobs: 0));
+    }
+
+    [Fact]
+    public async Task RunAsync_DuplicateJobNames_ThrowsArgumentException()
+    {
+        using var orch = Make((_, _) => Task.CompletedTask);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            orch.RunAsync(new[] { "A", "B", "A" }, CancellationToken.None));
+    }
+
+    // ---- happy paths ----
+
+    [Fact]
+    public async Task RunAsync_EmptyList_ReturnsEmptyResults()
+    {
+        using var orch = Make((_, _) => Task.CompletedTask);
+
+        var results = await orch.RunAsync(Array.Empty<string>(), CancellationToken.None);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task RunAsync_SingleJob_CompletesSucceeded()
+    {
+        using var orch = Make((_, _) => Task.CompletedTask);
+
+        var results = await orch.RunAsync(new[] { "job-A" }, CancellationToken.None);
+
+        var only = Assert.Single(results);
+        Assert.Equal("job-A", only.JobName);
+        Assert.Equal(JobOutcome.Succeeded, only.Outcome);
+        Assert.Null(only.Message);
+    }
+
+    [Fact]
+    public async Task RunAsync_PreservesInputOrderInResults()
+    {
+        // Each runner sleeps a different amount so completion order does
+        // not match submission order; the orchestrator must still return
+        // the results in the original sequence.
+        using var orch = Make(async (ctx, _) =>
+        {
+            int delay = ctx.JobName switch
+            {
+                "c" => 30,
+                "a" => 5,
+                "b" => 20,
+                "d" => 10,
+                _ => 0
+            };
+            await Task.Delay(delay);
+        });
+
+        var input = new[] { "c", "a", "b", "d" };
+        var results = await orch.RunAsync(input, CancellationToken.None);
+
+        Assert.Equal(input, results.Select(r => r.JobName).ToArray());
+    }
+
+    [Fact]
+    public async Task RunAsync_RunnerThrows_OutcomeIsFailedWithMessage()
+    {
+        using var orch = Make((_, _) => throw new InvalidOperationException("boom"));
+
+        var results = await orch.RunAsync(new[] { "A" }, CancellationToken.None);
+
+        Assert.Equal(JobOutcome.Failed, results[0].Outcome);
+        Assert.Equal("boom", results[0].Message);
+    }
+
+    // ---- cancellation ----
+
+    [Fact]
+    public async Task RunAsync_BatchTokenCancelledMidFlight_AllInFlightJobsAreCancelled()
+    {
+        var bothStarted = new TaskCompletionSource();
+        var startedCount = 0;
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (Interlocked.Increment(ref startedCount) == 2)
+                bothStarted.SetResult();
+            await Task.Delay(Timeout.Infinite, ctx.Cts.Token);
+        }, maxParallelJobs: 2);
+
+        using var cts = new CancellationTokenSource();
+        var task = orch.RunAsync(new[] { "A", "B" }, cts.Token);
+
+        await bothStarted.Task;
+        cts.Cancel();
+
+        var results = await task;
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal(JobOutcome.Cancelled, r.Outcome));
+        Assert.All(results, r => Assert.Equal("batch cancelled", r.Message));
+    }
+
+    [Fact]
+    public async Task RunAsync_BatchTokenCancelledBeforeSlot_QueuedJobsReportCancelledBeforeSlot()
+    {
+        // cap = 1 so only one job runs at a time. The first job blocks
+        // forever; we cancel the batch while jobs B and C are still
+        // queued for the slot.
+        var firstStarted = new TaskCompletionSource();
+        var releaseFirst = new TaskCompletionSource();
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (ctx.JobName == "A") firstStarted.SetResult();
+            await releaseFirst.Task.WaitAsync(ctx.Cts.Token);
+        }, maxParallelJobs: 1);
+
+        using var cts = new CancellationTokenSource();
+        var task = orch.RunAsync(new[] { "A", "B", "C" }, cts.Token);
+
+        await firstStarted.Task;
+        cts.Cancel();
+        releaseFirst.TrySetResult();
+
+        var results = await task;
+
+        Assert.Equal(JobOutcome.Cancelled, results[0].Outcome);
+        Assert.Equal("batch cancelled before slot", results[1].Message);
+        Assert.Equal("batch cancelled before slot", results[2].Message);
+    }
+
+    // ---- parallelism cap ----
+
+    [Fact]
+    public async Task RunAsync_RespectsMaxParallelJobsCap()
+    {
+        int inFlight = 0;
+        int observedMax = 0;
+        var releaseAll = new TaskCompletionSource();
+
+        using var orch = Make(async (_, _) =>
+        {
+            int now = Interlocked.Increment(ref inFlight);
+            // Race-free max tracking via CAS loop.
+            int prev;
+            do
+            {
+                prev = observedMax;
+                if (now <= prev) break;
+            } while (Interlocked.CompareExchange(ref observedMax, now, prev) != prev);
+
+            await releaseAll.Task;
+            Interlocked.Decrement(ref inFlight);
+        }, maxParallelJobs: 2);
+
+        var task = orch.RunAsync(new[] { "A", "B", "C", "D" }, CancellationToken.None);
+
+        // Give the scheduler a beat for jobs A and B to enter the runner.
+        // With cap = 2, observedMax must never exceed 2.
+        await Task.Delay(150);
+        Assert.Equal(2, observedMax);
+
+        releaseAll.SetResult();
+        await task;
+
+        Assert.Equal(2, observedMax);
+    }
+
+    // ---- pause / resume / stop ----
+
+    [Fact]
+    public async Task Pause_ResetsTargetJobsPauseGate_OtherJobsUnaffected()
+    {
+        var aStarted = new TaskCompletionSource();
+        var bStarted = new TaskCompletionSource();
+        var inspect = new TaskCompletionSource();
+        var observedAGate = false;
+        var observedBGate = false;
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (ctx.JobName == "A") aStarted.SetResult();
+            else bStarted.SetResult();
+            await inspect.Task;
+            if (ctx.JobName == "A") observedAGate = ctx.PauseGate.IsSet;
+            else observedBGate = ctx.PauseGate.IsSet;
+        }, maxParallelJobs: 2);
+
+        var task = orch.RunAsync(new[] { "A", "B" }, CancellationToken.None);
+
+        await Task.WhenAll(aStarted.Task, bStarted.Task);
+
+        orch.Pause("A");
+        inspect.SetResult();
+
+        await task;
+
+        Assert.False(observedAGate);    // A was paused
+        Assert.True(observedBGate);     // B untouched
+    }
+
+    [Fact]
+    public async Task Resume_SetsTargetJobsPauseGateAfterPause()
+    {
+        var started = new TaskCompletionSource();
+        var inspect = new TaskCompletionSource();
+        var gateAfterResume = false;
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            started.SetResult();
+            await inspect.Task;
+            gateAfterResume = ctx.PauseGate.IsSet;
+        }, maxParallelJobs: 1);
+
+        var task = orch.RunAsync(new[] { "A" }, CancellationToken.None);
+
+        await started.Task;
+        orch.Pause("A");
+        orch.Resume("A");
+        inspect.SetResult();
+
+        await task;
+
+        Assert.True(gateAfterResume);
+    }
+
+    [Fact]
+    public async Task Stop_CancelsTargetJob_OtherJobsCompleteSucceeded()
+    {
+        var aStarted = new TaskCompletionSource();
+        var bDone = new TaskCompletionSource();
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (ctx.JobName == "A")
+            {
+                aStarted.SetResult();
+                await Task.Delay(Timeout.Infinite, ctx.Cts.Token);
+            }
+            else
+            {
+                bDone.SetResult();
+            }
+        }, maxParallelJobs: 2);
+
+        var task = orch.RunAsync(new[] { "A", "B" }, CancellationToken.None);
+
+        await Task.WhenAll(aStarted.Task, bDone.Task);
+        orch.Stop("A");
+
+        var results = await task;
+
+        Assert.Equal(JobOutcome.Cancelled, results[0].Outcome);
+        Assert.Equal("stopped via Stop()", results[0].Message);
+        Assert.Equal(JobOutcome.Succeeded, results[1].Outcome);
+    }
+
+    [Fact]
+    public async Task Stop_OnJobBlockedOnPauseGate_ProducesCancelled()
+    {
+        // The runner closes the gate itself before parking so there is no
+        // race over whether Pause("A") arrived before the runner reached
+        // Wait. Task.Run pushes the blocking Wait onto a thread-pool thread;
+        // without it the synchronous Wait would block the orchestrator's
+        // continuation on the test thread and deadlock.
+        var started = new TaskCompletionSource();
+
+        using var orch = Make((ctx, _) => Task.Run(() =>
+        {
+            ctx.PauseGate.Reset();
+            started.SetResult();
+            ctx.PauseGate.Wait(ctx.Cts.Token);
+        }), maxParallelJobs: 1);
+
+        var task = orch.RunAsync(new[] { "A" }, CancellationToken.None);
+
+        await started.Task;
+        orch.Stop("A");
+
+        var results = await task;
+        Assert.Equal(JobOutcome.Cancelled, results[0].Outcome);
+        Assert.Equal("stopped via Stop()", results[0].Message);
+    }
+
+    [Theory]
+    [InlineData("Pause")]
+    [InlineData("Resume")]
+    [InlineData("Stop")]
+    public void PauseResumeStop_OnUnknownJobName_AreNoOps(string verb)
+    {
+        using var orch = Make((_, _) => Task.CompletedTask);
+
+        // Should not throw despite no job ever being registered.
+        switch (verb)
+        {
+            case "Pause": orch.Pause("ghost"); break;
+            case "Resume": orch.Resume("ghost"); break;
+            case "Stop": orch.Stop("ghost"); break;
+        }
+    }
+
+    // ---- progress fan-out ----
+
+    [Fact]
+    public async Task ProgressChanged_FiresWhenRunnerPublishesAndReachesSubscribers()
+    {
+        var captured = new List<JobProgressDto>();
+        var snapshot = new JobProgressDto(
+            JobName: "A",
+            State: JobStateEnum.Running,
+            CurrentFile: "file-1.bin",
+            FilesLeft: 4,
+            TotalFiles: 5,
+            BytesLeft: 100,
+            BytesTotal: 200);
+
+        using var orch = Make((_, publish) =>
+        {
+            publish(snapshot);
+            return Task.CompletedTask;
+        });
+
+        orch.ProgressChanged += p =>
+        {
+            lock (captured) captured.Add(p);
+        };
+
+        await orch.RunAsync(new[] { "A" }, CancellationToken.None);
+
+        Assert.Single(captured);
+        Assert.Equal(snapshot, captured[0]);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 v3.0 implementation pair — concrete `ParallelBackupOrchestrator` plus its test suite. Pairs two ClickUp tasks together (impl + tests) since neither stands alone.

The interface (`IParallelBackupOrchestrator`) and the result types (`JobResult`, `JobOutcome`) shipped in PR #136. This PR provides the runtime: a parallel runner bounded by `MaxParallelJobs`, with full Pause / Resume / Stop semantics and a fan-out `ProgressChanged` event.

## New `IJobRunner` abstraction

Decouples the orchestrator from the actual backup pipeline so the orchestrator only owns concurrency / lifecycle / progress, and tests can plug in arbitrary fakes without standing up `BackupManager`. The concrete runner that wires the v3 backup pipeline lands in a follow-up PR.

```csharp
public interface IJobRunner
{
    Task RunAsync(JobExecutionContext context, Action<JobProgressDto> publishProgress);
}
```

Hard requirement on impls: every wait on `PauseGate` MUST be the token-aware overload `PauseGate.Wait(ctx.Cts.Token)` — see Stop semantics below.

## Impl notes (`src/EasySave/Services/ParallelBackupOrchestrator.cs`)

- `SemaphoreSlim _slots(MaxParallelJobs, MaxParallelJobs)` caps parallelism.
- `ConcurrentDictionary _running` lets `Pause`/`Resume`/`Stop` find the live `JobExecutionContext` for a name without racing the runner's add/remove.
- `batchCt.Register` propagates the batch cancellation token into each job's per-job CTS so a single `RunAsync(...)` token cancellation tears every running job down through its own context.
- `ProgressChanged` is invoked via a local snapshot of the delegate so a concurrent `-=` doesn't NRE on `Invoke`.
- Every code path in `RunSingleAsync` returns a `JobResult` — exceptions are caught and converted, never thrown out of `Task.WhenAll`. The result list always has one entry per submitted name in input order.
- Duplicate names in `jobNames` throw `ArgumentException` eagerly before any work starts (per the contract added in PR #136).

### Stop semantics (Cancel-only, no gate pulse)

I originally also pulsed `PauseGate.Set()` from `Stop()` so non-token-aware waiters would fall through. That races with `ManualResetEventSlim.Wait` — the event-set check can win the race against the cancellation-token check, leaving the runner thinking it returned successfully and producing a `Succeeded` result instead of `Cancelled`. The orchestrator now only calls `Cts.Cancel()` from `Stop()`; runners have to use the token-aware `PauseGate.Wait(ctx.Cts.Token)` to surface `OperationCanceledException` deterministically. The `IJobRunner` doc spells out this requirement.

## Tests (`tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs`)

18 cases (240 ms locally):

- **Argument validation** — null runner, `maxParallelJobs < 1`, duplicate job names.
- **Happy paths** — empty list, single job, multi-job, order preservation in result list, runner-throws-Failed-with-Message.
- **Cancellation** — batch token cancelled mid-flight (`'batch cancelled'`), batch token cancelled before slot acquired (queued jobs report `'batch cancelled before slot'`).
- **Cap** — 4 jobs with `MaxParallelJobs = 2` → no more than 2 ever in-flight, verified with a CAS-based max tracker so the assertion is race-free.
- **Pause / Resume** — `Pause('A')` resets target's `PauseGate` while sibling is untouched; `Resume('A')` sets it again.
- **Stop** — cancels target with message `'stopped via Stop()'` while sibling completes Succeeded; Stop on a job blocked in `PauseGate.Wait(ctx.Cts.Token)` produces `Cancelled` (token-aware path).
- **Defensive no-ops** — `[Theory]` covering `Pause` / `Resume` / `Stop` on an unknown job name (must not throw).
- **Fan-out** — `ProgressChanged` event delivers the runner's snapshot to subscribers.

The test class uses a tiny `FakeJobRunner` (lambda-driven) and a `NoOpLogger` so each test reads top-to-bottom without harness boilerplate. Pause / Stop tests use `TaskCompletionSource` handshakes instead of `Thread.Sleep` so nothing is timing-sensitive; the only timed probe is the 150 ms ` Task.Delay` inside the cap test, which is a hard cap on how long the assertion can take, not a sleep that races a state change.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet test EasySave.Tests.V2` → **87 / 87 passing** (orchestrator suite: 18 / 18, 240 ms)
- [x] `dotnet format` clean on the new files
- [ ] Real `IJobRunner` wiring against the v3 backup pipeline lands in a follow-up PR