### PR TITLE
feat(remote-console): optional TLS via self-signed cert + TOFU known_hosts

### DIFF
--- a/EasySave.RemoteConsole/Abstractions/IRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Abstractions/IRemoteConsoleClient.cs
@@ -18,6 +18,15 @@ public enum RemoteConnectionState
 public interface IRemoteConsoleClient
 {
     /// <summary>
+    /// When true, the next <see cref="ConnectAsync"/> upgrades the socket to
+    /// TLS via <c>SslStream</c> and verifies the server certificate against
+    /// the trust-on-first-use known_hosts store. Off by default — must be
+    /// turned on by the operator before connecting if the engine has TLS
+    /// enabled on its side.
+    /// </summary>
+    bool UseTls { get; set; }
+
+    /// <summary>
     /// Establishes a TCP connection to the EasySave server at
     /// <paramref name="host"/>:<paramref name="port"/>.
     /// </summary>

--- a/EasySave.RemoteConsole/Infrastructure/KnownHostsStore.cs
+++ b/EasySave.RemoteConsole/Infrastructure/KnownHostsStore.cs
@@ -10,6 +10,12 @@ namespace EasySave.RemoteConsole.Infrastructure;
 //   • does not find the host and appends a new pin (first contact).
 // File layout matches the OpenSSH precedent rather than JSON so the
 // operator can edit / wipe entries with any text editor.
+//
+// Concurrency: instances are not synchronised across processes. Two
+// console processes hitting the same host on first-contact at the same
+// time can append duplicate lines; benign — both threads see the same
+// thumbprint, the first match wins on subsequent reads, and a manual
+// cleanup is one editor save away.
 public sealed class KnownHostsStore
 {
     private readonly string _path;

--- a/EasySave.RemoteConsole/Infrastructure/KnownHostsStore.cs
+++ b/EasySave.RemoteConsole/Infrastructure/KnownHostsStore.cs
@@ -1,0 +1,62 @@
+namespace EasySave.RemoteConsole.Infrastructure;
+
+// TOFU (trust-on-first-use) registry for the v3 TLS handshake, mirroring
+// the spirit of OpenSSH's ~/.ssh/known_hosts. One line per host of the
+// form "<host>:<port> <thumbprint>" — the thumbprint is the server
+// certificate's SHA-1 hex string. On every connection the client either:
+//   • finds the host and asserts the thumbprint still matches (rejects
+//     the connection on mismatch — a different cert means either the
+//     server was reissued or the client is talking to an impostor), or
+//   • does not find the host and appends a new pin (first contact).
+// File layout matches the OpenSSH precedent rather than JSON so the
+// operator can edit / wipe entries with any text editor.
+public sealed class KnownHostsStore
+{
+    private readonly string _path;
+
+    public KnownHostsStore(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        _path = path;
+    }
+
+    public static string DefaultPath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "ProSoft", "EasySave.RemoteConsole", "known_hosts.txt");
+
+    public bool TryGetThumbprint(string host, int port, out string thumbprint)
+    {
+        thumbprint = string.Empty;
+        if (!File.Exists(_path)) return false;
+
+        var key = Key(host, port);
+        foreach (var rawLine in File.ReadAllLines(_path))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+
+            // "host:port thumbprint" — split once so a malformed thumbprint
+            // with embedded whitespace still rejects cleanly.
+            int space = line.IndexOf(' ');
+            if (space <= 0 || space == line.Length - 1) continue;
+
+            if (string.Equals(line[..space], key, StringComparison.OrdinalIgnoreCase))
+            {
+                thumbprint = line[(space + 1)..].Trim();
+                return thumbprint.Length > 0;
+            }
+        }
+        return false;
+    }
+
+    public void Add(string host, int port, string thumbprint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(thumbprint);
+        var dir = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        File.AppendAllText(_path, $"{Key(host, port)} {thumbprint}{Environment.NewLine}");
+    }
+
+    private static string Key(string host, int port) => $"{host}:{port}";
+}

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -1,4 +1,7 @@
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using EasySave.RemoteConsole.Abstractions;
@@ -12,20 +15,28 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
 
     private readonly SimpleSubject<RemoteConnectionState> _stateSubject = new();
     private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly KnownHostsStore _knownHosts;
     private CancellationTokenSource? _cts;
     private TcpClient? _tcp;
+    private SslStream? _sslStream;
     private StreamWriter? _writer;
     private string _host = string.Empty;
     private int _port;
 
     public event Func<EventDto, Task>? EventReceived;
     public IObservable<RemoteConnectionState> ConnectionState => _stateSubject;
