### PR TITLE
fix(v1.1): exit code on bad CLI args, typed catch in WriteAtomic, ensure config dirs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,9 +33,10 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        # Pinned: v1.0.113 regressed PR-base compare; v1.0.112 is the last
-        # known-good release. Must match the version on main so the action's
-        # workflow-validation step accepts PRs targeting any branch.
+        # Pinned: v1.0.113 (2026-05-06) regressed PR-base compare and started
+        # erroring with "404 ... compare/main...claude/pr-XXX" on every run.
+        # v1.0.112 is the last known-good release. Bump back to @v1 once the
+        # upstream regression is fixed.
         uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -103,8 +103,13 @@ public sealed class JsonDailyLogger : IDailyLogger
             File.WriteAllText(tmpPath, JsonSerializer.Serialize(entries, SerializerOptions));
             File.Move(tmpPath, filePath, overwrite: true);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            // Narrow catch: only IO-class failures get the tmp cleanup +
+            // rethrow path. OutOfMemoryException, StackOverflowException,
+            // and other programmer errors propagate untouched — same posture
+            // as BackupManager.ExecuteAll after the v1.1 typed-catch fix
+            // (PR #109). The tmp cleanup is best-effort.
             try { File.Delete(tmpPath); } catch { }
             throw;
         }

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -22,7 +22,10 @@ if (cliArgs.Length > 0)
     if (indices.Count == 0)
     {
         Console.Error.WriteLine(langService.T("error.invalid_selection"));
-        return;
+        // Non-zero exit code so wrapping shell scripts and CI pipelines
+        // can detect the bad invocation; the previous `return;` left the
+        // process exiting 0 alongside the stderr message.
+        Environment.Exit(1);
     }
 
     JobSelectionRunner.Execute(

--- a/src/EasySave/Services/AppConfig.cs
+++ b/src/EasySave/Services/AppConfig.cs
@@ -42,17 +42,52 @@ public sealed class AppConfig
         if (!File.Exists(path))
         {
             Instance = new AppConfig();
-            return;
+        }
+        else
+        {
+            try
+            {
+                var json = File.ReadAllText(path);
+                Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+            }
+            catch (Exception ex) when (ex is JsonException or IOException)
+            {
+                Instance = new AppConfig();
+            }
         }
 
+        EnsurePathsWritable(Instance);
+    }
+
+    // Best-effort directory creation so JsonDailyLogger / StateTracker /
+    // JobRepository never crash on the very first write with a cryptic
+    // DirectoryNotFoundException when the configured directory just hasn't
+    // been created yet. On unwritable paths we surface a stderr warning at
+    // startup so the operator sees the configuration problem before the
+    // first backup runs, rather than mid-job.
+    private static void EnsurePathsWritable(AppConfig config)
+    {
+        TryEnsureDir(config.LogDirectory, nameof(LogDirectory));
+        TryEnsureDir(Path.GetDirectoryName(config.StateFilePath), nameof(StateFilePath));
+        TryEnsureDir(Path.GetDirectoryName(config.JobsFilePath), nameof(JobsFilePath));
+    }
+
+    private static void TryEnsureDir(string? dir, string source)
+    {
+        if (string.IsNullOrEmpty(dir)) return;
         try
         {
-            var json = File.ReadAllText(path);
-            Instance = JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
+            Directory.CreateDirectory(dir);
         }
-        catch (Exception ex) when (ex is JsonException or IOException)
+        catch (Exception ex)
+            when (ex is IOException
+                or UnauthorizedAccessException
+                or PathTooLongException
+                or NotSupportedException
+                or ArgumentException)
         {
-            Instance = new AppConfig();
+            Console.Error.WriteLine(
+                $"[AppConfig] Could not create directory for {source} at '{dir}': {ex.Message}");
         }
     }
 }

