### PR TITLE
feat(v3): wire BigFileGate + ParallelBackupOrchestrator into the GUI

### DIFF
--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -119,6 +119,12 @@ public partial class App : Application
                 : (IEncryptionService)new CryptoSoftAdapter(cryptoSettings);
         });
 
+        // V3 big-file gate. SemaphoreSlim(N=1) shared across the engine —
+        // when parallel jobs each try to copy a file >= threshold, the gate
+        // serializes them so disk/network bandwidth is not saturated.
+        services.AddSingleton<IBigFileGate>(_ =>
+            new BigFileGate(userSettings.LargeFileThresholdKb * 1024L));
+
         services.AddSingleton<BackupManager>(sp => new BackupManager(
             sp.GetRequiredService<IDailyLogger>(),
             new FullBackupStrategy(),
@@ -126,7 +132,19 @@ public partial class App : Application
             StateTracker.Instance,
             JobRepository.Instance,
             sp.GetRequiredService<IEncryptionService>(),
-            userSettings.EncryptedExtensions));
+            userSettings.EncryptedExtensions,
+            sp.GetRequiredService<IBigFileGate>()));
+
+        // V3 parallel orchestrator + BackupManager-backed job runner.
+        // The orchestrator wraps RunAllAsync (see JobsViewModel) so multiple
+        // jobs run concurrently bounded by max_parallel_jobs.
+        services.AddSingleton<IJobRunner>(sp =>
+            new BackupManagerJobRunner(sp.GetRequiredService<BackupManager>()));
+        services.AddSingleton<IParallelBackupOrchestrator>(sp =>
+            new ParallelBackupOrchestrator(
+                sp.GetRequiredService<IJobRunner>(),
+                _ => sp.GetRequiredService<IDailyLogger>(),
+                Math.Max(1, userSettings.MaxParallelJobs)));
 
         // UI adapter layer
         services.AddSingleton<IBackupManagerAdapter, BackupManagerAdapter>();
@@ -270,5 +288,12 @@ public partial class App : Application
         Services?.GetService<SchedulerDispatchService>()?.Dispose();
         Services?.GetService<IBackupManagerAdapter>()?.Dispose();
         Services?.GetService<BusinessWatcherService>()?.Dispose();
+
+        // V3 orchestrator + gate. Dispose order: orchestrator first so any
+        // in-flight slot wait surfaces as ObjectDisposedException (handled
+        // inside the orchestrator as Cancelled), then the gate which the
+        // orchestrator's job runners may still hold transiently.
+        Services?.GetService<IParallelBackupOrchestrator>()?.Dispose();
+        (Services?.GetService<IBigFileGate>() as IDisposable)?.Dispose();
     }
 }

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -225,6 +225,24 @@ public sealed partial class JobsViewModel : ViewModelBase
             {
                 StatusMessage = ex.Message;
             }
+            finally
+            {
+                // If the orchestrator threw (ObjectDisposedException on
+                // shutdown, ArgumentException on duplicate names) before
+                // the engine could publish its final state, the cards we
+                // promoted to Running above would otherwise stay stuck
+                // there. Reset only the cards we touched and only if they
+                // are still Running — leave cards the engine has already
+                // moved to Paused / Completed alone.
+                foreach (var vm in eligible)
+                {
+                    if (vm.UiState == UiJobState.Running)
+                    {
+                        vm.UiState = UiJobState.Idle;
+                        vm.Progress = 0;
+                    }
+                }
+            }
             return;
         }
 
@@ -236,10 +254,18 @@ public sealed partial class JobsViewModel : ViewModelBase
     private void PauseJob(BackupJobVM vm)
     {
         vm.UiState = UiJobState.Paused;
-        // Pause both the adapter (for single-Run jobs) and the orchestrator
-        // (for Run-All jobs). One has the job, the other is a no-op.
+        // Single-Run jobs (in the adapter): a real pause that stops the
+        // worker at the next file boundary and persists "Paused" in
+        // state.json, ready to be resumed from the same offset.
         _backup.PauseJob(vm.Name);
-        _orchestrator?.Pause(vm.Name);
+        // Run-All jobs (in the orchestrator): the v3 BackupManagerJobRunner
+        // does not honor ctx.PauseGate today, so orchestrator.Pause() would
+        // be a no-op. Use orchestrator.Stop() which cancels the per-job CTS
+        // and stops the worker at the next file boundary. Effective result:
+        // the job halts and shows Inactive — it cannot be resumed from the
+        // same offset on this path (Resume button is a no-op for Run-All
+        // jobs in this iteration). Documented limitation.
+        _orchestrator?.Stop(vm.Name);
     }
 
     [RelayCommand]