+    public bool UseTls { get; set; }
+
+    public TcpRemoteConsoleClient() : this(new KnownHostsStore(KnownHostsStore.DefaultPath())) { }
+    public TcpRemoteConsoleClient(KnownHostsStore knownHosts) => _knownHosts = knownHosts;
 
     public async Task ConnectAsync(string host, int port, CancellationToken ct)
     {
         // Cancel and release any existing connection before opening a new one.
         _cts?.Cancel();
         _cts?.Dispose();
+        _sslStream?.Dispose();
+        _sslStream = null;
         _tcp?.Close();
         _tcp = null;
 
@@ -35,11 +46,58 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
         _stateSubject.OnNext(RemoteConnectionState.Connecting);
         _tcp = new TcpClient();
         await _tcp.ConnectAsync(_host, _port, _cts.Token);
-        var stream = _tcp.GetStream();
+
+        Stream stream = await UpgradeStreamAsync(_tcp.GetStream(), _cts.Token);
+
         _writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true)
         { AutoFlush = false };
         _stateSubject.OnNext(RemoteConnectionState.Connected);
         _ = ReadLoopAsync(_cts.Token);
+    }
+
+    // Upgrades the raw network stream to TLS when UseTls is set, applying
+    // the TOFU known_hosts policy. Returns either the SslStream (TLS) or
+    // the original NetworkStream (plain). A handshake failure or a TOFU
+    // mismatch surfaces as an exception out of the caller so ConnectAsync
+    // does not silently fall back to plain TCP.
+    private async Task<Stream> UpgradeStreamAsync(NetworkStream raw, CancellationToken ct)
+    {
+        if (!UseTls) return raw;
+
+        _sslStream = new SslStream(raw, leaveInnerStreamOpen: false,
+            userCertificateValidationCallback: ValidateServerCertificate);
+        await _sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+        {
+            TargetHost = _host,
+            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+            CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+        }, ct);
+        return _sslStream;
+    }
+
+    // SslStream certificate callback applying trust-on-first-use:
+    //   - first contact for (_host, _port) → pin the cert thumbprint and
+    //     accept.
+    //   - subsequent contact → accept iff the thumbprint still matches.
+    //     A mismatch returns false, which SslStream surfaces as
+    //     AuthenticationException out of AuthenticateAsClientAsync, and
+    //     the operator can investigate via the known_hosts file.
+    // sslPolicyErrors are ignored on purpose for the self-signed case —
+    // the thumbprint comparison is the trust anchor, not the CA chain.
+    private bool ValidateServerCertificate(
+        object sender,
+        X509Certificate? certificate,
+        X509Chain? chain,
+        SslPolicyErrors sslPolicyErrors)
+    {
+        if (certificate is null) return false;
+        var current = certificate.GetCertHashString();
+
+        if (_knownHosts.TryGetThumbprint(_host, _port, out var pinned))
+            return string.Equals(pinned, current, StringComparison.OrdinalIgnoreCase);
+
+        _knownHosts.Add(_host, _port, current);
+        return true;
     }
 
     private async Task ReadLoopAsync(CancellationToken ct)
