### PR TITLE
fix(v1.1): validate language load and surface failure to caller

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,10 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        # Pinned: v1.0.113 regressed PR-base compare; v1.0.112 is the last
+        # known-good release. Must match the version on main so the action's
+        # workflow-validation step accepts PRs targeting any branch.
+        uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,9 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # Pinned: see comment in claude-code-review.yml. v1.0.112 is the
+        # last known-good release.
+        uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/src/EasySave/CLI/ConsoleUI.cs
+++ b/src/EasySave/CLI/ConsoleUI.cs
@@ -171,7 +171,15 @@ public sealed class ConsoleUI
             return;
         }
 
-        _lang.SetLanguage(lang);
+        // Reject the change if the resource file is missing/corrupt — without
+        // this guard the UI silently regressed to raw translation keys after
+        // confirming "Language set to fr."
+        if (!_lang.SetLanguage(lang))
+        {
+            Console.WriteLine(_lang.T("error.language_load_failed"));
+            return;
+        }
+
         Console.WriteLine(string.Format(_lang.T("confirm.language_changed"), lang));
     }
 }

--- a/src/EasySave/Resources/en.json
+++ b/src/EasySave/Resources/en.json
@@ -16,6 +16,7 @@
   "error.duplicate_job": "A job with this name already exists.",
   "error.empty_field": "Name, source path and target path are required.",
   "error.invalid_language": "Invalid language. Supported: en, fr.",
+  "error.language_load_failed": "Could not load translations for that language. Keeping the current one.",
   "error.source_not_found": "Source directory does not exist.",
   "error.execute_failed": "Execution error: {0}",
   "prompt.job_name": "Enter job name: ",

--- a/src/EasySave/Resources/fr.json
+++ b/src/EasySave/Resources/fr.json
@@ -16,6 +16,7 @@
   "error.duplicate_job": "Un job avec ce nom existe déjà.",
   "error.empty_field": "Le nom, le chemin source et le chemin cible sont obligatoires.",
   "error.invalid_language": "Langue invalide. Supportées : en, fr.",
+  "error.language_load_failed": "Impossible de charger les traductions pour cette langue. La langue actuelle est conservée.",
   "error.source_not_found": "Le dossier source n'existe pas.",
   "error.execute_failed": "Erreur d'exécution : {0}",
   "prompt.job_name": "Nom de la sauvegarde : ",

--- a/src/EasySave/Services/LanguageService.cs
+++ b/src/EasySave/Services/LanguageService.cs
@@ -9,35 +9,65 @@ public sealed class LanguageService
 
     public LanguageService(AppConfig config)
     {
-        _translations = LoadTranslations(config.Language);
+        // Try the configured language first; fall back to "en" if it fails so
+        // the UI never starts up showing raw translation keys when fr.json is
+        // missing or corrupt. Last resort is an empty dictionary — T(key)
+        // then returns the key, which is at least a debuggable signal.
+        if (TryLoad(config.Language, out var translations) ||
+            (config.Language != "en" && TryLoad("en", out translations)))
+        {
+            _translations = translations;
+            return;
+        }
+        _translations = new Dictionary<string, string>();
     }
 
     /// <summary>Returns the translated string for the given key, or the key itself if not found.</summary>
     public string T(string key) =>
         _translations.TryGetValue(key, out var value) ? value : key;
 
-    /// <summary>Switches the active language and reloads translations from disk.</summary>
-    public void SetLanguage(string lang)
+    /// <summary>
+    /// Switches the active language and reloads translations from disk.
+    /// Returns <c>true</c> on success. On failure (file missing, malformed
+    /// JSON, transient IO error) the previous translations are kept so the
+    /// caller can surface a localized error in the *current* language and
+    /// the UI does not regress to raw translation keys.
+    /// </summary>
+    public bool SetLanguage(string lang)
     {
-        _translations = LoadTranslations(lang);
+        if (!TryLoad(lang, out var translations))
+            return false;
+
+        _translations = translations;
+        return true;
     }
 
-    private static Dictionary<string, string> LoadTranslations(string lang)
+    // True only when the file exists, parses, and yields a non-empty dictionary.
+    // IOException / UnauthorizedAccessException are treated as transient load
+    // failures (same convention as AppConfig.Load in v1.0.1) — the caller
+    // decides whether to retry or fall back, which is why this method does
+    // not throw.
+    private static bool TryLoad(string lang, out Dictionary<string, string> translations)
     {
-        var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", $"{lang}.json");
+        translations = new Dictionary<string, string>();
 
+        var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", $"{lang}.json");
         if (!File.Exists(path))
-            return new Dictionary<string, string>();
+            return false;
 
         try
         {
             var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(json)
-                   ?? new Dictionary<string, string>();
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            if (parsed is null || parsed.Count == 0)
+                return false;
+
+            translations = parsed;
+            return true;
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
-            return new Dictionary<string, string>();
+            return false;
         }
     }
 }