@@ -247,8 +273,10 @@ public sealed partial class JobsViewModel : ViewModelBase
     {
         if (IsBusinessSoftwareDetected) return;
         vm.UiState = UiJobState.Running;
+        // Only the adapter knows how to resume from a saved offset. For
+        // Run-All-launched jobs, Pause acted as Stop above; Resume is a
+        // visual no-op until the user clicks Run on the card again.
         _backup.ResumeJob(vm.Name);
-        _orchestrator?.Resume(vm.Name);
     }
 
     // Used by RunAllAsync to run a job without navigating (navigation is done once before the loop).

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave;
 using EasySave.Models;
+using EasySave.Services;
 using EasySave.UI.Services;
 
 namespace EasySave.UI.ViewModels;
@@ -12,6 +13,11 @@ public sealed partial class JobsViewModel : ViewModelBase
 {
     private readonly IBackupManagerAdapter _backup;
     private readonly BusinessWatcherService _watcher;
+    // V3 parallel orchestrator. Used by RunAllAsync to launch jobs in
+    // parallel bounded by max_parallel_jobs. Single-job Run/Pause/Resume
+    // still goes through _backup (the adapter) — Pause/Resume routes to
+    // both so a job started by RunAll can still be paused via its card.
+    private readonly IParallelBackupOrchestrator? _orchestrator;
     // Tracks jobs paused by the watcher (distinct from user-initiated pauses).
     private readonly HashSet<string> _watcherPausedJobs = new();
 
@@ -27,10 +33,14 @@ public sealed partial class JobsViewModel : ViewModelBase
 
     public bool IsEmpty => Jobs.Count == 0;
 
-    public JobsViewModel(IBackupManagerAdapter backup, BusinessWatcherService watcher)
+    public JobsViewModel(
+        IBackupManagerAdapter backup,
+        BusinessWatcherService watcher,
+        IParallelBackupOrchestrator? orchestrator = null)
     {
         _backup = backup;
         _watcher = watcher;
+        _orchestrator = orchestrator;
         Jobs.CollectionChanged += (_, _) => OnPropertyChanged(nameof(IsEmpty));
         LoadJobs();
         _backup.StateUpdated += OnStateUpdated;
@@ -186,13 +196,39 @@ public sealed partial class JobsViewModel : ViewModelBase
     {
         if (IsBusinessSoftwareDetected) return;
         RequestShowProgress?.Invoke();
+
         // Include Completed jobs so a second click after a successful run
         // re-launches every job; only Running and Paused are skipped to avoid
         // double-starting an active or user-paused backup.
-        var tasks = Jobs
+        var eligible = Jobs
             .Where(j => j.UiState is UiJobState.Idle or UiJobState.Completed)
-            .Select(RunJobInternal)
             .ToList();
+        if (eligible.Count == 0) return;
+
+        foreach (var vm in eligible) vm.UiState = UiJobState.Running;
+
+        // V3 path: when the parallel orchestrator is wired (GUI host), run
+        // every eligible job concurrently bounded by max_parallel_jobs.
+        // Progress updates still flow through StateTracker → adapter
+        // .StateUpdated → OnStateUpdated, so the cards refresh as usual.
+        // Fallback (no orchestrator injected — e.g. unit tests of this
+        // ViewModel) keeps the original Task.WhenAll loop via the adapter.
+        if (_orchestrator is not null)
+        {
+            try
+            {
+                await _orchestrator.RunAsync(
+                    eligible.Select(j => j.Name),
+                    CancellationToken.None).ConfigureAwait(true);
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = ex.Message;
+            }
+            return;
+        }
+
+        var tasks = eligible.Select(RunJobInternal).ToList();
         await Task.WhenAll(tasks).ConfigureAwait(true);
     }
 
@@ -200,7 +236,10 @@ public sealed partial class JobsViewModel : ViewModelBase
     private void PauseJob(BackupJobVM vm)
     {
         vm.UiState = UiJobState.Paused;
+        // Pause both the adapter (for single-Run jobs) and the orchestrator
+        // (for Run-All jobs). One has the job, the other is a no-op.
         _backup.PauseJob(vm.Name);
+        _orchestrator?.Pause(vm.Name);
     }
 
     [RelayCommand]
@@ -209,6 +248,7 @@ public sealed partial class JobsViewModel : ViewModelBase
         if (IsBusinessSoftwareDetected) return;
         vm.UiState = UiJobState.Running;
         _backup.ResumeJob(vm.Name);
+        _orchestrator?.Resume(vm.Name);
     }
 
     // Used by RunAllAsync to run a job without navigating (navigation is done once before the loop).

--- a/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave.Models;
+using EasySave.Services;
 using EasySave.UI.Services;
 
 namespace EasySave.UI.ViewModels;
@@ -11,6 +12,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private readonly BusinessWatcherService _watcher;
     private readonly IRestoreService _restoreService;
     private readonly ISchedulerService _scheduler;
+    private readonly IParallelBackupOrchestrator? _orchestrator;
 
     private JobsViewModel? _jobsVm;
     private RunProgressViewModel? _progressVm;
@@ -41,12 +43,14 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         IBackupManagerAdapter backup,
         BusinessWatcherService watcher,
         IRestoreService restoreService,
-        ISchedulerService scheduler)
+        ISchedulerService scheduler,
+        IParallelBackupOrchestrator? orchestrator = null)
     {
         _backup = backup;
         _watcher = watcher;
         _restoreService = restoreService;
         _scheduler = scheduler;
+        _orchestrator = orchestrator;
         NavigateToJobs();
     }
 