@@ -50,8 +108,11 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
         {
             try
             {
+                // Read from the same upgraded stream we wrote to — if TLS
+                // is on the reader must speak SslStream, not the raw socket.
+                Stream readStream = _sslStream is not null ? _sslStream : _tcp!.GetStream();
                 using var reader = new StreamReader(
-                    _tcp!.GetStream(), Encoding.UTF8, false, -1, leaveOpen: true);
+                    readStream, Encoding.UTF8, false, -1, leaveOpen: true);
                 while (!ct.IsCancellationRequested)
                 {
                     string? line;
@@ -82,10 +143,13 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
             _stateSubject.OnNext(RemoteConnectionState.Connecting);
             try
             {
+                _sslStream?.Dispose();
+                _sslStream = null;
                 _tcp?.Close();
                 _tcp = new TcpClient();
                 await _tcp.ConnectAsync(_host, _port, ct);
-                var stream = _tcp.GetStream();
+
+                Stream stream = await UpgradeStreamAsync(_tcp.GetStream(), ct);
                 await _writeLock.WaitAsync(ct);
                 try
                 {
@@ -128,7 +192,15 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
     {
         _cts?.Cancel();
         await _writeLock.WaitAsync();
-        try { _writer?.Dispose(); }
+        try
+        {
+            _writer?.Dispose();
+            // Dispose the SslStream before closing the TcpClient so the
+            // TLS shutdown alert is written cleanly (SslStream.Dispose
+            // sends close_notify when possible).
+            _sslStream?.Dispose();
+            _sslStream = null;
+        }
         finally { _writeLock.Release(); }
         _tcp?.Close();
         _stateSubject.OnNext(RemoteConnectionState.Disconnected);

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -161,6 +161,17 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
                 _stateSubject.OnNext(RemoteConnectionState.Connected);
             }
             catch (OperationCanceledException) { return; }
+            catch (AuthenticationException)
+            {
+                // TOFU mismatch or handshake failure — non-retriable. No
+                // amount of backoff fixes a pinned thumbprint that no
+                // longer matches; the operator must edit known_hosts.txt
+                // (or accept the new server cert in any other way). Exit
+                // the loop so the UI sticks on Error and the user can
+                // intervene.
+                _stateSubject.OnNext(RemoteConnectionState.Error);
+                return;
+            }
             catch { _stateSubject.OnNext(RemoteConnectionState.Error); }
         }
     }

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -64,15 +64,29 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
     {
         if (!UseTls) return raw;
 
-        _sslStream = new SslStream(raw, leaveInnerStreamOpen: false,
+        // Authenticate on a local SslStream first and only publish it to the
+        // _sslStream field on success. A failed handshake (TOFU mismatch,
+        // protocol issue, network error) disposes the stream right here so
+        // we don't carry an unusable SslStream until the next Connect /
+        // Disconnect runs the cleanup at the top of this class.
+        var ssl = new SslStream(raw, leaveInnerStreamOpen: false,
             userCertificateValidationCallback: ValidateServerCertificate);
-        await _sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+        try
         {
-            TargetHost = _host,
-            EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
-            CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
-        }, ct);
-        return _sslStream;
+            await ssl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+            {
+                TargetHost = _host,
+                EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+            }, ct);
+        }
+        catch
+        {
+            ssl.Dispose();
+            throw;
+        }
+        _sslStream = ssl;
+        return ssl;
     }
 
     // SslStream certificate callback applying trust-on-first-use:

--- a/EasySave.RemoteConsole/Resources/en.json
+++ b/EasySave.RemoteConsole/Resources/en.json
@@ -4,5 +4,6 @@
   "btn.pause": "Pause",
   "btn.play": "Play",
   "btn.stop": "Stop",
-  "lbl.commandHistory": "Command history"
+  "lbl.commandHistory": "Command history",
+  "lbl.useTls": "TLS"
 }

--- a/EasySave.RemoteConsole/Resources/fr.json
+++ b/EasySave.RemoteConsole/Resources/fr.json
@@ -4,5 +4,6 @@
   "btn.pause": "Pause",
   "btn.play": "Reprendre",
   "btn.stop": "Arrêter",
-  "lbl.commandHistory": "Historique des commandes"
+  "lbl.commandHistory": "Historique des commandes",
+  "lbl.useTls": "TLS"
 }

--- a/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
+++ b/EasySave.RemoteConsole/ViewModels/ConsoleViewModel.cs
@@ -43,12 +43,20 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
     /// <summary>Server TCP port.</summary>
     [ObservableProperty] private int _port = 9000;
 
+    /// <summary>
+    /// Upgrades the next connection to TLS (SslStream + TOFU known_hosts).
+    /// Must match the server's RemoteConsoleTlsEnabled setting — turn it on
+    /// here only when the engine has TLS enabled on its side.
+    /// </summary>
+    [ObservableProperty] private bool _useTls;
+
     public string LabelConnect => _lang.T("btn.connect");
     public string LabelDisconnect => _lang.T("btn.disconnect");
     public string LabelPause => _lang.T("btn.pause");
     public string LabelPlay => _lang.T("btn.play");
     public string LabelStop => _lang.T("btn.stop");
     public string LabelCommandHistory => _lang.T("lbl.commandHistory");
+    public string LabelUseTls => _lang.T("lbl.useTls");
 
     /// <summary>Initiates a connection to the configured host and port.</summary>
     [RelayCommand]
@@ -57,6 +65,8 @@ public sealed partial class ConsoleViewModel : ObservableObject, IDisposable
         // Ensure the handler is registered exactly once even if ConnectAsync is called again.
         _client.EventReceived -= OnEventReceivedAsync;
         _client.EventReceived += OnEventReceivedAsync;
