### PR TITLE
fix(easylog): writer task survives ReadExisting failure (closes #155)

### DIFF
--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -131,7 +131,23 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
                     batch.Add(req);
                 }
 
-                FlushBatch(batch);
+                try
+                {
+                    FlushBatch(batch);
+                }
+                catch (Exception ex)
+                {
+                    // Belt-and-braces: FlushBatch is now expected to swallow
+                    // per-group failures itself (issue #155), but any code
+                    // path that ever re-introduces a throw here would kill
+                    // the writer task and hang every future Append on its
+                    // TaskCompletionSource. Catch + surface to surviving
+                    // acks so the writer stays alive.
+                    foreach (var req in batch)
+                    {
+                        req.Ack.TrySetException(ex);
+                    }
+                }
             }
         }
         finally
@@ -163,34 +179,46 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
         foreach (var group in batch.GroupBy(r => r.FilePath, StringComparer.OrdinalIgnoreCase))
         {
             string filePath = group.Key;
-            if (!_cachePerDay.TryGetValue(filePath, out var entries))
-            {
-                entries = ReadExisting(filePath);
-                _cachePerDay[filePath] = entries;
-            }
 
+            // Wrap the whole per-group body. Pre-fix (issue #155), only the
+            // WriteAtomic try/catch was here, and a throw from ReadExisting
+            // (transient IOException from AV / OneDrive on the first append
+            // of the day) escaped FlushBatch, killed the writer task, and
+            // left every future Append blocked on its TaskCompletionSource.
             int addedThisGroup = 0;
-            foreach (var req in group)
-            {
-                entries.Add(req.Entry);
-                addedThisGroup++;
-            }
-
+            List<LogEntry>? entries = null;
             try
             {
+                if (!_cachePerDay.TryGetValue(filePath, out entries))
+                {
+                    entries = ReadExisting(filePath);
+                    _cachePerDay[filePath] = entries;
+                }
+
+                foreach (var req in group)
+                {
+                    entries.Add(req.Entry);
+                    addedThisGroup++;
+                }
+
                 WriteAtomic(filePath, entries);
+                foreach (var req in group) req.Ack.TrySetResult();
             }
             catch (Exception ex)
             {
                 // Roll back the in-memory cache so the next flush retries
-                // the same entries cleanly, then surface the error to every
-                // caller in this group.
-                entries.RemoveRange(entries.Count - addedThisGroup, addedThisGroup);
+                // the same entries cleanly. addedThisGroup is 0 when the
+                // throw came from ReadExisting (entries was never mutated)
+                // or when entries is still null (initial assignment failed).
+                if (entries is not null && addedThisGroup > 0)
+                {
+                    entries.RemoveRange(entries.Count - addedThisGroup, addedThisGroup);
+                }
+                // Surface the failure to every caller in this group and let
+                // the next foreach iteration handle the next day file —
+                // the writer task stays alive.
                 foreach (var req in group) req.Ack.TrySetException(ex);
-                continue;
             }
-
-            foreach (var req in group) req.Ack.TrySetResult();
         }
     }
 

--- a/tests/EasySave.Tests.V2/JsonDailyLoggerConcurrencyTests.cs
+++ b/tests/EasySave.Tests.V2/JsonDailyLoggerConcurrencyTests.cs
@@ -149,4 +149,83 @@ public class JsonDailyLoggerConcurrencyTests : IDisposable
         if (dash < 0) return -1;
         return int.Parse(sourceFile.AsSpan(dash + 1, dot - dash - 1));
     }