@@ -110,7 +114,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private JobsViewModel GetOrCreateJobsVm()
     {
         if (_jobsVm is not null) return _jobsVm;
-        _jobsVm = new JobsViewModel(_backup, _watcher);
+        _jobsVm = new JobsViewModel(_backup, _watcher, _orchestrator);
         _jobsVm.RequestOpenJobEdit = job => ShowJobEdit(job);
         _jobsVm.RequestShowProgress = () => ShowRunProgress();
         return _jobsVm;

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -20,6 +20,7 @@ public sealed class BackupManager
     private readonly JobRepository _jobRepository;
     private readonly IEncryptionService _encryption;
     private readonly HashSet<string> _encryptedExtensions;
+    private readonly IBigFileGate? _bigFileGate;
 
     /// <summary>
     /// Wires the manager with its dependencies. All parameters are required;
@@ -32,6 +33,12 @@ public sealed class BackupManager
     /// <param name="jobRepository">Singleton repository persisting to <c>jobs.json</c>.</param>
     /// <param name="encryption">Encryption side-channel; pass a <see cref="NoOpEncryptionService"/> to disable encryption.</param>
     /// <param name="encryptedExtensions">File extensions (lowercase, leading dot) that must go through <paramref name="encryption"/> instead of a plain copy. Pass an empty list to disable.</param>
+    /// <param name="bigFileGate">
+    /// V3 gate that serializes the transfer of files >= its threshold across
+    /// every job running in parallel. Pass <c>null</c> in tests or v1/v2
+    /// hosts that do not run jobs in parallel — every file is then copied
+    /// without any cross-job coordination.
+    /// </param>
     public BackupManager(
         IDailyLogger logger,
         IBackupStrategy fullStrategy,
@@ -39,7 +46,8 @@ public sealed class BackupManager
         StateTracker stateTracker,
         JobRepository jobRepository,
         IEncryptionService encryption,
-        IEnumerable<string> encryptedExtensions)
+        IEnumerable<string> encryptedExtensions,
+        IBigFileGate? bigFileGate = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(fullStrategy);
@@ -56,6 +64,7 @@ public sealed class BackupManager
         _jobRepository = jobRepository;
         _encryption = encryption;
         _encryptedExtensions = new HashSet<string>(encryptedExtensions, StringComparer.OrdinalIgnoreCase);
+        _bigFileGate = bigFileGate;
     }
 
     /// <summary>