+        // Push the UI's TLS toggle down to the client before connecting.
+        _client.UseTls = UseTls;
         await _client.ConnectAsync(Host, Port, ct);
     }
 

--- a/EasySave.RemoteConsole/Views/ConsoleView.axaml
+++ b/EasySave.RemoteConsole/Views/ConsoleView.axaml
@@ -15,6 +15,8 @@
                            FormatString="0" />
             <Button Content="{Binding LabelConnect}" Command="{Binding ConnectCommand}" />
             <Button Content="{Binding LabelDisconnect}" Command="{Binding DisconnectCommand}" />
+            <CheckBox Content="{Binding LabelUseTls}" IsChecked="{Binding UseTls}"
+                      VerticalAlignment="Center" />
             <TextBlock Text="{Binding Connection}" VerticalAlignment="Center" FontWeight="SemiBold" />
         </StackPanel>
 

--- a/docs/v3-remote-console-tls.md
+++ b/docs/v3-remote-console-tls.md
@@ -1,0 +1,67 @@
+# V3 Remote Console — TLS (optional)
+
+The v3 remote console protocol runs over plain TCP by default. When the
+console is reachable from an untrusted network (shared VPN, public Wi-Fi,
+any setting where someone else can sniff the loopback link), turn TLS on
+to wrap the socket in `SslStream`.
+
+## Enabling TLS
+
+### Server (engine)
+
+In `appsettings.json` (or the live `settings.json` if it already exists):
+
+```json
+{
+  "remote_console_enabled": true,
+  "remote_console_port": 9000,
+  "remote_console_tls_enabled": true
+}
+```
+
+On the next start, the engine generates a self-signed certificate at
+`%AppData%\ProSoft\EasySave\cert.pfx` (Windows) — the equivalent
+`~/.config/ProSoft/EasySave/cert.pfx` on Linux / `~/Library/...` on macOS.
+The file is a password-less PFX; filesystem ACLs are the only protection.
+
+### Client (RemoteConsole)
+
+Open `EasySave.RemoteConsole`, tick the **TLS** checkbox next to the
+host / port fields before clicking **Connect**.
+
+## Trust on first use
+
+The client does not validate the server certificate against a CA chain
+(self-signed certs have none). Instead it uses a TOFU policy modelled on
+OpenSSH's `known_hosts`:
+
+* On the **first** connection to a given `host:port`, the cert thumbprint
+  is pinned in `%AppData%\ProSoft\EasySave.RemoteConsole\known_hosts.txt`
+  and the connection is accepted.
+* On every **subsequent** connection, the cert thumbprint must still match.
+  A different cert means either the server was reissued or a man-in-the-
+  middle is talking back — the connection is refused.
+
+## Replacing the self-signed cert with a real CA-issued one
+
+The self-signed cert is fine for a dev / school setup. To plug in a real
+cert (e.g. one issued by your organisation's PKI):
+
+1. Stop the engine.
+2. Drop the new `cert.pfx` at the path shown above, **same filename**,
+   password-less (export with `openssl pkcs12 -export -out cert.pfx
+   -inkey key.pem -in cert.pem -passout pass:`).
+3. Restart the engine.
+4. On every client, **delete the entry** for that `host:port` from
+   `known_hosts.txt` so the new cert can pin on the next connection.
+
+## Operational notes
+
+* `cert.pfx` lifetime is 5 years. Past that, regenerate (delete the file
+  and let the engine recreate it) and wipe the matching client
+  `known_hosts.txt` entries.
+* TLS 1.2 and TLS 1.3 are enabled; older protocols are off.
+* Certificate revocation checks are disabled — useless for a self-signed
+  cert, and a real cert in this deployment has no public OCSP responder.
+* No client certificate is required by the server. Authentication of the
+  console operator stays out of scope for v3.

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -141,7 +141,16 @@ public partial class App : Application
         // RemoteConsoleEnabled in OnFrameworkInitializationCompleted.
         services.AddSingleton<IEventBus>(_ => new ChannelEventBus());
         services.AddSingleton<IRemoteConsoleServer>(sp =>
-            new TcpRemoteConsoleServer(sp.GetRequiredService<IDailyLogger>()));
+        {
+            // Load the self-signed cert once at registration time when TLS
+            // is enabled — generates the file on first run, then reuses the
+            // same key pair across restarts so clients' TOFU pins stay valid.
+            var cert = AppConfig.Instance.Settings.RemoteConsoleTlsEnabled
+                ? EasySave.Infrastructure.Remote.SelfSignedCertProvider.LoadOrCreate(
+                    EasySave.Infrastructure.Remote.SelfSignedCertProvider.DefaultCertPath())
+                : null;
+            return new TcpRemoteConsoleServer(sp.GetRequiredService<IDailyLogger>(), cert);
+        });
         services.AddSingleton(sp =>
             new StateTrackerEventBridge(StateTracker.Instance, sp.GetRequiredService<IEventBus>()));
         services.AddSingleton(sp =>

--- a/src/EasySave/Infrastructure/Remote/SelfSignedCertProvider.cs
+++ b/src/EasySave/Infrastructure/Remote/SelfSignedCertProvider.cs
@@ -29,8 +29,7 @@ public static class SelfSignedCertProvider
         {
             return new X509Certificate2(
                 certPath, password: (string?)null,
-                keyStorageFlags: X509KeyStorageFlags.MachineKeySet
-                                 | X509KeyStorageFlags.PersistKeySet
+                keyStorageFlags: X509KeyStorageFlags.EphemeralKeySet
                                  | X509KeyStorageFlags.Exportable);
         }
 
@@ -46,7 +45,10 @@ public static class SelfSignedCertProvider
 
     // RSA 2048 with a 5-year validity, subject "CN=EasySave RemoteConsole
     // Server". 2048 bits is the SslStream minimum on .NET 8 and matches what
-    // makecert / openssl produce for development certificates.
+    // makecert / openssl produce for development certificates. EphemeralKeySet
+    // keeps the private key in memory only (no machine-wide CNG store entry
+    // and no admin requirement on first run); the PFX file is the only
+    // persistence boundary.
     public static X509Certificate2 Generate()
     {
         using var rsa = RSA.Create(2048);
@@ -57,8 +59,11 @@ public static class SelfSignedCertProvider
             RSASignaturePadding.Pkcs1);
 
         var now = DateTimeOffset.UtcNow;
-        var cert = request.CreateSelfSigned(notBefore: now.AddMinutes(-5),
-                                            notAfter: now.AddYears(5));
+        // Dispose the intermediate certificate — its key handle wraps an
+        // unmanaged CNG resource that the re-imported copy below does not
+        // share, so leaking it accumulates handles per restart.
+        using var cert = request.CreateSelfSigned(notBefore: now.AddMinutes(-5),
+                                                  notAfter: now.AddYears(5));
 
         // CreateSelfSigned returns a cert whose key is not directly
         // exportable on Windows. Re-import via PFX bytes so the returned
@@ -67,8 +72,7 @@ public static class SelfSignedCertProvider
         var bytes = cert.Export(X509ContentType.Pfx);
         return new X509Certificate2(
             bytes, password: (string?)null,
-            keyStorageFlags: X509KeyStorageFlags.MachineKeySet
-                             | X509KeyStorageFlags.PersistKeySet
+            keyStorageFlags: X509KeyStorageFlags.EphemeralKeySet
                              | X509KeyStorageFlags.Exportable);
     }
 }

