### PR TITLE
docs(diagrams): add v3.0 UML diagrams (Mermaid sources)

### DIFF
--- a/docs/diagrams/EasySave v3.0 — Activity Diagram.mmd
+++ b/docs/diagrams/EasySave v3.0 — Activity Diagram.mmd
@@ -1,0 +1,44 @@
+stateDiagram-v2
+    %% Lifecycle of a single job inside ParallelBackupOrchestrator.RunAsync.
+    %% Each state corresponds to an observable JobStateEnum value plus the
+    %% internal "Queued" wait for a slot in the parallelism semaphore.
+
+    [*] --> Submitted : in jobNames
+
+    Submitted --> Queued : slots full
+    Submitted --> Running : slot available
+
+    Queued --> Running : slot freed
+    Queued --> Cancelled : batch cancelled\\nbefore slot
+
+    state Running {
+        [*] --> CopyingFiles
+        CopyingFiles --> WaitingOnGate : large file
+        WaitingOnGate --> CopyingFiles : gate acquired
+        CopyingFiles --> CopyingFiles : publish progress
+    }
+
+    Running --> Paused : Pause(jobName)\\n(PauseGate.Reset)
+    Paused --> Running : Resume(jobName)\\n(PauseGate.Set)
+
+    Running --> Done : runner completes
+    Running --> Failed : runner throws
+    Running --> Cancelled : Stop(jobName)\\nor batch ct cancelled
+
+    Paused --> Cancelled : Stop(jobName)\\n(token-aware wait throws OCE)
+
+    Done --> [*] : JobOutcome.Succeeded
+    Failed --> [*] : JobOutcome.Failed
+    Cancelled --> [*] : JobOutcome.Cancelled
+
+    note right of Running
+        ProgressChanged event fires on every
+        publishProgress(snapshot) call from the
+        runner, on the worker thread.
+    end note
+
+    note left of WaitingOnGate
+        BigFileGate is a single-slot global
+        semaphore — at most one large file
+        copy in flight across all jobs.
+    end note

