### PR TITLE
fix(remote): cap ReadLineAsync at 64 KB to prevent OOM on oversized client lines

### DIFF
--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -136,19 +136,16 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
     private static async Task<string?> ReadLineBoundedAsync(StreamReader reader, int max, CancellationToken ct)
     {
         var sb = new StringBuilder();
-        var buf = new char[256];
+        var buf = new char[1];
         while (!ct.IsCancellationRequested)
         {
             int n = await reader.ReadAsync(buf.AsMemory(), ct);
             if (n == 0) return sb.Length == 0 ? null : sb.ToString();
-            for (var i = 0; i < n; i++)
-            {
-                if (buf[i] == '\n') return sb.ToString();
-                if (buf[i] == '\r') continue;
-                if (sb.Length >= max)
-                    throw new InvalidDataException($"Line over {max} chars — client dropped");
-                sb.Append(buf[i]);
-            }
+            if (buf[0] == '\n') return sb.ToString();
+            if (buf[0] == '\r') continue;
+            if (sb.Length >= max)
+                throw new InvalidDataException($"Line over {max} chars — client dropped");
+            sb.Append(buf[0]);
         }
         return null;
     }

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -109,7 +109,8 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
             while (!ct.IsCancellationRequested)
             {
                 string? line;
-                try { line = await reader.ReadLineAsync(ct); }
+                try { line = await ReadLineBoundedAsync(reader, MaxLineLengthBytes, ct); }
+                catch (InvalidDataException) { break; }
                 catch (OperationCanceledException) { break; }
                 if (line is null) break;
 
@@ -124,6 +125,28 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         }
         catch { /* network disconnect */ }
         finally { RemoveClient(key); }
+    }
+
+    private const int MaxLineLengthBytes = 64 * 1024;
+
+    // Reads one line from reader, capping at max chars. Returns null on EOF.
+    // Throws InvalidDataException when a line exceeds the cap so the caller
+    // can drop the misbehaving client without buffering the full payload.
+    private static async Task<string?> ReadLineBoundedAsync(StreamReader reader, int max, CancellationToken ct)
+    {
+        var sb = new StringBuilder();
+        var buf = new char[1];
+        while (!ct.IsCancellationRequested)
+        {
+            int n = await reader.ReadAsync(buf.AsMemory(), ct);
+            if (n == 0) return sb.Length == 0 ? null : sb.ToString();
+            if (buf[0] == '\n') return sb.ToString();
+            if (buf[0] == '\r') continue;
+            if (sb.Length >= max)
+                throw new InvalidDataException($"Line over {max} bytes — client dropped");
+            sb.Append(buf[0]);
+        }
+        return null;
     }
 
     private async Task FireCommandReceivedAsync(CommandDto cmd)

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -109,7 +109,7 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
             while (!ct.IsCancellationRequested)
             {
                 string? line;
-                try { line = await ReadLineBoundedAsync(reader, MaxLineLengthBytes, ct); }
+                try { line = await ReadLineBoundedAsync(reader, MaxLineLengthChars, ct); }
                 catch (InvalidDataException) { break; }
                 catch (OperationCanceledException) { break; }
                 if (line is null) break;
@@ -127,24 +127,28 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
         finally { RemoveClient(key); }
     }
 
-    private const int MaxLineLengthBytes = 64 * 1024;
+    // Cap is in characters (JSON commands are ASCII-only, so chars == bytes in practice).
+    private const int MaxLineLengthChars = 64 * 1024;
 
-    // Reads one line from reader, capping at max chars. Returns null on EOF.
+    // Reads one line from reader, capping at max characters. Returns null on EOF.
     // Throws InvalidDataException when a line exceeds the cap so the caller
     // can drop the misbehaving client without buffering the full payload.
     private static async Task<string?> ReadLineBoundedAsync(StreamReader reader, int max, CancellationToken ct)
     {
         var sb = new StringBuilder();
-        var buf = new char[1];
+        var buf = new char[256];
         while (!ct.IsCancellationRequested)
         {
             int n = await reader.ReadAsync(buf.AsMemory(), ct);
             if (n == 0) return sb.Length == 0 ? null : sb.ToString();
-            if (buf[0] == '\n') return sb.ToString();
-            if (buf[0] == '\r') continue;
-            if (sb.Length >= max)
-                throw new InvalidDataException($"Line over {max} bytes — client dropped");
-            sb.Append(buf[0]);
+            for (var i = 0; i < n; i++)
+            {
+                if (buf[i] == '\n') return sb.ToString();
+                if (buf[i] == '\r') continue;
+                if (sb.Length >= max)
+                    throw new InvalidDataException($"Line over {max} chars — client dropped");
+                sb.Append(buf[i]);
+            }
         }
         return null;
     }

--- a/tests/EasySave.Tests.V2/TcpRemoteConsoleServerTests.cs
+++ b/tests/EasySave.Tests.V2/TcpRemoteConsoleServerTests.cs
@@ -214,12 +214,18 @@ public class TcpRemoteConsoleServerTests
         await stream.FlushAsync();
 
         // The server must drop the connection: drain until EOF.
+        // Catch IOException — the server may issue a TCP RST instead of a clean FIN,
+        // which surfaces as an IOException on the client side; both mean disconnected.
         // WaitAsync throws TimeoutException if the server does not close within 3 s.
         var buf = new byte[256];
         var drainTask = Task.Run(async () =>
         {
-            int n;
-            while ((n = await stream.ReadAsync(buf)) > 0) { }
+            try
+            {
+                int n;
+                while ((n = await stream.ReadAsync(buf)) > 0) { }
+            }
+            catch (IOException) { /* RST from server — connection dropped as expected */ }
         });
         await drainTask.WaitAsync(TimeSpan.FromSeconds(3));
 

--- a/tests/EasySave.Tests.V2/TcpRemoteConsoleServerTests.cs
+++ b/tests/EasySave.Tests.V2/TcpRemoteConsoleServerTests.cs
@@ -193,6 +193,39 @@ public class TcpRemoteConsoleServerTests
         Assert.Null(line2);
     }
 
+    [Fact]
+    public async Task HandleClient_DropsConnection_WhenLineExceedsCap()
+    {
+        int port = GetFreePort();
+        var server = new TcpRemoteConsoleServer(NullLogger.Instance);
+        using var serverCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        _ = server.StartAsync(port, serverCts.Token);
+
+        await WaitForListenerAsync(port);
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        var stream = client.GetStream();
+
+        // Send 70 KB without a newline — exceeds the 64 KB cap.
+        var payload = new byte[70 * 1024];
+        Array.Fill(payload, (byte)'A');
+        await stream.WriteAsync(payload);
+        await stream.FlushAsync();
+
+        // The server must drop the connection: drain until EOF.
+        // WaitAsync throws TimeoutException if the server does not close within 3 s.
+        var buf = new byte[256];
+        var drainTask = Task.Run(async () =>
+        {
+            int n;
+            while ((n = await stream.ReadAsync(buf)) > 0) { }
+        });
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(3));
+
+        await server.StopAsync();
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
 
     private static int GetFreePort()


### PR DESCRIPTION
Fixes #165

## Summary
- Replace unbounded `StreamReader.ReadLineAsync` with `ReadLineBoundedAsync` (64 KB cap)
- A client sending >64 KB without a newline gets its connection dropped via `InvalidDataException → break → RemoveClient`
- Normal `CommandDto` traffic is < 200 bytes — the cap is a 300× safety margin

## Test plan
- [ ] `HandleClient_DropsConnection_WhenLineExceedsCap` — sends 70 KB without newline, asserts server closes the connection within 3 s
- [ ] Full suite: 0 failures