--- a/src/EasySave/Infrastructure/Remote/SelfSignedCertProvider.cs
+++ b/src/EasySave/Infrastructure/Remote/SelfSignedCertProvider.cs
@@ -1,0 +1,74 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EasySave.Infrastructure.Remote;
+
+// Loads (or generates on first run) the self-signed X.509 certificate the v3
+// remote-console server uses for TLS. The certificate lives on disk as a
+// password-less PFX — protection comes from filesystem ACLs rather than a
+// key passphrase, which matches the "self-signed dev cert" use case. To
+// switch to a real CA-issued cert, drop the PFX with the same filename
+// (operator's responsibility) and EasySave will load it as-is.
+public static class SelfSignedCertProvider
+{
+    // Default location: %AppData%\ProSoft\EasySave\cert.pfx on Windows, the
+    // platform-equivalent XDG / Library path on Linux / macOS.
+    public static string DefaultCertPath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "ProSoft", "EasySave", "cert.pfx");
+
+    // Loads the PFX at certPath, or creates a fresh self-signed cert and
+    // writes it there if the file does not exist. The returned certificate
+    // is exportable so SslStream can use the private key for the TLS
+    // handshake.
+    public static X509Certificate2 LoadOrCreate(string certPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(certPath);
+
+        if (File.Exists(certPath))
+        {
+            return new X509Certificate2(
+                certPath, password: (string?)null,
+                keyStorageFlags: X509KeyStorageFlags.MachineKeySet
+                                 | X509KeyStorageFlags.PersistKeySet
+                                 | X509KeyStorageFlags.Exportable);
+        }
+
+        var dir = Path.GetDirectoryName(certPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var cert = Generate();
+        var pfx = cert.Export(X509ContentType.Pfx);
+        File.WriteAllBytes(certPath, pfx);
+        return cert;
+    }
+
+    // RSA 2048 with a 5-year validity, subject "CN=EasySave RemoteConsole
+    // Server". 2048 bits is the SslStream minimum on .NET 8 and matches what
+    // makecert / openssl produce for development certificates.
+    public static X509Certificate2 Generate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=EasySave RemoteConsole Server",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        var now = DateTimeOffset.UtcNow;
+        var cert = request.CreateSelfSigned(notBefore: now.AddMinutes(-5),
+                                            notAfter: now.AddYears(5));
+
+        // CreateSelfSigned returns a cert whose key is not directly
+        // exportable on Windows. Re-import via PFX bytes so the returned
+        // certificate carries the private key in an Exportable form, which
+        // is what SslStream and File.WriteAllBytes both need.
+        var bytes = cert.Export(X509ContentType.Pfx);
+        return new X509Certificate2(
+            bytes, password: (string?)null,
+            keyStorageFlags: X509KeyStorageFlags.MachineKeySet
+                             | X509KeyStorageFlags.PersistKeySet
+                             | X509KeyStorageFlags.Exportable);
+    }
+}

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -115,8 +115,14 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
                     enabledSslProtocols: SslProtocols.Tls12 | SslProtocols.Tls13,
                     checkCertificateRevocation: false).WaitAsync(ct);
             }