--- a/docs/diagrams/EasySave v3.0 — Class Diagram.mmd
+++ b/docs/diagrams/EasySave v3.0 — Class Diagram.mmd
@@ -1,0 +1,179 @@
+classDiagram
+    direction LR
+
+    %% ========== EasySave.Shared (wire DTOs) ==========
+    class JobProgressDto {
+        <<record>>
+        +string JobName
+        +JobStateEnum State
+        +string CurrentFile
+        +int FilesLeft
+        +int TotalFiles
+        +long BytesLeft
+        +long BytesTotal
+    }
+
+    class CommandDto {
+        <<record>>
+        +string JobName
+        +CommandType Action
+    }
+
+    class EventDto {
+        <<record>>
+        +DateTimeOffset Timestamp
+        +EventType Type
+        +string? JobName
+        +JobProgressDto? Progress
+        +IReadOnlyList~JobProgressDto~? Jobs
+        +string? Message
+    }
+
+    class JobStateEnum {
+        <<enumeration>>
+        Done = 0
+        Running = 1
+        Paused = 2
+    }
+
+    class CommandType {
+        <<enumeration>>
+        Pause = 0
+        Play = 1
+        Stop = 2
+    }
+
+    class EventType {
+        <<enumeration>>
+        JobList
+        JobProgress
+        JobStarted
+        JobPaused
+        JobResumed
+        JobFinished
+        JobFailed
+        Error
+        LogEvent
+    }
+
+    %% ========== EasySave (engine, server-side) ==========
+    class IParallelBackupOrchestrator {
+        <<interface>>
+        +RunAsync(jobNames, ct) Task~IReadOnlyList~JobResult~~
+        +Pause(jobName) void
+        +Resume(jobName) void
+        +Stop(jobName) void
+        +ProgressChanged event Action~JobProgressDto~
+    }
+
+    class ParallelBackupOrchestrator {
+        -SemaphoreSlim _slots
+        -ConcurrentDictionary _running
+        -IJobRunner _runner
+        -Func~string,IDailyLogger~ _loggerFactory
+        +ProgressChanged event Action~JobProgressDto~
+    }
+
+    class IJobRunner {
+        <<interface>>
+        +RunAsync(context, publishProgress) Task
+    }
+
+    class JobExecutionContext {
+        +string JobName
+        +CancellationTokenSource Cts
+        +ManualResetEventSlim PauseGate
+        +IDailyLogger Logger
+        +JobProgressDto Progress
+    }
+
+    class JobResult {
+        <<record>>
+        +string JobName
+        +JobOutcome Outcome
+        +DateTimeOffset StartedAt
+        +DateTimeOffset EndedAt
+        +string? Message
+    }
+
+    class JobOutcome {
+        <<enumeration>>
+        Succeeded = 0
+        Failed = 1
+        Cancelled = 2
+    }
+
+    class IBigFileGate {
+        <<interface>>
+        +long LargeFileThresholdBytes
+        +AcquireAsync(fileSizeBytes, ct) Task~IDisposable~
+    }
+
+    class BigFileGate {
+        -SemaphoreSlim _gate
+        -static IDisposable _smallFileHandle
+    }
+
+    class BackupManager {
+        +ExecuteJob(name, startFromIndex, ct) void
+        +ListJobs() IReadOnlyList~BackupJob~
+        +AddJob(job) void
+        +RemoveJob(name) void
+    }
+
+    class IRemoteConsoleServer {
+        <<interface>>
+        +StartAsync(port, ct) Task
+        +StopAsync() Task
+    }
+
+    %% ========== EasySave.RemoteConsole (client-side) ==========
+    class IRemoteConsoleClient {
+        <<interface>>
+        +ConnectAsync(host, port, ct) Task
+        +SendAsync(command) Task
+        +Events IAsyncEnumerable~EventDto~
+    }
+
+    class ConsoleViewModel {
+        <<MVVM>>
+        +Jobs ObservableCollection~JobProgressVm~
+        +Pause(jobName) RelayCommand
+        +Play(jobName) RelayCommand
+        +Stop(jobName) RelayCommand
+    }
+
+    %% ========== Relationships ==========
+    IParallelBackupOrchestrator <|.. ParallelBackupOrchestrator
+    IBigFileGate <|.. BigFileGate
+
+    ParallelBackupOrchestrator o-- IJobRunner : delegates per-job work
+    ParallelBackupOrchestrator *-- "*" JobExecutionContext : owns
+    ParallelBackupOrchestrator ..> JobResult : returns
+    ParallelBackupOrchestrator ..> JobProgressDto : emits via event
+
+    IJobRunner ..> JobExecutionContext : drives
+    IJobRunner ..> IBigFileGate : gates large files
+
+    JobExecutionContext --> JobProgressDto : holds current
+    JobExecutionContext --> JobStateEnum : reports state
+
+    JobResult --> JobOutcome
+
+    EventDto --> EventType
+    EventDto --> JobProgressDto : payload
+    CommandDto --> CommandType
+    JobProgressDto --> JobStateEnum
+
+    IRemoteConsoleServer ..> CommandDto : receives
+    IRemoteConsoleServer ..> EventDto : pushes
+    IRemoteConsoleServer ..> IParallelBackupOrchestrator : forwards control
+    IRemoteConsoleServer ..> BackupManager : queries job list
+
+    IRemoteConsoleClient ..> CommandDto : sends
+    IRemoteConsoleClient ..> EventDto : receives
+    ConsoleViewModel --> IRemoteConsoleClient
+
+    note for IRemoteConsoleServer "NDJSON over TCP\\n(one JSON message per line)"
+    note for ParallelBackupOrchestrator "MaxParallelJobs cap\\nfrom AppSettings"
+    note for BigFileGate "SemaphoreSlim(1,1) global\\nfor files >= LargeFileThresholdBytes"