--- a/tests/EasySave.Tests/LanguageServiceTests.cs
+++ b/tests/EasySave.Tests/LanguageServiceTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class LanguageServiceTests : IDisposable
+{
+    private readonly string _resourcesDir;
+    private readonly string _tempDir;
+    private readonly List<string> _createdLangFiles = new();
+
+    public LanguageServiceTests()
+    {
+        _resourcesDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources");
+        Directory.CreateDirectory(_resourcesDir);
+
+        _tempDir = Path.Combine(Path.GetTempPath(), $"easysave-lang-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        foreach (var f in _createdLangFiles)
+        {
+            try { File.Delete(f); } catch { /* best-effort cleanup */ }
+        }
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void SetLanguage_KnownLang_ReturnsTrueAndUpdatesTranslations()
+    {
+        // Use a synthetic locale code so the test does not depend on the
+        // shipped en.json / fr.json content evolving.
+        string langCode = "xx-good";
+        WriteLangFile(langCode, """{"hello": "world"}""");
+        var svc = new LanguageService(MakeConfig("en"));
+
+        Assert.True(svc.SetLanguage(langCode));
+        Assert.Equal("world", svc.T("hello"));
+    }
+
+    [Fact]
+    public void SetLanguage_MissingFile_ReturnsFalse_AndKeepsPreviousTranslations()
+    {
+        // Issue B1/B2: previously this regressed the UI to raw keys after
+        // confirming the language change. The current contract is: keep the
+        // previous translations and signal failure to the caller.
+        var svc = new LanguageService(MakeConfig("en"));
+        string before = svc.T("menu.title");
+
+        bool result = svc.SetLanguage("xx-missing-locale");
+
+        Assert.False(result);
+        Assert.Equal(before, svc.T("menu.title"));
+    }
+
+    [Fact]
+    public void SetLanguage_CorruptJson_ReturnsFalse_AndKeepsPreviousTranslations()
+    {
+        string langCode = "xx-corrupt";
+        WriteLangFile(langCode, "{ this is not valid json");
+        var svc = new LanguageService(MakeConfig("en"));
+        string before = svc.T("menu.title");
+
+        Assert.False(svc.SetLanguage(langCode));
+        Assert.Equal(before, svc.T("menu.title"));
+    }
+
+    [Fact]
+    public void SetLanguage_EmptyJson_ReturnsFalse()
+    {
+        // An empty {} dictionary has no translations to switch to — would
+        // surface every UI string as a raw key. Reject upfront.
+        string langCode = "xx-empty";
+        WriteLangFile(langCode, "{}");
+        var svc = new LanguageService(MakeConfig("en"));
+
+        Assert.False(svc.SetLanguage(langCode));
+    }
+
+    [Fact]
+    public void Constructor_PreferredLangMissing_FallsBackToEnglish()
+    {
+        // Operator misconfigures appsettings.json with a missing language
+        // file. The startup must not regress to raw keys; it falls back to
+        // the shipped en.json so the menu is still usable.
+        var svc = new LanguageService(MakeConfig("xx-missing-startup"));
+
+        Assert.Equal("=== EasySave ===", svc.T("menu.title"));
+    }
+
+    private void WriteLangFile(string lang, string content)
+    {
+        string path = Path.Combine(_resourcesDir, $"{lang}.json");
+        File.WriteAllText(path, content);
+        _createdLangFiles.Add(path);
+    }
+
+    private AppConfig MakeConfig(string language)
+    {
+        // AppConfig setters are init-only; round-trip a JSON payload through
+        // AppConfig.Load to populate the singleton.
+        string configPath = Path.Combine(_tempDir, "appsettings.json");
+        var payload = new { Language = language };
+        File.WriteAllText(configPath, JsonSerializer.Serialize(payload));
+        AppConfig.Load(configPath);
+        return AppConfig.Instance;
+    }
+}


### PR DESCRIPTION
## Summary

Audit findings B1 and B2 from the v1.1 review. The shipped behaviour silently regressed the menu to raw translation keys (\`menu.title\`, \`menu.option.add\`, …) when the configured language file was missing/corrupt, after confirming \"Language set to fr.\" — non-trivial to diagnose, and inconsistent with the typed-catch posture from PR #66 (v1.0.1).

| # | Where | Bug |
|---|---|---|
| **B1** | \`LanguageService.LoadTranslations\` | Swallowed \`JsonException\` and a missing file by returning an empty dict; \`IOException\` was not caught at all → crash on a locked file. |
| **B2** | \`ConsoleUI.ChangeLanguage\` | \`SetLanguage\` was \`void\`, no validation; UI confirmed the change while the dict was empty. |

## What changes

- \`LanguageService.SetLanguage\` returns \`bool\`. On failure it leaves the previous translations untouched so the next \`T(key)\` still returns localized text and the caller can surface a localized error in the *current* language.
- New \`TryLoad\` helper: rejects empty \`{}\` dictionaries, missing files, malformed JSON, and \`IOException\` / \`UnauthorizedAccessException\` (mirrors the v1.0.1 typed-catch fix on \`AppConfig.Load\`).
- Constructor falls back to \`\"en\"\` when the configured language fails so the UI never starts up in raw-keys mode.
- \`ConsoleUI.ChangeLanguage\` rejects the switch when \`SetLanguage\` returns \`false\` and prints \`error.language_load_failed\` (new localized key in \`en.json\` + \`fr.json\`).

## Test plan

- [x] \`dotnet build EasySave.sln\` — 0 erreur
- [x] \`dotnet test EasySave.sln\` — 77 / 77 passants (5 nouveaux)
- [x] \`dotnet format --verify-no-changes\` — clean

New tests in \`tests/EasySave.Tests/LanguageServiceTests.cs\`:
- \`SetLanguage_KnownLang_ReturnsTrueAndUpdatesTranslations\`
- \`SetLanguage_MissingFile_ReturnsFalse_AndKeepsPreviousTranslations\`
- \`SetLanguage_CorruptJson_ReturnsFalse_AndKeepsPreviousTranslations\`
- \`SetLanguage_EmptyJson_ReturnsFalse\`
- \`Constructor_PreferredLangMissing_FallsBackToEnglish\`

## Out of scope

- Other audit findings (B3 \`Program.cs\` exit code, B4 \`JsonDailyLogger\` typed catch, B5 \`AppConfig\` path validation) — held for separate PRs to keep this one focused on the i18n regression.
- The \`EasyLog.dll\` v1.0 public API stays frozen — no change there.