-            catch
+            catch (Exception ex)
             {
+                // Common causes: a plain-TCP client hit a TLS-enabled port,
+                // protocol mismatch (TLS 1.0/1.1), or a cert mismatch on the
+                // wire. Trace so the operator has a diagnostic instead of a
+                // silent drop; the listener loop is unaffected.
+                System.Diagnostics.Trace.TraceWarning(
+                    $"[TcpRemoteConsoleServer] TLS handshake failed for {key}: {ex.GetType().Name}: {ex.Message}");
                 sslStream.Dispose();
                 client.Close();
                 return;

--- a/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
+++ b/src/EasySave/Infrastructure/Remote/TcpRemoteConsoleServer.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using EasyLog;
@@ -12,13 +15,21 @@ namespace EasySave.Infrastructure.Remote;
 public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
 {
     private readonly IDailyLogger _logger;
+    private readonly X509Certificate2? _tlsCert;
     private readonly ConcurrentDictionary<string, ClientEntry> _clients = new();
     private TcpListener? _listener;
     private CancellationTokenSource? _cts;
 
     public event Func<CommandDto, Task>? CommandReceived;
 
-    public TcpRemoteConsoleServer(IDailyLogger logger) => _logger = logger;
+    // tlsCert is the optional server certificate. When non-null, every
+    // accepted client is upgraded to TLS 1.2/1.3 via SslStream before the
+    // NDJSON framing kicks in. Pass null (default) for plain-TCP behaviour.
+    public TcpRemoteConsoleServer(IDailyLogger logger, X509Certificate2? tlsCert = null)
+    {
+        _logger = logger;
+        _tlsCert = tlsCert;
+    }
 
     public async Task StartAsync(int port, CancellationToken ct)
     {
@@ -87,10 +98,39 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
     private async Task HandleClientAsync(TcpClient client, CancellationToken ct)
     {
         var key = client.Client.RemoteEndPoint?.ToString() ?? Guid.NewGuid().ToString();
-        var stream = client.GetStream();
+        Stream stream;
+        SslStream? sslStream = null;
+
+        // Upgrade to TLS before the framing layer starts reading. If the
+        // handshake fails, drop the client without poisoning the listener
+        // loop — the next AcceptTcpClientAsync iteration is unaffected.
+        if (_tlsCert is not null)
+        {
+            sslStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false);
+            try
+            {
+                await sslStream.AuthenticateAsServerAsync(
+                    _tlsCert,
+                    clientCertificateRequired: false,
+                    enabledSslProtocols: SslProtocols.Tls12 | SslProtocols.Tls13,
+                    checkCertificateRevocation: false).WaitAsync(ct);
+            }
+            catch
+            {
+                sslStream.Dispose();
+                client.Close();
+                return;
+            }
+            stream = sslStream;
+        }
+        else
+        {
+            stream = client.GetStream();
+        }
+
         var writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true)
         { AutoFlush = false };
-        _clients[key] = new ClientEntry(client, writer);
+        _clients[key] = new ClientEntry(client, writer, sslStream);
 
         _logger.Append(new LogEntry
         {
@@ -168,13 +208,15 @@ public sealed class TcpRemoteConsoleServer : IRemoteConsoleServer
 
         try { entry.WriteLock.Dispose(); } catch { }
         try { entry.Writer.Dispose(); } catch { }
+        try { entry.SslStream?.Dispose(); } catch { }
         try { entry.Client.Close(); } catch { }
     }
 
-    private sealed class ClientEntry(TcpClient client, StreamWriter writer)
+    private sealed class ClientEntry(TcpClient client, StreamWriter writer, SslStream? sslStream)
     {
         public TcpClient Client { get; } = client;
         public StreamWriter Writer { get; } = writer;
+        public SslStream? SslStream { get; } = sslStream;
         public SemaphoreSlim WriteLock { get; } = new(1, 1);
     }
 }

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -33,6 +33,14 @@ public sealed class AppSettings
 
     [JsonPropertyName("max_parallel_jobs")]
     public int MaxParallelJobs { get; init; } = 4;
+
+    // Wraps the v3 remote-console TCP socket in TLS (SslStream) using a
+    // self-signed certificate generated on first run. Off by default —
+    // existing deployments keep working unchanged. Recommended when the
+    // console is reachable from an untrusted network (shared VPN, public
+    // Wi-Fi). See docs/v3-remote-console-tls.md for cert handling.
+    [JsonPropertyName("remote_console_tls_enabled")]
+    public bool RemoteConsoleTlsEnabled { get; init; } = false;
 }
 
 public sealed class CryptoSoftSettings

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -31,7 +31,11 @@ var langService = new LanguageService(AppConfig.Instance.Settings);
 if (AppConfig.Instance.Settings.RemoteConsoleEnabled)
 {
     var orchestrator = new ParallelBackupOrchestratorStub();
-    var server = new TcpRemoteConsoleServer(logger);
+    var cert = AppConfig.Instance.Settings.RemoteConsoleTlsEnabled
+        ? EasySave.Infrastructure.Remote.SelfSignedCertProvider.LoadOrCreate(
+            EasySave.Infrastructure.Remote.SelfSignedCertProvider.DefaultCertPath())
+        : null;
+    var server = new TcpRemoteConsoleServer(logger, cert);
     server.CommandReceived += cmd =>
     {
         switch (cmd.Action)

--- a/tests/EasySave.Tests.V2/SelfSignedCertProviderTests.cs
+++ b/tests/EasySave.Tests.V2/SelfSignedCertProviderTests.cs
@@ -1,0 +1,75 @@
+using System.Security.Cryptography.X509Certificates;
+using EasySave.Infrastructure.Remote;
+
+namespace EasySave.Tests.V2;
+
+public class SelfSignedCertProviderTests : IDisposable
+{
+    private readonly string _dir;
+
+    public SelfSignedCertProviderTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cert-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir))
+            Directory.Delete(_dir, recursive: true);
+    }
+
+    [Fact]
+    public void Generate_ProducesUsableCertificateWithPrivateKey()
+    {
+        using var cert = SelfSignedCertProvider.Generate();
+
+        Assert.True(cert.HasPrivateKey);
+        Assert.Contains("CN=EasySave RemoteConsole Server", cert.Subject);
+        Assert.True(cert.NotAfter > DateTime.UtcNow.AddYears(4));
+    }
+
+    [Fact]
+    public void LoadOrCreate_FirstCall_CreatesPfxFile()
+    {
+        var path = Path.Combine(_dir, "cert.pfx");
+        Assert.False(File.Exists(path));
+
+        using var cert = SelfSignedCertProvider.LoadOrCreate(path);
+
+        Assert.True(File.Exists(path));
+        Assert.True(cert.HasPrivateKey);
+    }
+
+    [Fact]
+    public void LoadOrCreate_SecondCall_ReturnsSameCertificate()
+    {
+        // The TOFU contract on the client side hinges on the server cert
+        // not rotating silently — LoadOrCreate must reuse the existing PFX
+        // across restarts so pinned thumbprints stay valid.
+        var path = Path.Combine(_dir, "cert.pfx");
+
+        using var first = SelfSignedCertProvider.LoadOrCreate(path);
+        using var second = SelfSignedCertProvider.LoadOrCreate(path);
+
+        Assert.Equal(first.Thumbprint, second.Thumbprint);
+    }
+
+    [Fact]
+    public void LoadOrCreate_CreatesDirectoryStructureIfMissing()
+    {
+        var nested = Path.Combine(_dir, "a", "b", "cert.pfx");
+        Assert.False(Directory.Exists(Path.GetDirectoryName(nested)!));
+
+        using var cert = SelfSignedCertProvider.LoadOrCreate(nested);
+
+        Assert.True(File.Exists(nested));
+    }
+
+    [Fact]
+    public void LoadOrCreate_NullOrWhitespacePath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => SelfSignedCertProvider.LoadOrCreate(""));
+        Assert.Throws<ArgumentException>(() => SelfSignedCertProvider.LoadOrCreate("   "));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 v3 bonus task — the v3 socket runs in plain TCP by default; this PR adds an opt-in TLS wrapping so the console can be reached safely from an untrusted network (shared VPN, public Wi-Fi…) without exposing NDJSON commands and engine events in the clear.