--- a/docs/diagrams/EasySave v3.0 — Deployment Diagram.mmd
+++ b/docs/diagrams/EasySave v3.0 — Deployment Diagram.mmd
@@ -1,0 +1,42 @@
+flowchart LR
+    %% Mermaid does not have a dedicated UML deployment shape; this
+    %% flowchart uses subgraphs as deployment nodes (Server / Client) and
+    %% rectangles as deployed artifacts. Lollipop arrows mark protocol
+    %% surfaces; dashed arrows mark filesystem access.
+
+    subgraph ServerNode["fa:fa-server Server node (Windows / Linux / macOS)"]
+        direction TB
+        Engine["EasySave.exe<br/>(engine)"]
+        Orch["ParallelBackupOrchestrator<br/>+ BigFileGate<br/>+ JobExecutionContext per job"]
+        BackupMgr["BackupManager<br/>(Full / Differential strategies)"]
+        Crypto["CryptoSoft.exe<br/>(external process)"]
+        Server["IRemoteConsoleServer<br/>TCP listener"]
+        StateFile[("state.json")]
+        Logs[("Daily logs<br/>YYYY-MM-DD.json / .xml")]
+        Source[("Source folders<br/>(local / external / UNC)")]
+        Target[("Target folders<br/>(local / external / UNC)")]
+
+        Engine --- Orch
+        Engine --- BackupMgr
+        Engine --- Server
+        Orch -.calls.-> BackupMgr
+        BackupMgr -.spawns.-> Crypto
+        BackupMgr -.read.-> Source
+        BackupMgr -.write.-> Target
+        Orch -.write.-> StateFile
+        BackupMgr -.append.-> Logs
+    end
+
+    subgraph ClientNode["fa:fa-desktop Operator workstation"]
+        direction TB
+        ClientApp["EasySave.RemoteConsole.exe<br/>(Avalonia GUI)"]
+        ClientLib["IRemoteConsoleClient"]
+        ClientApp --- ClientLib
+    end
+
+    Server <-->|"NDJSON over TCP<br/>CommandDto / EventDto"| ClientLib
+
+    classDef artifact fill:#fff,stroke:#333,stroke-width:1px
+    classDef store fill:#fff8dc,stroke:#a07a00,stroke-width:1px
+    class Engine,Orch,BackupMgr,Crypto,Server,ClientApp,ClientLib artifact
+    class StateFile,Logs,Source,Target store

--- a/docs/diagrams/EasySave v3.0 — Sequence Diagram (Parallel + BigFileGate).mmd
+++ b/docs/diagrams/EasySave v3.0 — Sequence Diagram (Parallel + BigFileGate).mmd
@@ -1,0 +1,56 @@
+sequenceDiagram
+    autonumber
+    actor User
+    participant Orch as ParallelBackupOrchestrator
+    participant Slots as SemaphoreSlim _slots
+    participant Runner as IJobRunner
+    participant CtxA as JobExecutionContext (A)
+    participant CtxB as JobExecutionContext (B)
+    participant Gate as BigFileGate
+
+    User->>Orch: RunAsync(["A","B","C"], ct)
+    Note over Orch: MaxParallelJobs = 2
+
+    par Job A
+        Orch->>Slots: WaitAsync(batchCt)
+        Slots-->>Orch: slot acquired
+        Orch->>CtxA: new JobExecutionContext("A")
+        Orch->>Runner: RunAsync(ctxA, publishA)
+        Runner->>CtxA: read PauseGate, Cts.Token
+
+        loop for each file in job A
+            alt fileSize >= LargeFileThresholdBytes
+                Runner->>Gate: AcquireAsync(fileSize, ctxA.Cts.Token)
+                Gate-->>Runner: IDisposable handle
+            else small file
+                Runner->>Gate: AcquireAsync(small, ...)
+                Gate-->>Runner: NoOpHandle
+            end
+            Runner->>Runner: copy + encrypt file
+            Runner->>Runner: handle.Dispose() (releases slot)
+            Runner->>Orch: publishA(JobProgressDto)
+            Orch-->>User: ProgressChanged event
+        end
+        Runner-->>Orch: completes
+    and Job B
+        Orch->>Slots: WaitAsync(batchCt)
+        Slots-->>Orch: slot acquired
+        Orch->>CtxB: new JobExecutionContext("B")
+        Orch->>Runner: RunAsync(ctxB, publishB)
+
+        Note over Runner,Gate: B hits a large file while A holds the gate
+        Runner->>Gate: AcquireAsync(largeSize, ctxB.Cts.Token)
+        Note over Gate: blocked — A is in
+        Gate-->>Runner: handle (after A releases)
+        Runner->>Runner: copy + encrypt
+        Runner->>Runner: handle.Dispose()
+        Runner-->>Orch: completes
+    end
+
+    Note over Orch: A and B finished — slots free
+    Orch->>Slots: WaitAsync (for C)
+    Slots-->>Orch: slot acquired
+    Orch->>Runner: RunAsync(ctxC, publishC)
+    Runner-->>Orch: completes
+
+    Orch-->>User: IReadOnlyList~JobResult~ (3 entries, input order)

