### PR TITLE
feat(v3): wire TcpRemoteConsoleServer + event-bus bridges into the GUI

### DIFF
--- a/docs/recettes/v3-remote-console.md
+++ b/docs/recettes/v3-remote-console.md
@@ -48,10 +48,20 @@ second machine on the LAN.
 - Configure at least one backup job that runs long enough to interact with —
   e.g. ≥ 200 small files or ~50 MB to copy, so Pause / Play windows are
   observable. Use the v2 GUI Jobs view to create it.
-- Pre-condition: the wiring of `TcpRemoteConsoleServer.StartAsync` in
-  `App.OnFrameworkInitializationCompleted` must be merged. The class itself,
-  the bridges, and the unit tests are already in. If the wiring task is still
-  open, this recette runs against a local mock or is held until wiring lands.
+- Wiring is live since the V3 wire-remote-console PR: `App.axaml.cs`
+  resolves `IEventBus` / `IRemoteConsoleServer` / `StateTrackerEventBridge`
+  / `RemoteConsoleBroadcastBridge` from the DI container and starts the
+  TCP listener + bridges when `RemoteConsoleEnabled` is true. Disabling
+  the flag in `appsettings.json` keeps the GUI's startup unchanged.
+
+### Known limitation — scenario 4
+
+The adapter has no dedicated `Stop` API yet. The `Stop` button in the
+client routes through `PauseJob` with reason `"Stopped"`, so the job
+halts at the next file boundary but `state.json` reports `"Paused"`
+(not `"Inactive"`) until a follow-up exposes a true Stop transition.
+Expect step 4.2 to be a partial pass; track via the issue raised in
+the next iteration.
 
 ## Scenarios
 

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -2,7 +2,10 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using EasyLog;
+using EasySave.Infrastructure.Events;
+using EasySave.Infrastructure.Remote;
 using EasySave.Services;
+using EasySave.Shared;
 using EasySave.UI.Services;
 using EasySave.UI.ViewModels;
 using EasySave.UI.Views;