--- a/tests/EasySave.Tests/AppConfigTests.cs
+++ b/tests/EasySave.Tests/AppConfigTests.cs
@@ -36,22 +36,76 @@ public class AppConfigTests : IDisposable
     [Fact]
     public void Load_ValidFile_AppliesValues()
     {
+        // Paths under _tempDir so the EnsurePathsWritable side-effect of
+        // Load (creates the dirs if missing) only touches our cleanup-tracked
+        // temp tree, not /tmp at large.
         var file = Path.Combine(_tempDir, "settings.json");
+        var customLog = Path.Combine(_tempDir, "custom-logs");
+        var customState = Path.Combine(_tempDir, "state-dir", "custom-state.json");
+        var customJobs = Path.Combine(_tempDir, "jobs-dir", "custom-jobs.json");
         var payload = new
         {
-            LogDirectory = "/tmp/custom-logs",
-            StateFilePath = "/tmp/custom-state.json",
-            JobsFilePath = "/tmp/custom-jobs.json",
+            LogDirectory = customLog,
+            StateFilePath = customState,
+            JobsFilePath = customJobs,
             Language = "fr"
         };
         File.WriteAllText(file, JsonSerializer.Serialize(payload));
 
         AppConfig.Load(file);
 
-        Assert.Equal("/tmp/custom-logs", AppConfig.Instance.LogDirectory);
-        Assert.Equal("/tmp/custom-state.json", AppConfig.Instance.StateFilePath);
-        Assert.Equal("/tmp/custom-jobs.json", AppConfig.Instance.JobsFilePath);
+        Assert.Equal(customLog, AppConfig.Instance.LogDirectory);
+        Assert.Equal(customState, AppConfig.Instance.StateFilePath);
+        Assert.Equal(customJobs, AppConfig.Instance.JobsFilePath);
         Assert.Equal("fr", AppConfig.Instance.Language);
+    }
+
+    [Fact]
+    public void Load_NonexistentDirs_AreCreatedAtStartup()
+    {
+        // B5: the first JsonDailyLogger / StateTracker / JobRepository write
+        // used to crash with DirectoryNotFoundException when the configured
+        // directories had not been created yet. Load now ensures them so the
+        // failure (if any) surfaces here, with a clear path in the message.
+        var file = Path.Combine(_tempDir, "settings.json");
+        var logDir = Path.Combine(_tempDir, "deep", "nested", "logs");
+        var stateDir = Path.Combine(_tempDir, "deep", "state");
+        var jobsDir = Path.Combine(_tempDir, "deep", "jobs");
+        var payload = new
+        {
+            LogDirectory = logDir,
+            StateFilePath = Path.Combine(stateDir, "state.json"),
+            JobsFilePath = Path.Combine(jobsDir, "jobs.json"),
+        };
+        File.WriteAllText(file, JsonSerializer.Serialize(payload));
+
+        AppConfig.Load(file);
+
+        Assert.True(Directory.Exists(logDir), "LogDirectory should be created.");
+        Assert.True(Directory.Exists(stateDir), "StateFilePath parent should be created.");
+        Assert.True(Directory.Exists(jobsDir), "JobsFilePath parent should be created.");
+    }
+
+    [Fact]
+    public void Load_UnwritablePath_DoesNotThrow()
+    {
+        // Same B5: an invalid / unwritable path must not crash the startup.
+        // The actual error surfaces later at the write site, but Load itself
+        // is best-effort and only logs to stderr.
+        var file = Path.Combine(_tempDir, "settings.json");
+        // Embedded null byte makes the path unconditionally invalid on
+        // every platform — Directory.CreateDirectory throws ArgumentException.
+        var bogus = Path.Combine(_tempDir, "bad\0path");
+        var payload = new
+        {
+            LogDirectory = bogus,
+            StateFilePath = Path.Combine(bogus, "state.json"),
+            JobsFilePath = Path.Combine(bogus, "jobs.json"),
+        };
+        File.WriteAllText(file, JsonSerializer.Serialize(payload));
+
+        var ex = Record.Exception(() => AppConfig.Load(file));
+        Assert.Null(ex);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Three remaining audit findings on top of B1+B2 (already in via #156).

| # | Sev | Where | Bug |
|---|---|---|---|
| **B3** | medium | \`Program.cs:25\` | \`return;\` after \`error.invalid_selection\` → exit code 0; wrapping shells / CI cannot detect a malformed CLI invocation. |
| **B4** | medium | \`JsonDailyLogger.WriteAtomic:106\` | \`catch (Exception)\` swallows OOM / StackOverflow alongside IO; inconsistent with the v1.1 typed-catch posture from PR #109. |
| **B5** | low | \`AppConfig.Load\` | No path validation → first JsonDailyLogger / StateTracker / JobRepository write crashes with a cryptic \`DirectoryNotFoundException\` instead of a clear startup signal. |

## What changes

- **B3**: \`Environment.Exit(1)\` on the invalid-selection path.
- **B4**: \`catch\` filter narrowed to \`IOException\` / \`UnauthorizedAccessException\`. Tmp cleanup + re-throw stays for IO; programmer errors propagate untouched.
- **B5**: New \`EnsurePathsWritable\` called at the end of \`Load\`. Best-effort \`Directory.CreateDirectory\` on \`LogDirectory\` + parent of \`StateFilePath\` and \`JobsFilePath\`. Failure logs to stderr but does not throw — the genuinely unwritable case still surfaces at the actual write site.

## Test plan

- [x] \`dotnet build EasySave.sln\` — 0 erreur
- [x] \`dotnet test EasySave.sln\` — 79 / 79 passants (2 nouveaux)
- [x] \`dotnet format --verify-no-changes\` — clean

New tests in \`tests/EasySave.Tests/AppConfigTests.cs\`:
- \`Load_NonexistentDirs_AreCreatedAtStartup\` — proves B5 fix
- \`Load_UnwritablePath_DoesNotThrow\` — proves the bogus-path tolerance

Existing \`Load_ValidFile_AppliesValues\` moved from \`/tmp/*\` paths to paths under the test temp dir so the new side-effect (dir creation) stays contained in the test cleanup.

## Out of scope

- B3 has no test (testing \`Environment.Exit\` requires spawning a process; out of scope for the cahier test suite).
- B4 has no test (simulating OOM in unit tests is unreliable). The narrowed \`catch\` is reviewed against the existing pattern in \`BackupManager.ExecuteAll\`.
- \`EasyLog.dll\` v1.0 public API stays frozen — no signature change.