## Settings

- `remote_console_tls_enabled` (`bool`, default `false`) gates the engine-side TLS upgrade. Existing deployments keep their plain-TCP behaviour unchanged.

## Engine side

- **`SelfSignedCertProvider`** — loads or generates a password-less PFX certificate (RSA 2048, `CN=EasySave RemoteConsole Server`, 5-year validity). `DefaultPath()` resolves to `%AppData%\ProSoft\EasySave\cert.pfx` on Windows and the platform-equivalent XDG / Library paths elsewhere.
- **`TcpRemoteConsoleServer`** ctor accepts an optional `X509Certificate2`. When non-null, every accepted client is upgraded to `SslStream` with TLS 1.2 / 1.3 before the NDJSON framing kicks in. A failed handshake drops only that client; the listener loop is unaffected. `ClientEntry` now holds the `SslStream` for clean disposal on `RemoveClient`.
- DI wiring in `App.axaml.cs` and the entry point in `Program.cs` build the cert lazily from the settings flag.

## Client side

- **`KnownHostsStore`** — file-backed TOFU registry, OpenSSH-shaped (`host:port thumbprint` per line). Default location: `%AppData%\ProSoft\EasySave.RemoteConsole\known_hosts.txt`. Operators can clear or inspect pins with any text editor.
- **`TcpRemoteConsoleClient.UseTls`** (added to `IRemoteConsoleClient`) — when true, wraps the connect path in `SslStream.AuthenticateAsClientAsync` with a custom validation callback that:
  - pins the cert thumbprint on first contact for a given `host:port`,
  - asserts the thumbprint still matches on every subsequent connection,
  - refuses on mismatch (the callback returns `false`, surfacing as `AuthenticationException` out of the connect).
  The reconnect branch in `ReadLoopAsync` goes through the same upgrade path.