--- a/docs/diagrams/EasySave v3.0 — Sequence Diagram (Remote Console).mmd
+++ b/docs/diagrams/EasySave v3.0 — Sequence Diagram (Remote Console).mmd
@@ -1,0 +1,67 @@
+sequenceDiagram
+    autonumber
+    actor Op as Operator
+    participant UI as ConsoleViewModel (Avalonia)
+    participant Client as IRemoteConsoleClient
+    participant Server as IRemoteConsoleServer (engine)
+    participant Orch as ParallelBackupOrchestrator
+    participant State as StateTracker
+
+    Note over Client,Server: NDJSON over TCP — one JSON per line
+
+    Op->>UI: launch RemoteConsole, enter host:port
+    UI->>Client: ConnectAsync(host, port, ct)
+    Client->>Server: TCP connect
+
+    Server-->>Client: EventDto(Type=JobList, Jobs=[...])
+    Client-->>UI: yield event
+    UI->>UI: render initial job list
+
+    rect rgb(245, 245, 245)
+        Note over Op,State: Pause flow
+        Op->>UI: click Pause on job "A"
+        UI->>Client: SendAsync(CommandDto("A", Pause))
+        Client->>Server: write line + "\\n"
+        Server->>Orch: Pause("A")
+        Orch->>Orch: ctx_A.PauseGate.Reset()
+        Server->>State: read state.json (or in-memory)
+        Server-->>Client: EventDto(Timestamp, JobPaused, JobName="A")
+        Client-->>UI: yield event
+        UI->>UI: mark "A" as Paused
+    end
+
+    rect rgb(245, 245, 245)
+        Note over Op,State: Live progress while running
+        Orch-->>Server: ProgressChanged(JobProgressDto)
+        Server-->>Client: EventDto(Timestamp, JobProgress, Progress=...)
+        Client-->>UI: yield event
+        UI->>UI: refresh per-job progress bar
+    end
+
+    rect rgb(245, 245, 245)
+        Note over Op,State: Resume flow
+        Op->>UI: click Play on job "A"
+        UI->>Client: SendAsync(CommandDto("A", Play))
+        Client->>Server: write line + "\\n"
+        Server->>Orch: Resume("A")
+        Orch->>Orch: ctx_A.PauseGate.Set()
+        Server-->>Client: EventDto(Timestamp, JobResumed, JobName="A")
+        Client-->>UI: yield event
+        UI->>UI: mark "A" as Running again
+    end
+
+    rect rgb(245, 245, 245)
+        Note over Op,State: Stop flow
+        Op->>UI: click Stop on job "A"
+        UI->>Client: SendAsync(CommandDto("A", Stop))
+        Client->>Server: write line + "\\n"
+        Server->>Orch: Stop("A")
+        Orch->>Orch: ctx_A.Cts.Cancel()
+        Note over Orch: token-aware Wait throws OCE
+        Orch-->>Server: ProgressChanged(final), then JobResult.Cancelled
+        Server-->>Client: EventDto(Timestamp, JobFinished, JobName="A")
+        Client-->>UI: yield event
+        UI->>UI: mark "A" as Done
+    end
+
+    Note over Server,Client: Server keeps streaming LogEvent\\nas the engine writes daily logs


