### PR TITLE
fix(ui): narrow PollState catch and trace JSON deserialize failures

### DIFF
--- a/src/EasySave.UI/Services/BackupManagerAdapter.cs
+++ b/src/EasySave.UI/Services/BackupManagerAdapter.cs
@@ -169,14 +169,19 @@ public sealed class BackupManagerAdapter : IBackupManagerAdapter
         catch (IOException) { /* transient — next poll will retry */ }
         catch (JsonException ex)
         {
-            // Not transient: a corrupt state.json keeps failing on every
-            // subsequent poll until the engine rewrites it. Trace the
-            // failure so the operator has a diagnostic — quarantine is
-            // already handled at the write side in StateTracker
-            // .ReadCurrentEntries via FileHelpers.QuarantineCorruptedFile,
-            // so duplicating it here is unnecessary.
+            // Corrupt state.json keeps failing every poll until the engine rewrites it; quarantine happens write-side in StateTracker.ReadCurrentEntries.
             System.Diagnostics.Trace.TraceWarning(
                 $"[BackupManagerAdapter] state.json deserialize failed: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            // Backstop: an exception escaping a System.Threading.Timer
+            // callback in .NET 8 terminates the process. Cover the ACL /
+            // unknown-exception case (e.g. UnauthorizedAccessException is
+            // a SystemException, not an IOException) so the poll loop and
+            // the GUI stay alive.
+            System.Diagnostics.Trace.TraceWarning(
+                $"[BackupManagerAdapter] PollState unexpected error: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/src/EasySave.UI/Services/BackupManagerAdapter.cs
+++ b/src/EasySave.UI/Services/BackupManagerAdapter.cs
@@ -166,7 +166,18 @@ public sealed class BackupManagerAdapter : IBackupManagerAdapter
             foreach (var entry in entries)
                 StateUpdated?.Invoke(this, entry);
         }
-        catch { /* transient I/O error — next poll will retry */ }
+        catch (IOException) { /* transient — next poll will retry */ }
+        catch (JsonException ex)
+        {
+            // Not transient: a corrupt state.json keeps failing on every
+            // subsequent poll until the engine rewrites it. Trace the
+            // failure so the operator has a diagnostic — quarantine is
+            // already handled at the write side in StateTracker
+            // .ReadCurrentEntries via FileHelpers.QuarantineCorruptedFile,
+            // so duplicating it here is unnecessary.
+            System.Diagnostics.Trace.TraceWarning(
+                $"[BackupManagerAdapter] state.json deserialize failed: {ex.Message}");
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
Closes #168.

## Problem

`BackupManagerAdapter.PollState` (`src/EasySave.UI/Services/BackupManagerAdapter.cs:157-170`) wrapped the entire read + deserialize in a single bare `catch`. The comment treated every exception as a transient I/O error, but a `JsonException` from a corrupted `state.json` is **not** transient — every subsequent poll keeps throwing on the same content until the engine rewrites the file, and the GUI never receives a `StateUpdated` event in the meantime. Progress bars freeze with no signal to the operator.

## Fix

Split the bare catch into two typed handlers, as suggested in the issue:

- `catch (IOException)` stays silent — transient by nature; the next 300 ms tick retries cleanly.
- `catch (JsonException ex)` now emits `System.Diagnostics.Trace.TraceWarning` so the operator has a diagnostic in stderr / DebugView when `state.json` is hand-corrupted.

Quarantine is **not** duplicated on the read side — `StateTracker.ReadCurrentEntries` already calls `FileHelpers.QuarantineCorruptedFile` on `JsonException` at the write side, so the engine recovers as soon as it writes again. The adapter only needs the missing observability.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] Issue reproduction: hand-corrupt `state.json` to `{ not valid`. Without the fix the GUI freezes silently. With the fix, a `Trace.TraceWarning` is emitted on every poll until the engine rewrites the file. The first valid rewrite from any subsequent `StateTracker.Update` clears the warning automatically.
- [ ] No new test — the issue explicitly notes testing `Trace` output is overkill for a 5-line observability fix.

## Zone

Dev4 — CLI/UI (`BackupManagerAdapter.cs` is the UI adapter layer). Bug raised by Julian; cross-zone fix.