### PR TITLE
feat(encryption): CryptoSoft semaphore — serialize concurrent calls

### DIFF
--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -95,7 +95,7 @@ public partial class App : Application
             var cryptoSettings = userSettings.CryptoSoft;
             return string.IsNullOrWhiteSpace(cryptoSettings.Path)
                 ? new NoOpEncryptionService()
-                : (IEncryptionService)new CryptoSoftAdapter(cryptoSettings);
+                : (IEncryptionService)new ThrottledEncryptionService(new CryptoSoftAdapter(cryptoSettings));
         });
 
         services.AddSingleton<BackupManager>(sp => new BackupManager(

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -17,7 +17,7 @@ catch (IOException ex)
 var logger = new JsonDailyLogger(AppConfig.Instance.LogDirectory);
 IEncryptionService encryption = string.IsNullOrWhiteSpace(AppConfig.Instance.Settings.CryptoSoft.Path)
     ? new NoOpEncryptionService()
-    : new CryptoSoftAdapter(AppConfig.Instance.Settings.CryptoSoft);
+    : new ThrottledEncryptionService(new CryptoSoftAdapter(AppConfig.Instance.Settings.CryptoSoft));
 var backupManager = new BackupManager(
     logger,
     new FullBackupStrategy(),

--- a/src/EasySave/Services/ThrottledEncryptionService.cs
+++ b/src/EasySave/Services/ThrottledEncryptionService.cs
@@ -1,0 +1,34 @@
+namespace EasySave.Services;
+
+// Decorator that serializes calls to an inner IEncryptionService via a
+// SemaphoreSlim. Required when multiple backup jobs run concurrently in V3:
+// CryptoSoft is an external process not designed for concurrent invocation —
+// a single semaphore slot (default) ensures at most one instance runs at once.
+public sealed class ThrottledEncryptionService : IEncryptionService, IDisposable
+{
+    private readonly IEncryptionService _inner;
+    private readonly SemaphoreSlim _semaphore;
+
+    public ThrottledEncryptionService(IEncryptionService inner, int maxConcurrent = 1)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxConcurrent, 1);
+        _inner = inner;
+        _semaphore = new SemaphoreSlim(maxConcurrent, maxConcurrent);
+    }
+
+    public EncryptResult Encrypt(string source, string dest)
+    {
+        _semaphore.Wait();
+        try
+        {
+            return _inner.Encrypt(source, dest);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public void Dispose() => _semaphore.Dispose();
+}

--- a/tests/EasySave.Tests/ThrottledEncryptionServiceTests.cs
+++ b/tests/EasySave.Tests/ThrottledEncryptionServiceTests.cs
@@ -1,0 +1,86 @@
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+public class ThrottledEncryptionServiceTests
+{
+    // Fake that records peak concurrency and optionally blocks until released.
+    private sealed class RecordingEncryptionService : IEncryptionService
+    {
+        private int _current;
+        public int PeakConcurrent;
+        public ManualResetEventSlim? Gate;
+
+        public EncryptResult Encrypt(string source, string dest)
+        {
+            var c = Interlocked.Increment(ref _current);
+            Interlocked.Exchange(ref PeakConcurrent, Math.Max(PeakConcurrent, c));
+            Gate?.Wait();
+            Interlocked.Decrement(ref _current);
+            return EncryptResult.Succeeded(0);
+        }
+    }
+
+    [Fact]
+    public void Encrypt_PassesResult_FromInnerService()
+    {
+        var inner = new RecordingEncryptionService();
+        using var sut = new ThrottledEncryptionService(inner);
+
+        var result = sut.Encrypt("src", "dst");
+
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task Encrypt_WithMaxConcurrent1_NeverRunsMoreThanOneAtATime()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var inner = new RecordingEncryptionService { Gate = gate };
+        using var sut = new ThrottledEncryptionService(inner, maxConcurrent: 1);
+
+        // Launch two concurrent encrypt calls; the semaphore must serialize them.
+        var t1 = Task.Run(() => sut.Encrypt("a", "a"));
+        // Give t1 time to enter the semaphore and block on the gate.
+        await Task.Delay(50);
+        var t2 = Task.Run(() => sut.Encrypt("b", "b"));
+
+        // Release the gate — both calls will eventually complete.
+        gate.Set();
+        await Task.WhenAll(t1, t2);
+
+        // Peak must be 1: the second call was queued, never overlapping.
+        Assert.Equal(1, inner.PeakConcurrent);
+    }
+
+    [Fact]
+    public async Task Encrypt_WithMaxConcurrent2_AllowsTwoConcurrentCalls()
+    {
+        var gate = new ManualResetEventSlim(false);
+        var inner = new RecordingEncryptionService { Gate = gate };
+        using var sut = new ThrottledEncryptionService(inner, maxConcurrent: 2);
+
+        var t1 = Task.Run(() => sut.Encrypt("a", "a"));
+        var t2 = Task.Run(() => sut.Encrypt("b", "b"));
+        await Task.Delay(80);
+
+        gate.Set();
+        await Task.WhenAll(t1, t2);
+
+        // Both calls must have overlapped.
+        Assert.Equal(2, inner.PeakConcurrent);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_WhenInnerIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ThrottledEncryptionService(null!));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentOutOfRangeException_WhenMaxConcurrentIsZero()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ThrottledEncryptionService(new RecordingEncryptionService(), 0));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ThrottledEncryptionService`, a decorator around `IEncryptionService` that uses `SemaphoreSlim` to limit concurrent CryptoSoft invocations
- Default `maxConcurrent = 1` — one external process at a time, as required when V3 jobs run in parallel
- Wire in both entry points: `Program.cs` (console) and `App.axaml.cs` (Avalonia GUI)

## Test plan
- [ ] `ThrottledEncryptionService` 5 unit tests — result pass-through, peak concurrency at 1, peak concurrency at 2, null guard, out-of-range guard
- [ ] Full test suite: 233 tests, 0 failures
- [ ] `dotnet build` — 0 warnings, 0 errors