+
+    // ── Regression: issue #155 ──────────────────────────────────────────────
+    //
+    // Pre-fix, ReadExisting could throw IOException (transient AV / OneDrive /
+    // log-viewer read lock on the first append of the day) outside FlushBatch's
+    // only try/catch. The exception killed the writer task; every subsequent
+    // Append then hung forever on its TaskCompletionSource.
+    //
+    // Windows-only because Unix file locks are advisory: File.ReadAllText is
+    // not blocked by FileShare.None on Linux / macOS, so the IOException never
+    // fires and the test cannot reproduce the bug.
+
+    [Fact]
+    public async Task Append_PropagatesIOException_WhenDayFileLocked_AndDoesNotHang()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dayFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        File.WriteAllText(dayFile, "[]");
+
+        using var locker = new FileStream(dayFile, FileMode.Open, FileAccess.Read, FileShare.None);
+        using var logger = new JsonDailyLogger(_tempDir);
+
+        var entry = new LogEntry { Timestamp = DateTime.Now.ToString("o"), JobName = "Foo" };
+
+        // The call must finish (surface the IOException) within a couple
+        // seconds — pre-fix it hung forever because the writer task was dead.
+        var task = Task.Run(() => logger.Append(entry));
+        var ex = await Assert.ThrowsAsync<IOException>(() => task.WaitAsync(TimeSpan.FromSeconds(2)));
+        Assert.NotNull(ex);
+    }
+
+    [Fact]
+    public async Task Append_KeepsWorking_AfterTransientLockReleased()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var dayFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        File.WriteAllText(dayFile, "[]");
+        using var logger = new JsonDailyLogger(_tempDir);
+
+        // First append while locked — must throw, not hang. The writer task
+        // must survive so the second append can succeed.
+        using (new FileStream(dayFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            var first = Task.Run(() => logger.Append(new LogEntry { JobName = "during-lock", FileTransferTimeMs = 1 }));
+            await Assert.ThrowsAsync<IOException>(() => first.WaitAsync(TimeSpan.FromSeconds(2)));
+        }
+
+        // Lock released. Next Append must reach disk normally.
+        logger.Append(new LogEntry { JobName = "after-lock", FileTransferTimeMs = 2 });
+        logger.Dispose();
+
+        var raw = File.ReadAllText(dayFile);
+        var entries = JsonSerializer.Deserialize<List<LogEntry>>(raw)!;
+        Assert.Contains(entries, e => e.JobName == "after-lock");
+    }
+
+    [Fact]
+    public async Task Append_DoesNotStrandBatchSiblings_WhenOneGroupFailsToLoad()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        // Pre-fix, a failing group killed the whole writer task and any
+        // subsequent Append in the same process hung forever waiting on its
+        // TaskCompletionSource. Fire two consecutive locked-day Appends and
+        // assert both surface the IOException — the writer survived the
+        // first failure to serve the second one.
+        var dayFile = Path.Combine(_tempDir, $"{DateTime.Now:yyyy-MM-dd}.json");
+        File.WriteAllText(dayFile, "[]");
+        using var locker = new FileStream(dayFile, FileMode.Open, FileAccess.Read, FileShare.None);
+        using var logger = new JsonDailyLogger(_tempDir);
+
+        var first = Task.Run(() => logger.Append(new LogEntry { JobName = "first", FileTransferTimeMs = 1 }));
+        await Assert.ThrowsAsync<IOException>(() => first.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        var second = Task.Run(() => logger.Append(new LogEntry { JobName = "second", FileTransferTimeMs = 2 }));
+        await Assert.ThrowsAsync<IOException>(() => second.WaitAsync(TimeSpan.FromSeconds(2)));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #155. PR #146's channel-based writer had a single \`try/catch\` around \`WriteAtomic\`. \`ReadExisting\` could throw (transient \`IOException\` from AV / OneDrive / log-viewer read lock on the first append of the day, or \`UnauthorizedAccessException\`, \`PathTooLongException\`) **outside** that try block. The exception escaped \`FlushBatch\`, exited the writer loop, killed the \`Task\` — and every future \`Append\` then blocked forever on its \`TaskCompletionSource\` because the channel writer was still open (TryWrite succeeded) but no one was reading or signaling.

Three cumulative consequences, all reproducible:

1. Acks in the failing batch group went stranded → callers hung on \`ack.Task.GetAwaiter().GetResult()\`.
2. The writer task ended; no auto-restart.
3. Every future \`Append\` queued cleanly but hung forever.

Engine impact: \`BackupManager.RunJob\` worker stuck → \`state.json\` frozen \`Active\` → operator must SIGKILL.

## Fix

Two-layer defence in \`src/EasyLog/JsonDailyLogger.cs\`:

1. **\`FlushBatch\`** — wrap the whole per-group body in \`try/catch\`. Failure to load entries (\`ReadExisting\`), to mutate the list, or to write atomically all surface to the group's \`Acks\` via \`TrySetException\` and the loop continues to the next day-file group. Cache rollback only fires when entries were actually appended.
2. **\`WriterLoopAsync\`** — belt-and-braces \`try/catch\` around the per-batch \`FlushBatch\` call. Even if a future code path reintroduces a leak from \`FlushBatch\` (refactor regression), the catch surfaces the failure to every Ack in the batch instead of killing the writer.

## Tests

Three new tests in \`tests/EasySave.Tests.V2/JsonDailyLoggerConcurrencyTests.cs\`, all guarded by \`OperatingSystem.IsWindows()\` since POSIX file locks are advisory and do not reproduce the read-block:

- \`Append_PropagatesIOException_WhenDayFileLocked_AndDoesNotHang\` — exact issue repro: pre-existing day file held by \`FileStream(FileShare.None)\`, \`Append\` must throw \`IOException\` within 2 s, not hang.
- \`Append_KeepsWorking_AfterTransientLockReleased\` — first \`Append\` throws while locked, second \`Append\` succeeds after the lock is released. Proves the writer task survived the first failure.
- \`Append_DoesNotStrandBatchSiblings_WhenOneGroupFailsToLoad\` — two consecutive failing \`Appends\` both surface \`IOException\` instead of the second hanging on a dead writer.

The existing \`FourJobs_ThousandEntriesEach\` stress test does not exercise this path — it starts with an empty temp dir so \`ReadExisting\` returns immediately on \`!File.Exists\` and never hits the offending \`File.ReadAllText\` line.

## Test plan

- [x] \`dotnet build EasySave.sln\` — 0 erreur
- [x] \`dotnet test EasySave.sln\` — 231 / 231 passants (3 nouveaux)
- [x] \`dotnet format --verify-no-changes\` — clean
- [ ] CI on Windows runner (if applicable) — the new tests target the Windows-only path

## Out of scope

The class-level Append docstring already promises "blocks until flushed (or the writer reports an error)". The fix re-aligns the behaviour with that contract — no doc change needed.

EasyLog.dll v1.0 public API stays frozen. Only impl-level changes.