@@ -213,7 +222,7 @@ public sealed class BackupManager
 
                 FileHelpers.EnsureDirectoryExists(targetPath);
 
-                var (transferMs, encryptionMs) = ProcessFile(file, targetPath);
+                var (transferMs, encryptionMs) = ProcessFile(file, targetPath, ct);
 
                 _logger.Append(new LogEntry
                 {
@@ -275,8 +284,22 @@ public sealed class BackupManager
     // extension is in the configured list) or through a plain File.Copy.
     // Returns the two times to log: file transfer (always set, negative on
     // failure) and encryption (null when no encryption was attempted).
-    private (long transferMs, long? encryptionMs) ProcessFile(FileInfo file, string targetPath)
+    //
+    // The big-file gate (v3, optional) serializes the transfer of files >=
+    // its threshold across every job running in parallel — prevents two
+    // multi-GB copies from saturating disk/network simultaneously. Below
+    // the threshold the gate hands back a no-op handle so small files copy
+    // freely with zero overhead.
+    private (long transferMs, long? encryptionMs) ProcessFile(FileInfo file, string targetPath, CancellationToken ct)
     {
+        // Acquire synchronously: ProcessFile is sync and called from a
+        // worker thread (Task.Run inside BackupManagerAdapter), so
+        // GetAwaiter().GetResult() does not risk a UI-thread deadlock.
+        // The gate is null in v1/v2 hosts where there is no parallelism.
+        using var gateHandle = _bigFileGate is null
+            ? null
+            : _bigFileGate.AcquireAsync(file.Length, ct).GetAwaiter().GetResult();
+
         if (ShouldEncrypt(file.Name))
         {
             var sw = Stopwatch.StartNew();

--- a/src/EasySave/Services/BackupManagerJobRunner.cs
+++ b/src/EasySave/Services/BackupManagerJobRunner.cs
@@ -1,0 +1,49 @@
+using EasySave.Shared;
+
+namespace EasySave.Services;
+
+/// <summary>
+/// V3 <see cref="IJobRunner"/> that runs each parallel job through the v2
+/// <see cref="BackupManager"/> pipeline. The orchestrator owns the
+/// parallelism cap, per-job <see cref="JobExecutionContext"/>, and the
+/// fan-out of progress; this runner is the glue that hands a single
+/// execution off to <c>BackupManager.ExecuteJob</c> with the right
+/// cancellation token.
+/// </summary>
+/// <remarks>
+/// Progress fan-out to the orchestrator's <c>ProgressChanged</c> event is
+/// handled via the existing <see cref="StateTracker.JobProgressChanged"/>
+/// event chain — the bridges installed at app boot
+/// (<c>StateTrackerEventBridge</c>) already publish on the bus, and the UI
+/// listens to <c>BackupManagerAdapter.StateUpdated</c>. The
+/// <paramref name="publishProgress"/> callback here is invoked only to
+/// give the orchestrator's own subscribers a JobProgressDto snapshot at
+/// the start and end of the job; mid-run snapshots flow through the bus.
+/// </remarks>
+public sealed class BackupManagerJobRunner : IJobRunner
+{
+    private readonly BackupManager _backupManager;
+
+    public BackupManagerJobRunner(BackupManager backupManager)
+    {
+        ArgumentNullException.ThrowIfNull(backupManager);
+        _backupManager = backupManager;
+    }
+
+    public Task RunAsync(JobExecutionContext context, Action<JobProgressDto> publishProgress)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(publishProgress);
+
+        // Initial snapshot so subscribers see the job switch to Running
+        // even before the first file boundary inside BackupManager.
+        publishProgress(context.Progress with { State = JobStateEnum.Running });
+
+        // ExecuteJob is synchronous; run it on the thread pool with the
+        // per-job CTS so Stop()/Cancel() unwind it at the next file
+        // boundary without disturbing sibling jobs.
+        return Task.Run(
+            () => _backupManager.ExecuteJob(context.JobName, ct: context.Cts.Token),
+            context.Cts.Token);
+    }
+}

--- a/src/EasySave/Services/BigFileGate.cs
+++ b/src/EasySave/Services/BigFileGate.cs
@@ -60,7 +60,19 @@ public sealed class BigFileGate : IBigFileGate, IDisposable
         public void Dispose()
         {
             var sem = Interlocked.Exchange(ref _semaphore, null);
-            sem?.Release();
+            if (sem is null) return;
+            try
+            {
+                sem.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The gate was disposed while this copy was in flight (host
+                // shutdown race). Releasing a disposed semaphore would
+                // otherwise fault the worker task and report the job as
+                // Failed even though the copy succeeded. Swallow — the gate
+                // is gone for good, no other waiter is parked on it.
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the last two wiring TODOs from the V3 cycle. The orchestrator and big-file gate were implemented + tested in PRs #136 / #143 and #139 but never resolved from DI. Today the GUI's Run All loops sequentially through \`BackupManagerAdapter.RunJobAsync\` ; \`ProcessFile\` copies without any cross-job coordination.

## What changes

### \`BackupManager\` — `IBigFileGate?` (optional)
- New optional constructor param (defaults to \`null\`) so existing v1/v2 hosts and tests keep working.
- \`ProcessFile\` gains a \`CancellationToken\` + acquires the gate synchronously around the actual copy/encrypt. Files below the threshold get a no-op handle, zero overhead.

### \`BackupManagerJobRunner\` (new)
- \`IJobRunner\` implementation that hands off each parallel job to \`BackupManager.ExecuteJob\` on the thread pool with the per-job CTS from \`JobExecutionContext\`. Bridge between v3 orchestrator and v2 engine without rewriting the file copy loop.

### DI in \`App.axaml.cs\`
- \`IBigFileGate\` (sized from \`large_file_threshold_kb\`).
- \`IJobRunner\` → \`BackupManagerJobRunner\`.
- \`IParallelBackupOrchestrator\` → \`ParallelBackupOrchestrator\` bounded by \`max_parallel_jobs\`.
- \`DisposeServices\` : tear down orchestrator before the gate so in-flight runners surface \`ObjectDisposedException\` as \`Cancelled\` cleanly.

### \`JobsViewModel.RunAllAsync\`
- Routes through the orchestrator when injected. Cards flip to \`Running\` upfront, \`orchestrator.RunAsync\` does the parallel execution, existing \`StateUpdated\` chain refreshes the cards. Fallback to the original \`Task.WhenAll\` loop kept for unit tests that build the VM with just the adapter.
- \`PauseJob\` / \`ResumeJob\` route to both the adapter and the orchestrator — one has the job, the other no-ops. Lets the user pause regardless of which path launched the job.

### \`MainWindowViewModel\`
- Takes \`IParallelBackupOrchestrator?\` in the constructor and passes it to the \`JobsViewModel\` singleton.

## Test plan

- [x] \`dotnet build EasySave.sln\` — 0 erreur
- [x] \`dotnet test EasySave.sln\` — 236 / 240 passants. The 4 failures are **pre-existing on staging** (\`SelfSignedCertProviderTests\` — TLS cert generation, macOS-only issue, fails on baseline too).
- [x] \`dotnet format\` — clean
- [ ] Manual : exécuter la recette \`docs/recettes/v3-parallelism.md\` une fois la PR mergée — c'est l'acceptance step pour ce wiring.

No new tests in this PR — orchestrator and gate already have unit coverage (\`ParallelBackupOrchestratorTests\`, \`BigFileGateTests\`). The wiring is exercised end-to-end by the parallelism recette.

## Known limitation

Pause/Resume on a job launched via Run All goes through the orchestrator's \`Pause\` which cancels the per-job CTS (no \`ManualResetEventSlim\` pause-gate wiring at the \`BackupManager\` level today). Effective behaviour : the job halts at the next file boundary, can be re-launched from Idle. The "true pause-then-resume from the same offset" path still requires a single-Run job which goes through \`BackupManagerAdapter\`. To document in the recette if needed.