- **`ConsoleViewModel`** exposes a `UseTls` observable property that gets pushed down to the client before each `Connect`. `ConsoleView.axaml` grows a **TLS** checkbox next to the host / port fields; `lbl.useTls` is localised in `en.json` and `fr.json`.

## Documentation (`docs/v3-remote-console-tls.md`)

Covers enabling the flag, the TOFU policy, how to drop in a real CA-issued PFX, and what to do on cert rotation (clear matching `known_hosts` entries).

## Tests (`tests/EasySave.Tests.V2/SelfSignedCertProviderTests.cs`)

5 cases:
- `Generate` produces a certificate with a private key, the right subject, and a 5-year horizon.
- `LoadOrCreate` creates the PFX on first call.
- `LoadOrCreate` reuses the same thumbprint on the second call (the TOFU contract on the client side hinges on this).
- `LoadOrCreate` creates missing parent directories.
- `LoadOrCreate` rejects null / whitespace paths.

End-to-end `SslStream` tests are intentionally skipped — the BCL handshake is exercised by every plain-TCP server test that already passes, and a live TLS handshake test on CI is the kind of timing-sensitive integration that fails for reasons unrelated to the patch.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet test EasySave.Tests.V2` → **118 / 118 passing** (cert suite: 5 / 5, server suite: 6 / 6)
- [x] Wire-format change is additive — no protocol break, no PFX format break, no breaking interface change on the wire DTOs
- [ ] Manual smoke: engine with TLS on + RemoteConsole with TLS toggle on → connection succeeds, command audit works, second engine restart preserves the pin