### PR DESCRIPTION
## Summary

Phase 4 v3.0 UML deliverables — five Mermaid source files covering the v3 architecture, one per ClickUp UML task. Drops alongside the existing v1.0 / v2.0 PNGs in \`docs/diagrams/\`. Source-only for now; the PNG variants can be exported by rendering with [mermaid.live](https://mermaid.live) or:

\`\`\`
npx -p @mermaid-js/mermaid-cli mmdc -i \"docs/diagrams/EasySave v3.0 — Class Diagram.mmd\" -o \"docs/diagrams/EasySave v3.0 — Class Diagram.png\"
\`\`\`

The Mermaid source becomes the version-controlled truth — review-friendly, diffs cleanly, and the PNGs can be regenerated whenever the architecture moves.

## Files (one per Phase 4 ClickUp task)

| ClickUp | File | Purpose |
|---|---|---|
| `869d5b8rt` (high) | `EasySave v3.0 — Class Diagram.mmd` | Full v3 type surface: orchestrator, runner, contexts, result types, big-file gate, the EasySave.Shared DTOs, the remote-console interfaces, and the v2 carry-over. |
| `869d5b8ga` | `EasySave v3.0 — Sequence Diagram (Parallel + BigFileGate).mmd` | Three jobs with cap = 2, par/and concurrency, B blocking on the gate while A holds it. |
| `869d5b8f6` | `EasySave v3.0 — Sequence Diagram (Remote Console).mmd` | Connect handshake, Pause / Play / Stop, live JobProgress fan-out, server-side translation to orchestrator calls. |
| `869d5b8u4` | `EasySave v3.0 — Deployment Diagram.mmd` | Server node (engine + TCP server + filesystem + CryptoSoft + state.json + logs) and client node (RemoteConsole.exe), linked over NDJSON-on-TCP. |
| `869d5b8vk` | `EasySave v3.0 — Activity Diagram.mmd` | Single-job lifecycle — Submitted → Queued → Running → Paused / Done / Failed / Cancelled, with WaitingOnGate as a Running sub-state. |

## Notes

- Class Diagram covers v3 only; v2 classes are mentioned where they take part in the new flows (e.g. `BackupManager` queried by the remote console server) but their full surface stays in the v2 PNG.
- Mermaid does not have a dedicated UML deployment shape, so the Deployment Diagram uses a flowchart with subgraphs for nodes and rectangles for artifacts. The shape is conventional in the Mermaid community and renders cleanly.
- Class Diagram cannot be rendered through the Figma MCP tool (`generate_diagram` does not support class diagrams), so all five files use the same Mermaid → mmdc / mermaid.live workflow for consistency.

## Test plan

- [x] Files render cleanly in [mermaid.live](https://mermaid.live) with no syntax errors
- [x] All v3 type names match the code on staging (`IBigFileGate`, `BigFileGate`, `ParallelBackupOrchestrator`, `IJobRunner`, `JobExecutionContext`, `JobResult`, `JobOutcome`, `JobProgressDto` + DTO peers, `IRemoteConsoleServer/Client`)
- [ ] Tutor / team review the diagrams for completeness
- [ ] PNGs exported and committed in a follow-up PR (or this one if the team prefers the binaries on `staging` immediately)