### PR TITLE
fix(remote): log handler exceptions in FireCommandReceivedAsync

### DIFF
--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -133,7 +134,11 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         foreach (var h in handler.GetInvocationList().Cast<Func<CommandDto, Task>>())
         {
             try { await h(cmd); }
-            catch { /* isolate faulted subscribers */ }
+            catch (Exception ex)
+            {
+                Trace.TraceError("[TcpRemoteConsoleServer] Handler for {0} on '{1}' failed: {2}",
+                    cmd.Action, cmd.JobName, ex.Message);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #167

## Summary
- Replace silent `catch { }` in `FireCommandReceivedAsync` with `catch (Exception ex)` + `Trace.TraceError`
- Handler isolation is preserved — one faulted subscriber still cannot stop the others
- Operator can now diagnose failed remote commands (e.g. Pause on a stale job name) via Trace output

## Test plan
- [ ] Build: 0 warnings, 0 errors
- [ ] Full suite: 233 tests, 0 failures