### PR TITLE
fix(remote-console): publish Error state when the initial ConnectAsync fails

### DIFF
--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -44,15 +44,49 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
         _port = port;
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         _stateSubject.OnNext(RemoteConnectionState.Connecting);
-        _tcp = new TcpClient();
-        await _tcp.ConnectAsync(_host, _port, _cts.Token);
+        try
+        {
+            _tcp = new TcpClient();
+            await _tcp.ConnectAsync(_host, _port, _cts.Token);
 
-        Stream stream = await UpgradeStreamAsync(_tcp.GetStream(), _cts.Token);
+            Stream stream = await UpgradeStreamAsync(_tcp.GetStream(), _cts.Token);
 
-        _writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true)
-        { AutoFlush = false };
-        _stateSubject.OnNext(RemoteConnectionState.Connected);
-        _ = ReadLoopAsync(_cts.Token);
+            _writer = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true)
+            { AutoFlush = false };
+            _stateSubject.OnNext(RemoteConnectionState.Connected);
+            _ = ReadLoopAsync(_cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // The caller (or DisposeAsync) cancelled the initial attempt —
+            // surface Disconnected, not Error, so the UI stays neutral.
+            _stateSubject.OnNext(RemoteConnectionState.Disconnected);
+            CleanupAfterFailedConnect();
+            throw;
+        }
+        catch
+        {
+            // TCP connect refused / unreachable, TLS handshake failure,
+            // TOFU thumbprint mismatch — same Error state as the reconnect
+            // loop. Without this catch the state subject would sit on
+            // Connecting forever and the UI label would freeze.
+            _stateSubject.OnNext(RemoteConnectionState.Error);
+            CleanupAfterFailedConnect();
+            throw;
+        }
+    }
+
+    // Releases the half-built TCP / TLS / writer state after a failed
+    // ConnectAsync so the next attempt starts from a clean baseline and the
+    // disposed _tcp does not leak its socket handle until the next call.
+    private void CleanupAfterFailedConnect()
+    {
+        try { _writer?.Dispose(); } catch { }
+        _writer = null;
+        try { _sslStream?.Dispose(); } catch { }
+        _sslStream = null;
+        try { _tcp?.Close(); } catch { }
+        _tcp = null;
     }
 
     // Upgrades the raw network stream to TLS when UseTls is set, applying

--- a/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
+++ b/EasySave.RemoteConsole/Infrastructure/TcpRemoteConsoleClient.cs
@@ -61,7 +61,7 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
             // The caller (or DisposeAsync) cancelled the initial attempt —
             // surface Disconnected, not Error, so the UI stays neutral.
             _stateSubject.OnNext(RemoteConnectionState.Disconnected);
-            CleanupAfterFailedConnect();
+            await CleanupAfterFailedConnectAsync();
             throw;
         }
         catch
@@ -71,7 +71,7 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
             // loop. Without this catch the state subject would sit on
             // Connecting forever and the UI label would freeze.
             _stateSubject.OnNext(RemoteConnectionState.Error);
-            CleanupAfterFailedConnect();
+            await CleanupAfterFailedConnectAsync();
             throw;
         }
     }
@@ -79,12 +79,20 @@ public sealed class TcpRemoteConsoleClient : IRemoteConsoleClient, IAsyncDisposa
     // Releases the half-built TCP / TLS / writer state after a failed
     // ConnectAsync so the next attempt starts from a clean baseline and the
     // disposed _tcp does not leak its socket handle until the next call.
-    private void CleanupAfterFailedConnect()
+    // _writer is disposed under _writeLock to match DisconnectAsync — a
+    // failed initial connect with an in-flight SendCommandAsync would
+    // otherwise race the dispose against the write, even if narrow.
+    private async Task CleanupAfterFailedConnectAsync()
     {
-        try { _writer?.Dispose(); } catch { }
-        _writer = null;
-        try { _sslStream?.Dispose(); } catch { }
-        _sslStream = null;
+        await _writeLock.WaitAsync();
+        try
+        {
+            try { _writer?.Dispose(); } catch { }
+            _writer = null;
+            try { _sslStream?.Dispose(); } catch { }
+            _sslStream = null;
+        }
+        finally { _writeLock.Release(); }
         try { _tcp?.Close(); } catch { }
         _tcp = null;
     }


### PR DESCRIPTION
Closes #175.

## Problem

`TcpRemoteConsoleClient.ConnectAsync` published `RemoteConnectionState.Connecting` and only flipped to `Connected` after both the TCP socket and the optional TLS handshake had succeeded. If either step threw — host unreachable, port closed, TLS handshake failure, TOFU thumbprint mismatch — the exception propagated out without any further state transition, so the UI label stuck on **Connecting** forever with zero feedback to the operator.

The reconnect loop inside `ReadLoopAsync` already covered this case (it catches `AuthenticationException` and the generic case, both emitting `Error`); only the initial path was broken.

## Fix

Wrap the body of `ConnectAsync` in a try/catch matching the reconnect loop:

- `catch (OperationCanceledException)` → `Disconnected` (caller / `DisposeAsync` cancelled the attempt, neutral state — not an error).
- `catch` (everything else) → `Error`, same posture as the reconnect path. TCP refused, TLS handshake mismatch and TOFU thumbprint mismatch all land here.

In both cases the partial state (`_tcp`, `_writer`, `_sslStream`) is released right away via a new `CleanupAfterFailedConnect()` helper so a follow-up `ConnectAsync` starts from a clean baseline and the failed socket handle does not sit on the field until the next call's top-of-method cleanup. The exception still bubbles up so test assertions and `AsyncRelayCommand` error surfaces keep their existing behaviour.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] Manual reproduction: launch `EasySave.RemoteConsole`, set Host = `127.0.0.1` Port = `9999` (nothing listening), click **Connect**. Before: status stays on `Connecting`. After: status transitions to `Error`.
- [x] TLS variant: TLS on against a non-TLS engine triggers `AuthenticationException` in `UpgradeStreamAsync` and now surfaces as `Error` instead of frozen `Connecting`.
- [ ] No new unit test added — exercising the failure path requires a fake `TcpClient` and the existing client suite is integration-based. The state-subject behaviour is a single observable transition; happy to add a stub-based test if reviewer prefers.

## Zone

Dev4 — CLI / Console UI. The TLS code path that exposed this gap was introduced in PR #174; cross-zone fix per the issue.