### PR TITLE
feat(events): add IEventBus + bridges for engine→remote-console relay

### DIFF
--- a/src/EasySave.Shared/ChannelEventBus.cs
+++ b/src/EasySave.Shared/ChannelEventBus.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+
+namespace EasySave.Shared;
+
+/// <summary>
+/// In-memory <see cref="IEventBus"/> backed by a single unbounded
+/// <see cref="Channel{T}"/>. Publish enqueues; one consumer task reads the
+/// queue and dispatches to every registered handler for the event's runtime
+/// type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Single-consumer design (vs. one channel per type) keeps event ordering
+/// across types deterministic — a JobStarted published before a JobProgress
+/// is delivered before the JobProgress, regardless of registration order.
+/// </para>
+/// <para>
+/// <see cref="Publish{T}"/> is non-blocking by design: the writer is
+/// unbounded and <c>TryWrite</c> never blocks on a hot path. Handlers run on
+/// a single background task and a faulted handler is caught and ignored so
+/// one bad subscriber cannot stop the others or kill the consumer loop.
+/// </para>
+/// </remarks>
+public sealed class ChannelEventBus : IEventBus, IAsyncDisposable, IDisposable
+{
+    private readonly Channel<(Type Type, object Evt)> _channel =
+        Channel.CreateUnbounded<(Type, object)>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    private readonly ConcurrentDictionary<Type, List<Delegate>> _handlers = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _consumer;
+    private bool _disposed;
+
+    public ChannelEventBus()
+    {
+        _consumer = Task.Run(ConsumeAsync);
+    }
+
+    /// <inheritdoc />
+    public void Publish<T>(T evt) where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        if (_disposed) return;
+        // TryWrite on an unbounded channel only fails when the writer is
+        // completed (post-Dispose), in which case dropping the event is the
+        // correct behaviour.
+        _channel.Writer.TryWrite((typeof(T), evt));
+    }
+
+    /// <inheritdoc />
+    public void Subscribe<T>(Action<T> handler) where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        var list = _handlers.GetOrAdd(typeof(T), static _ => new List<Delegate>());
+        lock (list) list.Add(handler);
+    }
+
+    private async Task ConsumeAsync()
+    {
+        try
+        {
+            await foreach (var (type, evt) in _channel.Reader.ReadAllAsync(_cts.Token).ConfigureAwait(false))
+            {
+                if (!_handlers.TryGetValue(type, out var list)) continue;
+
+                Delegate[] snapshot;
+                lock (list) snapshot = list.ToArray();
+
+                foreach (var d in snapshot)
+                {
+                    try { d.DynamicInvoke(evt); }
+                    catch
+                    {
+                        // Isolate per-handler exceptions: one faulted subscriber
+                        // must not stop other subscribers, nor kill the consumer
+                        // loop. Logging is intentionally absent here so the bus
+                        // stays infrastructure-light; a hosted logger subscriber
+                        // would re-publish the failure if needed.
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _channel.Writer.TryComplete();
+        _cts.Cancel();
+        try { await _consumer.ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        _cts.Dispose();
+    }
+
+    /// <summary>
+    /// Synchronous shutdown for callers in non-async contexts (test
+    /// teardown, console hosts). Delegates to <see cref="DisposeAsync"/>.
+    /// </summary>
+    public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+}

--- a/src/EasySave.Shared/IEventBus.cs
+++ b/src/EasySave.Shared/IEventBus.cs
@@ -1,0 +1,34 @@
+namespace EasySave.Shared;
+
+/// <summary>
+/// Minimal in-process pub/sub bus the V3 components use to broadcast engine
+/// events without the publisher knowing the consumers. The engine publishes
+/// <see cref="EventDto"/> snapshots; the remote console server, the daily
+/// logger, the GUI, and any future consumer subscribe by event type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Publish{T}"/> is non-blocking — the call returns immediately and
+/// the work runs on a consumer task. A faulted handler must not stop other
+/// handlers from receiving the event.
+/// </para>
+/// <para>
+/// The bus is type-keyed: <see cref="Publish{T}"/> dispatches only to handlers
+/// registered for the exact same <typeparamref name="T"/>. There is no
+/// inheritance / hierarchy resolution.
+/// </para>
+/// </remarks>
+public interface IEventBus
+{
+    /// <summary>
+    /// Enqueues <paramref name="evt"/> for delivery. Returns immediately;
+    /// handlers are invoked on a background consumer task.
+    /// </summary>
+    void Publish<T>(T evt) where T : notnull;
+
+    /// <summary>
+    /// Registers <paramref name="handler"/> to receive every <typeparamref name="T"/>
+    /// published from this point on. Subscriptions are not removed automatically.
+    /// </summary>
+    void Subscribe<T>(Action<T> handler) where T : notnull;
+}

--- a/src/EasySave/Infrastructure/Events/RemoteConsoleBroadcastBridge.cs
+++ b/src/EasySave/Infrastructure/Events/RemoteConsoleBroadcastBridge.cs
@@ -1,0 +1,54 @@
+using EasySave.Services;
+using EasySave.Shared;
+
+namespace EasySave.Infrastructure.Events;
+
+/// <summary>
+/// Subscribes to <see cref="EventDto"/> on the shared <see cref="IEventBus"/>
+/// and forwards each one to <see cref="IRemoteConsoleServer.BroadcastAsync"/>.
+/// The other end of the bridge from <see cref="StateTrackerEventBridge"/>:
+/// engine publishes, server broadcasts, neither knows about the other.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The handler is fire-and-forget: <c>BroadcastAsync</c> is awaited inside the
+/// bus consumer task so a slow client cannot block the engine, but its
+/// completion is intentionally not surfaced — broadcast failures are isolated
+/// per client by <see cref="IRemoteConsoleServer"/> itself, and the bus
+/// guarantees a faulted handler is caught.
+/// </para>
+/// <para>
+/// Call <see cref="Start"/> once at app boot, after the bus and the server
+/// are constructed.
+/// </para>
+/// </remarks>
+public sealed class RemoteConsoleBroadcastBridge
+{
+    private readonly IEventBus _bus;
+    private readonly IRemoteConsoleServer _server;
+    private bool _started;
+
+    public RemoteConsoleBroadcastBridge(IEventBus bus, IRemoteConsoleServer server)
+    {
+        ArgumentNullException.ThrowIfNull(bus);
+        ArgumentNullException.ThrowIfNull(server);
+        _bus = bus;
+        _server = server;
+    }
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+        _bus.Subscribe<EventDto>(OnEvent);
+    }
+
+    private void OnEvent(EventDto evt)
+    {
+        // Sync-over-async is intentional: the bus consumer task drives one
+        // event at a time, so blocking it on a Task is fine and keeps event
+        // ordering observable to clients. Per-client write lock and dead-
+        // client cleanup are handled inside TcpRemoteConsoleServer.
+        _server.BroadcastAsync(evt).GetAwaiter().GetResult();
+    }
+}

--- a/src/EasySave/Infrastructure/Events/StateTrackerEventBridge.cs
+++ b/src/EasySave/Infrastructure/Events/StateTrackerEventBridge.cs
@@ -1,0 +1,73 @@
+using EasySave.Services;
+using EasySave.Shared;
+
+namespace EasySave.Infrastructure.Events;
+
+/// <summary>
+/// Hooks the engine's <see cref="StateTracker.JobProgressChanged"/> event and
+/// republishes each snapshot on the shared <see cref="IEventBus"/> as an
+/// <see cref="EventDto"/>. Decouples the engine from the V3 transport layer:
+/// the engine never references the remote console, the WebSocket layer, or
+/// any other consumer — they all subscribe to the bus.
+/// </summary>
+/// <remarks>
+/// One bridge per <see cref="StateTracker"/> instance. Call <see cref="Start"/>
+/// once at app boot, after the bus and the tracker are constructed; the bridge
+/// detaches itself on <see cref="Dispose"/>.
+/// </remarks>
+public sealed class StateTrackerEventBridge : IDisposable
+{
+    private readonly StateTracker _tracker;
+    private readonly IEventBus _bus;
+    private bool _started;
+
+    public StateTrackerEventBridge(StateTracker tracker, IEventBus bus)
+    {
+        ArgumentNullException.ThrowIfNull(tracker);
+        ArgumentNullException.ThrowIfNull(bus);
+        _tracker = tracker;
+        _bus = bus;
+    }
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+        _tracker.JobProgressChanged += OnJobProgressChanged;
+    }
+
+    private void OnJobProgressChanged(object? sender, StateEntry entry)
+    {
+        // The handler runs synchronously inside StateTracker.Update (after the
+        // _lock is released, see StateTracker comment "outside _lock on
+        // purpose"). Publish enqueues and returns immediately so the engine's
+        // file copy loop never waits on a consumer — the bus contract.
+        var progress = new JobProgressDto(
+            JobName: entry.Name,
+            State: ToWireState(entry.State),
+            CurrentFile: entry.CurrentSource,
+            FilesLeft: entry.FilesRemaining,
+            TotalFiles: entry.TotalFilesEligible,
+            BytesLeft: entry.SizeRemaining,
+            BytesTotal: entry.TotalSize);
+
+        _bus.Publish(new EventDto(
+            Timestamp: DateTimeOffset.Now,
+            Type: EventType.JobProgress,
+            Progress: progress));
+    }
+
+    private static JobStateEnum ToWireState(JobState state) => state switch
+    {
+        JobState.Active => JobStateEnum.Running,
+        JobState.Paused => JobStateEnum.Paused,
+        _ => JobStateEnum.Done,
+    };
+
+    public void Dispose()
+    {
+        if (!_started) return;
+        _tracker.JobProgressChanged -= OnJobProgressChanged;
+        _started = false;
+    }
+}

--- a/tests/EasySave.Tests.V2/ChannelEventBusTests.cs
+++ b/tests/EasySave.Tests.V2/ChannelEventBusTests.cs
@@ -1,0 +1,126 @@
+using EasySave.Shared;
+
+namespace EasySave.Tests.V2;
+
+public class ChannelEventBusTests
+{
+    [Fact]
+    public async Task Subscribe_Then_Publish_DeliversEvent()
+    {
+        await using var bus = new ChannelEventBus();
+        var received = new TaskCompletionSource<EventDto>();
+        bus.Subscribe<EventDto>(e => received.TrySetResult(e));
+
+        var sent = new EventDto(DateTimeOffset.Now, EventType.JobStarted, JobName: "J1");
+        bus.Publish(sent);
+
+        var got = await received.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal("J1", got.JobName);
+        Assert.Equal(EventType.JobStarted, got.Type);
+    }
+
+    [Fact]
+    public async Task Publish_DispatchesToAllSubscribersOfSameType()
+    {
+        await using var bus = new ChannelEventBus();
+        var hits = 0;
+        var done = new TaskCompletionSource<bool>();
+
+        bus.Subscribe<EventDto>(_ => Interlocked.Increment(ref hits));
+        bus.Subscribe<EventDto>(_ =>
+        {
+            if (Interlocked.Increment(ref hits) == 2) done.TrySetResult(true);
+        });
+
+        bus.Publish(new EventDto(DateTimeOffset.Now, EventType.JobProgress));
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(2, hits);
+    }
+
+    [Fact]
+    public async Task FaultedHandler_DoesNotPreventOtherHandlers()
+    {
+        // A bad subscriber must not stop other subscribers from getting the
+        // event nor kill the consumer loop — a hard requirement for an
+        // infrastructure bus shared across N components.
+        await using var bus = new ChannelEventBus();
+        var goodReceived = new TaskCompletionSource<bool>();
+        bus.Subscribe<EventDto>(_ => throw new InvalidOperationException("boom"));
+        bus.Subscribe<EventDto>(_ => goodReceived.TrySetResult(true));
+
+        bus.Publish(new EventDto(DateTimeOffset.Now, EventType.JobProgress));
+
+        Assert.True(await goodReceived.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        // Loop is still alive — second event also delivered.
+        var second = new TaskCompletionSource<bool>();
+        bus.Subscribe<EventDto>(_ => second.TrySetResult(true));
+        bus.Publish(new EventDto(DateTimeOffset.Now, EventType.JobFinished));
+        Assert.True(await second.Task.WaitAsync(TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
+    public async Task Publish_OnlyDispatchesToHandlersOfMatchingType()
+    {
+        await using var bus = new ChannelEventBus();
+        var eventDtoHits = 0;
+        var stringHits = 0;
+        var stringDone = new TaskCompletionSource<bool>();
+
+        bus.Subscribe<EventDto>(_ => Interlocked.Increment(ref eventDtoHits));
+        bus.Subscribe<string>(_ =>
+        {
+            Interlocked.Increment(ref stringHits);
+            stringDone.TrySetResult(true);
+        });
+
+        bus.Publish("hello");
+
+        await stringDone.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, eventDtoHits);
+        Assert.Equal(1, stringHits);
+    }
+
+    [Fact]
+    public void Publish_IsNonBlocking()
+    {
+        // The engine's file-copy loop must not be slowed by a slow consumer.
+        // Even with a handler that sleeps for 200 ms, Publish must return in
+        // milliseconds — work is offloaded to the consumer task.
+        using var bus = new ChannelEventBus();
+        bus.Subscribe<EventDto>(_ => Thread.Sleep(200));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < 50; i++)
+            bus.Publish(new EventDto(DateTimeOffset.Now, EventType.JobProgress));
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 100,
+            $"Publish blocked the caller (took {sw.ElapsedMilliseconds} ms for 50 events with a 200 ms handler).");
+    }
+
+    [Fact]
+    public void Publish_NullEvent_Throws()
+    {
+        using var bus = new ChannelEventBus();
+        Assert.Throws<ArgumentNullException>(() => bus.Publish<EventDto>(null!));
+    }
+
+    [Fact]
+    public void Subscribe_NullHandler_Throws()
+    {
+        using var bus = new ChannelEventBus();
+        Assert.Throws<ArgumentNullException>(() => bus.Subscribe<EventDto>(null!));
+    }
+
+    [Fact]
+    public async Task Publish_AfterDispose_DoesNotThrow()
+    {
+        // Component shutdown order is not always controllable — a stray
+        // Publish after DisposeAsync must drop silently, not crash the host.
+        var bus = new ChannelEventBus();
+        await bus.DisposeAsync();
+        bus.Publish(new EventDto(DateTimeOffset.Now, EventType.JobProgress));
+    }
+}

--- a/tests/EasySave.Tests.V2/RemoteConsoleBroadcastBridgeTests.cs
+++ b/tests/EasySave.Tests.V2/RemoteConsoleBroadcastBridgeTests.cs
@@ -1,0 +1,70 @@
+using EasySave.Infrastructure.Events;
+using EasySave.Services;
+using EasySave.Shared;
+
+namespace EasySave.Tests.V2;
+
+public class RemoteConsoleBroadcastBridgeTests
+{
+    [Fact]
+    public async Task Publish_EventDto_OnBus_ForwardsToServerBroadcast()
+    {
+        await using var bus = new ChannelEventBus();
+        var server = new FakeRemoteConsoleServer();
+
+        var bridge = new RemoteConsoleBroadcastBridge(bus, server);
+        bridge.Start();
+
+        var evt = new EventDto(DateTimeOffset.Now, EventType.JobStarted, JobName: "remote-job");
+        bus.Publish(evt);
+
+        await server.Received.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Single(server.Broadcasts);
+        Assert.Equal("remote-job", server.Broadcasts[0].JobName);
+        Assert.Equal(EventType.JobStarted, server.Broadcasts[0].Type);
+    }
+
+    [Fact]
+    public async Task Bridge_DoesNotForwardOtherTypesPublishedOnTheBus()
+    {
+        await using var bus = new ChannelEventBus();
+        var server = new FakeRemoteConsoleServer();
+        var bridge = new RemoteConsoleBroadcastBridge(bus, server);
+        bridge.Start();
+
+        // A JobProgressDto published directly (not wrapped in EventDto) must
+        // not reach the server — the bridge listens for EventDto only. This
+        // protects the wire format from accidental leakage of internal types.
+        bus.Publish(new JobProgressDto("j", JobStateEnum.Running, "f", 1, 1, 1, 1));
+
+        // Give the consumer a chance to dispatch.
+        await Task.Delay(150);
+
+        Assert.Empty(server.Broadcasts);
+    }
+
+    private sealed class FakeRemoteConsoleServer : IRemoteConsoleServer
+    {
+        public readonly List<EventDto> Broadcasts = new();
+        public readonly TaskCompletionSource Received = new();
+
+        public event Func<CommandDto, Task>? CommandReceived;
+
+        public Task BroadcastAsync(EventDto evt)
+        {
+            lock (Broadcasts)
+            {
+                Broadcasts.Add(evt);
+                Received.TrySetResult();
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task StartAsync(int port, CancellationToken ct) => Task.CompletedTask;
+        public Task StopAsync() => Task.CompletedTask;
+
+        // Suppress CS0067 (event never used) — required by the interface even though tests don't fire it.
+        private void Touch() => CommandReceived?.Invoke(default!);
+    }
+}

--- a/tests/EasySave.Tests.V2/StateTrackerEventBridgeTests.cs
+++ b/tests/EasySave.Tests.V2/StateTrackerEventBridgeTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using EasySave;
+using EasySave.Infrastructure.Events;
+using EasySave.Services;
+using EasySave.Shared;
+
+namespace EasySave.Tests.V2;
+
+[Collection("AppConfigMutation")]
+public class StateTrackerEventBridgeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public StateTrackerEventBridgeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"easysave-bridge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        // Redirect AppConfig at the temp dir so StateTracker writes its
+        // state.json there. AppConfig setters are init-only — must go through
+        // AppConfig.Load(configPath) like the other AppConfig-mutating tests.
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new
+        {
+            StateFilePath = Path.Combine(_tempDir, "state.json"),
+            LogDirectory = _tempDir,
+            JobsFilePath = Path.Combine(_tempDir, "jobs.json"),
+        };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public async Task Bridge_Republishes_StateTrackerUpdate_AsEventDto()
+    {
+        await using var bus = new ChannelEventBus();
+        using var bridge = new StateTrackerEventBridge(StateTracker.Instance, bus);
+        bridge.Start();
+
+        var got = new TaskCompletionSource<EventDto>();
+        bus.Subscribe<EventDto>(e => got.TrySetResult(e));
+
+        StateTracker.Instance.Update(new StateEntry
+        {
+            Name = "bridge-test",
+            State = JobState.Active,
+            TotalFilesEligible = 10,
+            FilesRemaining = 7,
+            TotalSize = 1024,
+            SizeRemaining = 512,
+            CurrentSource = @"\\nas\share\src.docx",
+        });
+
+        var evt = await got.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(EventType.JobProgress, evt.Type);
+        Assert.NotNull(evt.Progress);
+        Assert.Equal("bridge-test", evt.Progress!.JobName);
+        Assert.Equal(JobStateEnum.Running, evt.Progress.State);
+        Assert.Equal(7, evt.Progress.FilesLeft);
+        Assert.Equal(10, evt.Progress.TotalFiles);
+        Assert.Equal(512, evt.Progress.BytesLeft);
+        Assert.Equal(1024, evt.Progress.BytesTotal);
+        Assert.Equal(@"\\nas\share\src.docx", evt.Progress.CurrentFile);
+    }
+
+    [Fact]
+    public async Task Bridge_MapsPausedAndInactive_ToWireStates()
+    {
+        await using var bus = new ChannelEventBus();
+        using var bridge = new StateTrackerEventBridge(StateTracker.Instance, bus);
+        bridge.Start();
+
+        var pausedReceived = new TaskCompletionSource<EventDto>();
+        var doneReceived = new TaskCompletionSource<EventDto>();
+        bus.Subscribe<EventDto>(e =>
+        {
+            if (e.Progress?.State == JobStateEnum.Paused) pausedReceived.TrySetResult(e);
+            if (e.Progress?.State == JobStateEnum.Done) doneReceived.TrySetResult(e);
+        });
+
+        StateTracker.Instance.Update(new StateEntry
+        {
+            Name = "map-test",
+            State = JobState.Active,
+            TotalFilesEligible = 5,
+            FilesRemaining = 5,
+        });
+        StateTracker.Instance.Pause("map-test", "test-reason");
+        StateTracker.Instance.Update(new StateEntry
+        {
+            Name = "map-test",
+            State = JobState.Inactive,
+            TotalFilesEligible = 5,
+            FilesRemaining = 0,
+        });
+
+        var paused = await pausedReceived.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var done = await doneReceived.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(JobStateEnum.Paused, paused.Progress!.State);
+        Assert.Equal(JobStateEnum.Done, done.Progress!.State);
+    }
+
+    [Fact]
+    public async Task Dispose_Detaches_FromStateTrackerEvent()
+    {
+        await using var bus = new ChannelEventBus();
+        using (var bridge = new StateTrackerEventBridge(StateTracker.Instance, bus))
+        {
+            bridge.Start();
+        }
+
+        var hits = 0;
+        bus.Subscribe<EventDto>(_ => Interlocked.Increment(ref hits));
+
+        StateTracker.Instance.Update(new StateEntry
+        {
+            Name = "post-dispose",
+            State = JobState.Active,
+            TotalFilesEligible = 1,
+            FilesRemaining = 1,
+        });
+
+        // Wait briefly to let the consumer deliver if anything was republished.
+        await Task.Delay(150);
+        Assert.Equal(0, hits);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the ClickUp P3 task **\"Bridge moteur → RemoteConsoleServer (EventBus)\"** — the engine publishes job-progress events; the remote console server (and any other consumer) subscribes by type without the engine knowing about them.

### Approach
Per the task spec:
- Small `IEventBus` with `Publish<T>(T)` and `Subscribe<T>(Action<T>)`
- Subscribers : `RemoteConsoleServer` (broadcast) + `JsonDailyLogger` (already wired directly today, no change)
- Engine publishes per `JobProgressDto` update
- Non-blocking publication (single unbounded `Channel<>` + consumer task)

## What lands

| File | Role |
|---|---|
| `src/EasySave.Shared/IEventBus.cs` | Interface (typed pub/sub) |
| `src/EasySave.Shared/ChannelEventBus.cs` | `System.Threading.Channels`-backed impl. Publish is non-blocking; single consumer task dispatches to typed handlers; faulted handlers are isolated. |
| `src/EasySave/Infrastructure/Events/StateTrackerEventBridge.cs` | Hooks `StateTracker.JobProgressChanged` → `bus.Publish(EventDto)`. Maps `JobState → JobStateEnum`. |
| `src/EasySave/Infrastructure/Events/RemoteConsoleBroadcastBridge.cs` | `bus.Subscribe<EventDto>(server.BroadcastAsync)`. Closes the loop. |
| `tests/EasySave.Tests.V2/ChannelEventBusTests.cs` | 8 tests: pub/sub, multi-subscribers, type isolation, faulted handler isolation, non-blocking publish, post-Dispose drop, null guards. |
| `tests/EasySave.Tests.V2/StateTrackerEventBridgeTests.cs` | 3 tests: bridge republishes Update as EventDto, state mapping (Active/Paused/Inactive), Dispose detaches. |
| `tests/EasySave.Tests.V2/RemoteConsoleBroadcastBridgeTests.cs` | 2 tests: forwards EventDto, ignores other types on the bus. |

## Why bridges instead of touching the engine

`BackupManager`, `StateTracker`, and `TcpRemoteConsoleServer` are unchanged. The two bridges observe the existing public surface (`StateTracker.JobProgressChanged` event, `IRemoteConsoleServer.BroadcastAsync` method) and stitch them together over the bus — no risk of conflict with the parallel V3 PRs that touch the same files.

## Wiring (out of scope here, lands in P3 wiring task)

Both bridges are constructed via DI at app boot. Sample composition:

\`\`\`csharp
var bus = new ChannelEventBus();
var stateBridge = new StateTrackerEventBridge(StateTracker.Instance, bus);
var broadcastBridge = new RemoteConsoleBroadcastBridge(bus, server);
stateBridge.Start();
broadcastBridge.Start();
\`\`\`

## Test plan

- [x] \`dotnet build EasySave.sln\` — 0 erreur
- [x] \`dotnet test EasySave.sln\` — 213 / 213 passants (13 nouveaux)
- [x] Format clean **on the new files** (a pre-existing whitespace error on \`EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs\` is on staging too — not in scope here)

## Out of scope

- DI wiring at app boot (separate P3 task).
- Removing the direct `JsonDailyLogger` call from `BackupManager` to subscribe via the bus instead — keeping the direct call preserves the v1 contract; bus-based logging can be added later as an additional subscriber without touching the existing path.
- Adding life-cycle events (`JobStarted`, `JobFinished`) — only `JobProgress` is bridged for now since that's what `StateTracker.JobProgressChanged` carries today.