@@ -13,6 +16,11 @@ namespace EasySave.UI;
 public partial class App : Application
 {
     public static IServiceProvider? Services { get; private set; }
+
+    // Cancellation source for the in-process TCP server. Cancelled in
+    // DisposeServices so the listener stops accepting and exits its loop
+    // before the process exits.
+    private static CancellationTokenSource? _remoteServerCts;
 
     public override void Initialize()
     {
@@ -58,6 +66,19 @@ public partial class App : Application
         }
 
         Services.GetRequiredService<SchedulerDispatchService>().Start();
+
+        // V3 remote console wiring. Gated on appsettings.json so the GUI
+        // boot stays minimal for operators who don't need a remote operator
+        // station. When enabled:
+        //   - StateTrackerEventBridge publishes JobProgress events on the bus,
+        //   - RemoteConsoleBroadcastBridge forwards them to every connected
+        //     client over TCP,
+        //   - the server's CommandReceived event routes Pause/Play/Stop into
+        //     the BackupManagerAdapter.
+        if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
+        {
+            StartRemoteConsole(Services);
+        }
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -114,11 +135,115 @@ public partial class App : Application
         services.AddSingleton<ISchedulerService, SchedulerService>();
         services.AddSingleton<SchedulerDispatchService>();
 
+        // V3 event-bus + bridges. Registered unconditionally (cheap to
+        // construct, no thread or socket allocated until Start is called);
+        // the actual server + bridge startup is gated by
+        // RemoteConsoleEnabled in OnFrameworkInitializationCompleted.
+        services.AddSingleton<IEventBus>(_ => new ChannelEventBus());
+        services.AddSingleton<IRemoteConsoleServer>(sp =>
+            new TcpRemoteConsoleServer(sp.GetRequiredService<IDailyLogger>()));
+        services.AddSingleton(sp =>
+            new StateTrackerEventBridge(StateTracker.Instance, sp.GetRequiredService<IEventBus>()));
+        services.AddSingleton(sp =>
+            new RemoteConsoleBroadcastBridge(
+                sp.GetRequiredService<IEventBus>(),
+                sp.GetRequiredService<IRemoteConsoleServer>()));
+
         services.AddSingleton<MainWindowViewModel>();
+    }
+
+    private static void StartRemoteConsole(IServiceProvider services)
+    {
+        var server = services.GetRequiredService<IRemoteConsoleServer>();
+        var backup = services.GetRequiredService<IBackupManagerAdapter>();
+        var logger = services.GetRequiredService<IDailyLogger>();
+
+        server.CommandReceived += cmd => HandleRemoteCommandAsync(cmd, backup, logger);
+
+        services.GetRequiredService<StateTrackerEventBridge>().Start();
+        services.GetRequiredService<RemoteConsoleBroadcastBridge>().Start();
+
+        _remoteServerCts = new CancellationTokenSource();
+        // Fire-and-forget: the listener loop runs until the CTS is cancelled
+        // in DisposeServices. Surface unexpected exits to Trace so they don't
+        // disappear silently.
+        _ = server.StartAsync(AppConfig.Instance.Settings.RemoteConsolePort, _remoteServerCts.Token)
+            .ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    System.Diagnostics.Trace.TraceError(
+                        $"[App] Remote console server stopped with error: {t.Exception?.GetBaseException().Message}");
+                }
+            }, TaskScheduler.Default);
+    }
+
+    private static Task HandleRemoteCommandAsync(CommandDto cmd, IBackupManagerAdapter backup, IDailyLogger logger)
+    {
+        // Route the command into the same adapter the GUI uses, so a remote
+        // operator sees identical job behaviour to a local one.
+        try
+        {
+            switch (cmd.Action)
+            {
+                case CommandType.Pause:
+                    backup.PauseJob(cmd.JobName, "RemoteCommand");
+                    break;
+                case CommandType.Play:
+                    // ResumeJob is a no-op if the job is not paused; the
+                    // follow-up RunJobAsync is a no-op if the job is already
+                    // running. Together they cover both "resume" and "start
+                    // from idle" without the caller having to inspect state.
+                    backup.ResumeJob(cmd.JobName);
+                    _ = backup.RunJobAsync(cmd.JobName);
+                    break;
+                case CommandType.Stop:
+                    // No native Stop on the adapter yet — Pause with a
+                    // dedicated reason is the closest available behaviour:
+                    // the job halts at the next file boundary. The engine
+                    // still marks the job Paused (not Inactive) in
+                    // state.json; the recette flags this as a known gap.
+                    backup.PauseJob(cmd.JobName, "Stopped");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Never let a command handler fail back to the TCP server's
+            // dispatch loop — the server isolates per-handler exceptions,
+            // but losing the audit log line would be worse than the throw.
+            System.Diagnostics.Trace.TraceError(
+                $"[App] Remote command {cmd.Action} on '{cmd.JobName}' failed: {ex.Message}");
+        }
+
+        logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = cmd.JobName,
+            SourceFile = cmd.SourceIp ?? string.Empty,
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+            EventType = LogEvent.CommandReceived,
+        });
+
+        return Task.CompletedTask;
     }
 
     private static void DisposeServices()
     {
+        // Stop the TCP listener first so no new commands land while we are
+        // tearing down the adapter / bridges they would forward to.
+        _remoteServerCts?.Cancel();
+        try { Services?.GetService<IRemoteConsoleServer>()?.StopAsync().GetAwaiter().GetResult(); }
+        catch { /* shutdown best-effort */ }
+        _remoteServerCts?.Dispose();
+        _remoteServerCts = null;
+
+        Services?.GetService<RemoteConsoleBroadcastBridge>();  // resolved already, no Stop API
+        Services?.GetService<StateTrackerEventBridge>()?.Dispose();
+        (Services?.GetService<IEventBus>() as IDisposable)?.Dispose();
+
         Services?.GetService<SchedulerDispatchService>()?.Dispose();
         Services?.GetService<IBackupManagerAdapter>()?.Dispose();
         Services?.GetService<BusinessWatcherService>()?.Dispose();

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -195,7 +195,19 @@ public partial class App : Application
                     // running. Together they cover both "resume" and "start
                     // from idle" without the caller having to inspect state.
                     backup.ResumeJob(cmd.JobName);
-                    _ = backup.RunJobAsync(cmd.JobName);
+                    // Observe the task so async failures (job not found,
+                    // orchestrator throw) surface to Trace — same posture as
+                    // StartAsync above. Without this continuation an async
+                    // fault disappears silently with no audit signal.
+                    _ = backup.RunJobAsync(cmd.JobName)
+                        .ContinueWith(t =>
+                        {
+                            if (t.IsFaulted)
+                            {
+                                System.Diagnostics.Trace.TraceError(
+                                    $"[App] RunJobAsync('{cmd.JobName}') from remote Play failed: {t.Exception?.GetBaseException().Message}");
+                            }
+                        }, TaskScheduler.Default);
                     break;
                 case CommandType.Stop:
                     // No native Stop on the adapter yet — Pause with a
@@ -240,7 +252,9 @@ public partial class App : Application
         _remoteServerCts?.Dispose();
         _remoteServerCts = null;
 
-        Services?.GetService<RemoteConsoleBroadcastBridge>();  // resolved already, no Stop API
+        // RemoteConsoleBroadcastBridge has no Stop/Dispose — the bus it
+        // subscribed to is disposed below, which drops the consumer task
+        // and releases the subscription transitively.
         Services?.GetService<StateTrackerEventBridge>()?.Dispose();
         (Services?.GetService<IEventBus>() as IDisposable)?.Dispose();
 


### PR DESCRIPTION
## Summary

Closes the wiring gap behind the V3 remote-console recette (PR #154 doc). The server, the event bus, and both bridges already existed as classes with their unit tests merged (PRs #142, #144) — but they were never instantiated by the running GUI. Result: a remote console could **connect** but no JobProgress events flowed, and Pause/Play/Stop landed on a stub orchestrator that did nothing on the real jobs.

## What changes

\`src/EasySave.UI/App.axaml.cs\`:

1. **\`ConfigureServices\`** — register \`IEventBus\` (\`ChannelEventBus\`), \`IRemoteConsoleServer\` (\`TcpRemoteConsoleServer\`), \`StateTrackerEventBridge\`, \`RemoteConsoleBroadcastBridge\` as singletons. All cheap to construct, no socket bound until \`Start\`.
2. **\`OnFrameworkInitializationCompleted\`** — when \`AppSettings.RemoteConsoleEnabled\` is true: hook \`CommandReceived\` to the \`BackupManagerAdapter\`, \`Start()\` both bridges, and launch the TCP listener in the background with a dedicated CTS. Faulted listener exits surface to \`Trace\`. Server stays off otherwise.
3. **\`DisposeServices\`** — stop the listener first (Cancel CTS + await \`StopAsync\`) so no command lands on a half-torn adapter, then dispose the bridges + bus before the rest of the graph.

## Command routing (Pause / Play / Stop)

| CommandType | Behaviour |
|---|---|
| \`Pause\` | \`adapter.PauseJob(jobName, \"RemoteCommand\")\` |
| \`Play\` | \`adapter.ResumeJob(jobName)\` then \`adapter.RunJobAsync(jobName)\`. Both no-op on the wrong-state case, so the sequence covers \"resume paused\" AND \"start idle\" without state inspection. |
| \`Stop\` | \`adapter.PauseJob(jobName, \"Stopped\")\` as best-effort — the adapter has no native Stop yet. The job halts at the next file boundary but state.json shows \`\"Paused\"\` (not \`\"Inactive\"\`). Documented as a known limitation in the recette. |

Per-handler exceptions are caught + Trace'd so a one-off failure cannot poison the TCP server's dispatch loop. Every command still hits the daily log with \`LogEvent.CommandReceived\` and the client IP (\`SourceFile = cmd.SourceIp\`).

## Recette doc update

\`docs/recettes/v3-remote-console.md\`:
- Removed the \"pre-condition: wiring task must merge first\" line.
- Added a \"known limitation\" block for scenario 4 (Stop → Paused).

## Test plan

- [x] \`dotnet build EasySave.sln\` — 0 erreur
- [x] \`dotnet test EasySave.sln\` — 231 / 231 passants (no test change)
- [x] \`dotnet format --verify-no-changes\` — clean
- [ ] Manual: run the v3 recette (scenarios 1-3, 5, 6 expected to pass; scenario 4 partial per the known-limitation note; scenario 7 LAN if a second machine is available).

## Out of scope

- Dedicated Stop transition on \`IBackupManagerAdapter\` — separate PR.
- CLI wiring in \`src/EasySave/Program.cs\` still uses \`ParallelBackupOrchestratorStub\`. The recette explicitly targets the GUI as the engine (\`dotnet run --project src/EasySave.UI\`), so the CLI path keeps its current shape.