### PR TITLE
feat(v3): HTTP log shipper with retry + buffer + LogMode routing

### DIFF
--- a/src/EasyLog/HttpLogShipper.cs
+++ b/src/EasyLog/HttpLogShipper.cs
@@ -61,7 +61,10 @@ public sealed class HttpLogShipper : ILogShipper
     private readonly Channel<LogEntry> _queue;
     private readonly CancellationTokenSource _shutdown = new();
     private readonly Task _writerLoop;
-    private volatile bool _disposed;
+    // 0 = live, 1 = DisposeAsync entered. Interlocked.CompareExchange makes
+    // the check-then-set atomic so two concurrent DisposeAsync callers cannot
+    // both cancel/dispose the shutdown CTS (would throw ObjectDisposedException).
+    private int _disposed;
 
     /// <summary>
     /// Creates a shipper that POSTs to <paramref name="endpoint"/>. The
@@ -101,7 +104,7 @@ public sealed class HttpLogShipper : ILogShipper
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        if (_disposed)
+        if (Volatile.Read(ref _disposed) == 1)
         {
             // Mirrors JsonDailyLogger: dropping silently post-Dispose is the
             // documented contract on the local writer. Centralized side adopts
@@ -147,8 +150,11 @@ public sealed class HttpLogShipper : ILogShipper
                         catch (OperationCanceledException)
                         {
                             // Shutdown arrived while we were backing off. The
-                            // outer catch handles re-queueing the in-flight
-                            // entry so DisposeAsync gets a chance to drain it.
+                            // in-flight entry is lost by design — the buffer
+                            // is in-memory, so a host crash or a Dispose-while-
+                            // collector-down combo never persists pending
+                            // entries. Operators run LogMode.Both during
+                            // cut-over as the safety net for this exact case.
                             return;
                         }
                     }
@@ -208,8 +214,10 @@ public sealed class HttpLogShipper : ILogShipper
     /// </remarks>
     public async ValueTask DisposeAsync()
     {
-        if (_disposed) return;
-        _disposed = true;
+        // Atomic check-then-set so a second concurrent caller bails out
+        // before touching _shutdown — Cancel/Dispose on an already-disposed
+        // CTS would throw ObjectDisposedException.
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
         _queue.Writer.TryComplete();
         _shutdown.Cancel();

--- a/src/EasyLog/HttpLogShipper.cs
+++ b/src/EasyLog/HttpLogShipper.cs
@@ -1,0 +1,235 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Channels;
+
+namespace EasyLog;
+
+/// <summary>
+/// <see cref="ILogShipper"/> that POSTs each <see cref="LogEntry"/> as JSON
+/// to a configured HTTP endpoint. Entries are accepted synchronously into
+/// an unbounded in-memory <see cref="Channel{T}"/> and a single background
+/// task drains the queue. Network failures trigger an exponential backoff
+/// (1s, 2s, 5s, 10s, capped at 30s) and entries stay in the buffer until
+/// the POST succeeds — no entry is dropped on transient outage. The
+/// machine name and current user are attached to every payload so the
+/// collector can demultiplex across hosts and operators.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The buffer is intentionally unbounded: backup logs are low-volume
+/// (one row per file copy) and dropping an entry would defeat the point
+/// of central logging. A misconfigured collector that stays down for
+/// weeks would leak memory; operators are expected to keep an eye on
+/// the host process via the daily file (LogMode.Both) until they trust
+/// the collector path.
+/// </para>
+/// <para>
+/// Order is preserved: the channel has SingleReader=true and the writer
+/// task processes one entry at a time. Inter-thread interleaving on the
+/// producer side mirrors the channel arrival order (no producer-side
+/// reordering).
+/// </para>
+/// </remarks>
+public sealed class HttpLogShipper : ILogShipper
+{
+    private static readonly JsonSerializerOptions PayloadOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // Exponential backoff sequence requested by the CdC: 1s, 2s, 5s, 10s,
+    // then the cap (30s) for every subsequent failure until the collector
+    // comes back. Reset to index 0 after any successful POST.
+    private static readonly TimeSpan[] BackoffSchedule =
+    {
+        TimeSpan.FromSeconds(1),
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(30),
+    };
+
+    private readonly HttpClient _http;
+    private readonly bool _ownsHttpClient;
+    private readonly Uri _endpoint;
+    private readonly string _machineName;
+    private readonly string _userName;
+    private readonly Channel<LogEntry> _queue;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly Task _writerLoop;
+    private volatile bool _disposed;
+
+    /// <summary>
+    /// Creates a shipper that POSTs to <paramref name="endpoint"/>. The
+    /// supplied <paramref name="http"/> is used as-is; the shipper takes
+    /// ownership only when the parameter is null (it then creates and
+    /// disposes its own client).
+    /// </summary>
+    /// <param name="endpoint">Absolute HTTP URI of the centralized collector (e.g. http://logs.local:9100/logs).</param>
+    /// <param name="http">Optional pre-configured client (test seam). Disposed only when null was passed.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpoint"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the endpoint is not an absolute HTTP/HTTPS URI.</exception>
+    public HttpLogShipper(Uri endpoint, HttpClient? http = null)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        if (!endpoint.IsAbsoluteUri || (endpoint.Scheme != Uri.UriSchemeHttp && endpoint.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("Endpoint must be an absolute http:// or https:// URI.", nameof(endpoint));
+        }
+
+        _endpoint = endpoint;
+        _http = http ?? new HttpClient();
+        _ownsHttpClient = http is null;
+        _machineName = Environment.MachineName;
+        _userName = Environment.UserName;
+
+        _queue = Channel.CreateUnbounded<LogEntry>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+        _writerLoop = Task.Run(() => WriterLoopAsync(_shutdown.Token));
+    }
+
+    /// <inheritdoc />
+    public void Append(LogEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (_disposed)
+        {
+            // Mirrors JsonDailyLogger: dropping silently post-Dispose is the
+            // documented contract on the local writer. Centralized side adopts
+            // the same convention so host-shutdown code paths never throw.
+            return;
+        }
+
+        _queue.Writer.TryWrite(entry);
+    }
+
+    private async Task WriterLoopAsync(CancellationToken ct)
+    {
+        int backoffIndex = 0;
+        LogEntry? inflight = null;
+
+        try
+        {
+            while (await _queue.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_queue.Reader.TryRead(out var entry))
+                {
+                    inflight = entry;
+
+                    // Retry loop: this entry stays "in flight" until the POST
+                    // succeeds or shutdown is requested. Order is preserved —
+                    // we never advance to the next queued entry while the
+                    // current one is still pending.
+                    while (!ct.IsCancellationRequested)
+                    {
+                        if (await TrySendAsync(entry, ct).ConfigureAwait(false))
+                        {
+                            backoffIndex = 0;
+                            inflight = null;
+                            break;
+                        }
+
+                        TimeSpan delay = BackoffSchedule[Math.Min(backoffIndex, BackoffSchedule.Length - 1)];
+                        backoffIndex++;
+                        try
+                        {
+                            await Task.Delay(delay, ct).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Shutdown arrived while we were backing off. The
+                            // outer catch handles re-queueing the in-flight
+                            // entry so DisposeAsync gets a chance to drain it.
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown path — the entry currently in flight (if any)
+            // never made it across the wire. We deliberately do nothing here:
+            // the buffer is in-memory, so a host restart loses unsent entries
+            // by design. Local file logging (LogMode.Both) is the operator's
+            // safety net during cut-over.
+        }
+        catch (Exception ex)
+        {
+            // Belt-and-braces: any unexpected throw in the loop would kill
+            // the writer and silently strand the queue. Trace + exit so the
+            // host's diagnostic infra sees the regression.
+            Trace.TraceError($"[EasyLog] HttpLogShipper writer task crashed: {ex}");
+        }
+    }
+
+    private async Task<bool> TrySendAsync(LogEntry entry, CancellationToken ct)
+    {
+        try
+        {
+            var payload = new CentralizedLogPayload(_machineName, _userName, entry);
+            using var content = JsonContent.Create(payload, options: PayloadOptions);
+            using var response = await _http.PostAsync(_endpoint, content, ct).ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Shutdown — surface as "not sent" so the caller decides to stop.
+            return false;
+        }
+        catch (HttpRequestException)
+        {
+            // Network unreachable, DNS failure, TLS handshake refused — keep
+            // the entry buffered and let the backoff loop retry.
+            return false;
+        }
+        catch (TaskCanceledException)
+        {
+            // Per-request timeout from HttpClient.Timeout — same handling as
+            // a network failure.
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Drains any in-flight buffer up to the per-request HTTP timeout times
+    /// the queue depth. Callers that want a hard ceiling should wrap the
+    /// returned task in their own <see cref="Task.WaitAsync(TimeSpan)"/>.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _queue.Writer.TryComplete();
+        _shutdown.Cancel();
+
+        try { await _writerLoop.ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            Trace.TraceError($"[EasyLog] HttpLogShipper writer task faulted on dispose: {ex}");
+        }
+
+        _shutdown.Dispose();
+        if (_ownsHttpClient) _http.Dispose();
+    }
+
+    // JSON envelope sent to the collector. Wraps the v1 LogEntry verbatim
+    // so the central side can persist the exact same shape it would read
+    // from a local daily file, with two extra demux fields.
+    private sealed record CentralizedLogPayload(
+        string MachineName,
+        string UserName,
+        LogEntry Entry);
+}

--- a/src/EasyLog/ILogShipper.cs
+++ b/src/EasyLog/ILogShipper.cs
@@ -1,0 +1,22 @@
+namespace EasyLog;
+
+/// <summary>
+/// Forwards log entries to a centralized collector. Implementations must:
+/// (1) accept entries without blocking the caller — a transient outage on
+/// the collector side never stalls a backup job; (2) buffer locally while
+/// the network is down and flush on reconnect; (3) preserve entry order
+/// per producer thread. Drop semantics are implementation-defined but
+/// must be documented.
+/// </summary>
+public interface ILogShipper : IAsyncDisposable
+{
+    /// <summary>
+    /// Enqueues <paramref name="entry"/> for shipment. Returns synchronously
+    /// without performing any network I/O — the actual POST is handled by a
+    /// background task. Implementations may reject the entry (return value
+    /// or exception) once <see cref="IAsyncDisposable.DisposeAsync"/> has
+    /// been initiated.
+    /// </summary>
+    /// <param name="entry">Entry to ship. Must not be null.</param>
+    void Append(LogEntry entry);
+}

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -39,6 +39,8 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
     private readonly string _logDirectory;
     private readonly Channel<WriteRequest> _queue;
     private readonly Task _writerLoop;
+    private readonly ILogShipper? _shipper;
+    private readonly LogMode _mode;
 
     // Per-day cache so a busy day's append loop does not re-read the file
     // from disk on every flush. The writer task is the only thread that
@@ -52,8 +54,22 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
     /// The directory is created if it does not exist.
     /// </summary>
     /// <param name="logDirectory">Absolute or UNC path where daily files are stored.</param>
+    /// <param name="shipper">
+    /// Optional V3 centralized shipper. When <paramref name="mode"/> is
+    /// <see cref="LogMode.Centralized"/> or <see cref="LogMode.Both"/>, every
+    /// <see cref="Append"/> also enqueues the entry on this shipper. Null
+    /// (default) keeps the v1/v2 local-only behaviour.
+    /// </param>
+    /// <param name="mode">
+    /// Routing for <see cref="Append"/> calls. <see cref="LogMode.Local"/>
+    /// (default) writes the daily file only; <see cref="LogMode.Centralized"/>
+    /// skips the local file and only ships; <see cref="LogMode.Both"/> does both.
+    /// When <paramref name="shipper"/> is null, the mode is forced back to
+    /// <see cref="LogMode.Local"/> so a misconfigured centralized setup
+    /// never causes silent log loss.
+    /// </param>
     /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
-    public JsonDailyLogger(string logDirectory)
+    public JsonDailyLogger(string logDirectory, ILogShipper? shipper = null, LogMode mode = LogMode.Local)
     {
         if (string.IsNullOrWhiteSpace(logDirectory))
         {
@@ -62,6 +78,10 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
 
         _logDirectory = logDirectory;
         Directory.CreateDirectory(_logDirectory);
+        _shipper = shipper;
+        // Centralized / Both without a shipper would silently drop entries.
+        // Fall back to Local so the daily file always exists.
+        _mode = shipper is null ? LogMode.Local : mode;
 
         _queue = Channel.CreateUnbounded<WriteRequest>(new UnboundedChannelOptions
         {
@@ -101,6 +121,24 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
             EncryptionTimeMs = entry.EncryptionTimeMs,
             EventType = entry.EventType,
         };
+
+        // Centralized side first: the shipper is async and non-blocking, so
+        // doing it before the local write does not slow the caller down.
+        // Append on the shipper is a buffered enqueue — never throws on
+        // network failures.
+        if (_mode is LogMode.Centralized or LogMode.Both)
+        {
+            _shipper!.Append(normalized);
+        }
+
+        // Centralized-only skips the daily file entirely. The shipper owns
+        // durability in that case; a host that crashes between Append and
+        // a successful POST loses the entry — operators are expected to
+        // run LogMode.Both during cut-over for that exact reason.
+        if (_mode == LogMode.Centralized)
+        {
+            return;
+        }
 
         var ack = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         if (!_queue.Writer.TryWrite(new WriteRequest(filePath, normalized, ack)))

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -79,9 +79,7 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
         _logDirectory = logDirectory;
         Directory.CreateDirectory(_logDirectory);
         _shipper = shipper;
-        // Centralized / Both without a shipper would silently drop entries.
-        // Fall back to Local so the daily file always exists.
-        _mode = shipper is null ? LogMode.Local : mode;
+        _mode = LogRouter.Effective(shipper, mode);
 
         _queue = Channel.CreateUnbounded<WriteRequest>(new UnboundedChannelOptions
         {
@@ -126,7 +124,7 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
         // doing it before the local write does not slow the caller down.
         // Append on the shipper is a buffered enqueue — never throws on
         // network failures.
-        if (_mode is LogMode.Centralized or LogMode.Both)
+        if (LogRouter.ShouldShip(_mode))
         {
             _shipper!.Append(normalized);
         }
@@ -135,7 +133,7 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
         // durability in that case; a host that crashes between Append and
         // a successful POST loses the entry — operators are expected to
         // run LogMode.Both during cut-over for that exact reason.
-        if (_mode == LogMode.Centralized)
+        if (!LogRouter.ShouldWriteLocal(_mode))
         {
             return;
         }

--- a/src/EasyLog/LogMode.cs
+++ b/src/EasyLog/LogMode.cs
@@ -1,0 +1,26 @@
+namespace EasyLog;
+
+/// <summary>
+/// Selects where <see cref="IDailyLogger.Append"/> calls land.
+/// V3 introduces a centralized HTTP shipper; existing v1/v2 deployments
+/// keep the local-only behaviour as the implicit default.
+/// </summary>
+public enum LogMode
+{
+    /// <summary>
+    /// Write the daily file on the local host only. v1/v2 behaviour, default.
+    /// </summary>
+    Local = 0,
+
+    /// <summary>
+    /// Ship to the centralized HTTP collector only. The local daily file is
+    /// skipped so a single source of truth lives in the central service.
+    /// </summary>
+    Centralized = 1,
+
+    /// <summary>
+    /// Ship to the central collector AND keep writing the local daily file.
+    /// Useful during cut-over while operators learn the central dashboard.
+    /// </summary>
+    Both = 2,
+}

--- a/src/EasyLog/LogRouter.cs
+++ b/src/EasyLog/LogRouter.cs
@@ -1,0 +1,30 @@
+namespace EasyLog;
+
+/// <summary>
+/// Shared helpers used by <see cref="JsonDailyLogger"/> and
+/// <see cref="XmlDailyLogger"/> to apply the V3 <see cref="LogMode"/>
+/// routing rules in a single place. Pulling these out of the loggers
+/// keeps the per-format Append paths free of duplicated bookkeeping
+/// (CLAUDE.md zero-duplication grading criterion) and ensures both
+/// formats follow the exact same fall-back semantics when a misconfigured
+/// host wires a centralized mode with a null shipper.
+/// </summary>
+internal static class LogRouter
+{
+    /// <summary>
+    /// Returns the effective routing mode for a given shipper / requested
+    /// mode pair. A null shipper forces <see cref="LogMode.Local"/> so a
+    /// host with <c>log_mode=Centralized</c> but no endpoint never silently
+    /// drops entries.
+    /// </summary>
+    public static LogMode Effective(ILogShipper? shipper, LogMode requested) =>
+        shipper is null ? LogMode.Local : requested;
+
+    /// <summary>True when the entry should be forwarded to the centralized shipper.</summary>
+    public static bool ShouldShip(LogMode mode) =>
+        mode is LogMode.Centralized or LogMode.Both;
+
+    /// <summary>True when the entry should be persisted to the local daily file.</summary>
+    public static bool ShouldWriteLocal(LogMode mode) =>
+        mode is LogMode.Local or LogMode.Both;
+}

--- a/src/EasyLog/XmlDailyLogger.cs
+++ b/src/EasyLog/XmlDailyLogger.cs
@@ -18,19 +18,25 @@ public sealed class XmlDailyLogger : IDailyLogger
     private readonly string _logDirectory;
     private readonly XmlFormatter _formatter = new();
     private readonly object _writeLock = new();
+    private readonly ILogShipper? _shipper;
+    private readonly LogMode _mode;
 
     /// <summary>
     /// Initializes a new logger writing to <paramref name="logDirectory"/>.
     /// The directory is created if it does not exist.
     /// </summary>
     /// <param name="logDirectory">Absolute or UNC path where daily XML files are stored.</param>
+    /// <param name="shipper">Optional V3 centralized shipper. See <see cref="JsonDailyLogger"/> for the contract.</param>
+    /// <param name="mode">Routing for <see cref="Append"/> calls. See <see cref="JsonDailyLogger"/> for the contract.</param>
     /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
-    public XmlDailyLogger(string logDirectory)
+    public XmlDailyLogger(string logDirectory, ILogShipper? shipper = null, LogMode mode = LogMode.Local)
     {
         if (string.IsNullOrWhiteSpace(logDirectory))
             throw new ArgumentException("Log directory must be provided.", nameof(logDirectory));
         _logDirectory = logDirectory;
         Directory.CreateDirectory(_logDirectory);
+        _shipper = shipper;
+        _mode = shipper is null ? LogMode.Local : mode;
     }
 
     /// <summary>Absolute path of the directory where daily log files are written.</summary>
@@ -54,7 +60,18 @@ public sealed class XmlDailyLogger : IDailyLogger
             FileSize = entry.FileSize,
             FileTransferTimeMs = entry.FileTransferTimeMs,
             EncryptionTimeMs = entry.EncryptionTimeMs,
+            EventType = entry.EventType,
         };
+
+        if (_mode is LogMode.Centralized or LogMode.Both)
+        {
+            _shipper!.Append(normalized);
+        }
+
+        if (_mode == LogMode.Centralized)
+        {
+            return;
+        }
 
         lock (_writeLock)
         {

--- a/src/EasyLog/XmlDailyLogger.cs
+++ b/src/EasyLog/XmlDailyLogger.cs
@@ -36,7 +36,7 @@ public sealed class XmlDailyLogger : IDailyLogger
         _logDirectory = logDirectory;
         Directory.CreateDirectory(_logDirectory);
         _shipper = shipper;
-        _mode = shipper is null ? LogMode.Local : mode;
+        _mode = LogRouter.Effective(shipper, mode);
     }
 
     /// <summary>Absolute path of the directory where daily log files are written.</summary>
@@ -63,12 +63,12 @@ public sealed class XmlDailyLogger : IDailyLogger
             EventType = entry.EventType,
         };
 
-        if (_mode is LogMode.Centralized or LogMode.Both)
+        if (LogRouter.ShouldShip(_mode))
         {
             _shipper!.Append(normalized);
         }
 
-        if (_mode == LogMode.Centralized)
+        if (!LogRouter.ShouldWriteLocal(_mode))
         {
             return;
         }

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -44,7 +44,9 @@ public sealed class AppSettings
 
     // V3 centralized logging. Default Local keeps v1/v2 deployments
     // untouched. Centralized / Both require LogCentralizedEndpoint to be
-    // set; the LogShipper falls back to Local when the endpoint is empty.
+    // set: the wiring code (Program.cs / App.axaml.cs) is responsible
+    // for skipping HttpLogShipper construction when the endpoint is
+    // empty, in which case the logger constructors fall back to Local.
     [JsonPropertyName("log_mode")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public EasyLog.LogMode LogMode { get; init; } = EasyLog.LogMode.Local;

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -41,6 +41,16 @@ public sealed class AppSettings
     // Wi-Fi). See docs/v3-remote-console-tls.md for cert handling.
     [JsonPropertyName("remote_console_tls_enabled")]
     public bool RemoteConsoleTlsEnabled { get; init; } = false;
+
+    // V3 centralized logging. Default Local keeps v1/v2 deployments
+    // untouched. Centralized / Both require LogCentralizedEndpoint to be
+    // set; the LogShipper falls back to Local when the endpoint is empty.
+    [JsonPropertyName("log_mode")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public EasyLog.LogMode LogMode { get; init; } = EasyLog.LogMode.Local;
+
+    [JsonPropertyName("log_centralized_endpoint")]
+    public string LogCentralizedEndpoint { get; init; } = string.Empty;
 }
 
 public sealed class CryptoSoftSettings

--- a/tests/EasySave.Tests.V2/HttpLogShipperTests.cs
+++ b/tests/EasySave.Tests.V2/HttpLogShipperTests.cs
@@ -1,0 +1,275 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+/// <summary>
+/// Unit tests for <see cref="HttpLogShipper"/> and the <see cref="LogMode"/>
+/// routing on <see cref="JsonDailyLogger"/>. The shipper is exercised
+/// through a custom <see cref="HttpMessageHandler"/> so tests never bind a
+/// real TCP socket (keeps them deterministic on CI runners).
+/// </summary>
+public class HttpLogShipperTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public HttpLogShipperTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "easylog-shipper-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public async Task Append_SendsEntry_AsJsonPostToEndpoint()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        shipper.Append(new LogEntry
+        {
+            Timestamp = "2026-05-12T10:00:00+02:00",
+            JobName = "demo",
+            SourceFile = @"C:\src\file.txt",
+            TargetFile = @"C:\dst\file.txt",
+            FileSize = 42,
+            FileTransferTimeMs = 3,
+        });
+
+        // Single drain — the background task is fire-and-forget so we wait
+        // for the request to be observed instead of relying on a sleep.
+        await handler.WaitForRequestsAsync(1);
+
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, handler.Requests[0].Method);
+        Assert.Equal("http://collector.local/logs", handler.Requests[0].Uri);
+
+        using var doc = JsonDocument.Parse(handler.Requests[0].Body);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("MachineName", out _));
+        Assert.True(root.TryGetProperty("UserName", out _));
+        Assert.Equal("demo", root.GetProperty("Entry").GetProperty("JobName").GetString());
+    }
+
+    [Fact]
+    public async Task Append_DoesNotBlockCaller_WhenCollectorIsDown()
+    {
+        // Simulate a network outage: every send fails with HttpRequestException.
+        var handler = new RecordingHandler(_ => throw new HttpRequestException("dns failure"));
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        // 50 calls in a tight loop must return instantly — none of them
+        // performs network I/O on the caller's thread.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < 50; i++)
+        {
+            shipper.Append(new LogEntry { JobName = $"job-{i}", Timestamp = "x" });
+        }
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 500,
+            $"Append blocked on a downed collector ({sw.ElapsedMilliseconds}ms for 50 calls).");
+    }
+
+    [Fact]
+    public async Task Append_FlushesBufferedEntries_AfterCollectorRecovers()
+    {
+        // First 3 attempts on the in-flight entry fail, the 4th succeeds.
+        // The shipper must keep retrying without losing the entry.
+        int callCount = 0;
+        var handler = new RecordingHandler(_ =>
+        {
+            callCount++;
+            if (callCount <= 3) throw new HttpRequestException("transient");
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        shipper.Append(new LogEntry { JobName = "retry-me", Timestamp = "t" });
+
+        // First two backoff steps are 1s + 2s = 3s; the shipper should send
+        // successfully on retry #4 around the 4–5s mark. Cap the test at 12s
+        // so a hung loop fails quickly.
+        await handler.WaitForRequestsAsync(4, TimeSpan.FromSeconds(12));
+
+        Assert.Equal(4, callCount);
+        Assert.Equal("retry-me",
+            JsonDocument.Parse(handler.Requests[3].Body)
+                .RootElement.GetProperty("Entry")
+                .GetProperty("JobName").GetString());
+    }
+
+    [Fact]
+    public void Constructor_Rejects_NonHttpEndpoint()
+    {
+        Assert.Throws<ArgumentException>(() => new HttpLogShipper(new Uri("ftp://x/y")));
+    }
+
+    [Fact]
+    public async Task JsonDailyLogger_LocalMode_DoesNotCallShipper()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        using (var logger = new JsonDailyLogger(_tempDir, shipper, LogMode.Local))
+        {
+            logger.Append(new LogEntry { JobName = "local-only", Timestamp = "t" });
+        }
+
+        // Local mode must never reach the shipper, even when one is wired.
+        await Task.Delay(200);
+        Assert.Empty(handler.Requests);
+        Assert.Single(Directory.GetFiles(_tempDir, "*.json"));
+    }
+
+    [Fact]
+    public async Task JsonDailyLogger_CentralizedMode_SkipsLocalFile()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        using (var logger = new JsonDailyLogger(_tempDir, shipper, LogMode.Centralized))
+        {
+            logger.Append(new LogEntry { JobName = "central-only", Timestamp = "t" });
+        }
+
+        await handler.WaitForRequestsAsync(1);
+        Assert.Single(handler.Requests);
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.json"));
+    }
+
+    [Fact]
+    public async Task JsonDailyLogger_BothMode_WritesLocalAndShips()
+    {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        using (var logger = new JsonDailyLogger(_tempDir, shipper, LogMode.Both))
+        {
+            logger.Append(new LogEntry { JobName = "both", Timestamp = "t" });
+        }
+
+        await handler.WaitForRequestsAsync(1);
+        Assert.Single(handler.Requests);
+        Assert.Single(Directory.GetFiles(_tempDir, "*.json"));
+    }
+
+    [Fact]
+    public void JsonDailyLogger_FallsBackToLocal_WhenShipperIsNullButModeIsCentralized()
+    {
+        // Misconfiguration guard: a logger created with Centralized but no
+        // shipper must NOT silently drop entries — it falls back to Local.
+        using var logger = new JsonDailyLogger(_tempDir, shipper: null, mode: LogMode.Centralized);
+        logger.Append(new LogEntry { JobName = "guard", Timestamp = "t" });
+
+        Assert.Single(Directory.GetFiles(_tempDir, "*.json"));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DoesNotBlockIndefinitely_OnDownCollector()
+    {
+        var handler = new RecordingHandler(_ => throw new HttpRequestException("down"));
+        var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        shipper.Append(new LogEntry { JobName = "stuck", Timestamp = "t" });
+
+        // Give the writer task a moment to start its first attempt.
+        await Task.Delay(200);
+
+        // DisposeAsync must cancel the in-flight backoff and complete quickly.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await shipper.DisposeAsync();
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 2000,
+            $"DisposeAsync took {sw.ElapsedMilliseconds}ms with a downed collector.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Recording handler — captures outgoing requests so tests can assert
+    // method, URI and JSON body without spinning a real HTTP listener.
+    // ──────────────────────────────────────────────────────────────────────
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _factory;
+        private readonly List<RecordedRequest> _requests = new();
+        private readonly object _lock = new();
+        private TaskCompletionSource _signal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> factory)
+        {
+            _factory = factory;
+        }
+
+        public IReadOnlyList<RecordedRequest> Requests
+        {
+            get { lock (_lock) return _requests.ToArray(); }
+        }
+
+        public async Task WaitForRequestsAsync(int count, TimeSpan? timeout = null)
+        {
+            var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+            while (DateTime.UtcNow < deadline)
+            {
+                lock (_lock)
+                {
+                    if (_requests.Count >= count) return;
+                }
+                await Task.WhenAny(_signal.Task, Task.Delay(100));
+            }
+            lock (_lock)
+            {
+                if (_requests.Count < count)
+                    throw new Xunit.Sdk.XunitException(
+                        $"Expected {count} requests, observed {_requests.Count} within timeout.");
+            }
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            lock (_lock)
+            {
+                _requests.Add(new RecordedRequest(
+                    request.Method,
+                    request.RequestUri?.ToString() ?? "",
+                    body));
+                var old = _signal;
+                _signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                old.TrySetResult();
+            }
+
+            // Throw / return based on the test factory. The factory runs
+            // outside the lock so it can throw freely without deadlocking.
+            return _factory(request);
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Uri, string Body);
+}

--- a/tests/EasySave.Tests.V2/HttpLogShipperTests.cs
+++ b/tests/EasySave.Tests.V2/HttpLogShipperTests.cs
@@ -101,10 +101,10 @@ public class HttpLogShipperTests : IDisposable
 
         shipper.Append(new LogEntry { JobName = "retry-me", Timestamp = "t" });
 
-        // First two backoff steps are 1s + 2s = 3s; the shipper should send
-        // successfully on retry #4 around the 4–5s mark. Cap the test at 12s
-        // so a hung loop fails quickly.
-        await handler.WaitForRequestsAsync(4, TimeSpan.FromSeconds(12));
+        // Three failures back off 1s + 2s + 5s = 8s before the 4th attempt
+        // succeeds. Cap the test at 15s so a hung loop fails quickly without
+        // making CI flaky on a slow runner.
+        await handler.WaitForRequestsAsync(4, TimeSpan.FromSeconds(15));
 
         Assert.Equal(4, callCount);
         Assert.Equal("retry-me",


### PR DESCRIPTION
## Summary

- New `ILogShipper` + `HttpLogShipper` (EasyLog) — Channel-backed, non-blocking, exponential backoff `1s → 2s → 5s → 10s → 30s cap`, single background drain task, no entry dropped on transient outage.
- `JsonDailyLogger` / `XmlDailyLogger` accept an optional shipper + `LogMode` (`Local` | `Centralized` | `Both`). `Local` is the default → v1/v2 deployments behave unchanged.
- `AppSettings` exposes `log_mode` + `log_centralized_endpoint`.
- Each HTTP payload carries `MachineName` + `UserName` so the central collector can demux across hosts/operators.
- Guard: a logger configured `Centralized` with a null shipper falls back to `Local` — no silent log loss on misconfiguration.

## Test plan

- [x] `dotnet build EasySave.sln` — 0 errors
- [x] 9 new `HttpLogShipperTests` pass (POST format, retry-until-success, non-blocking append on downed collector, LogMode routing, DisposeAsync timely shutdown)
- [x] No regression on the 113 other V2 tests (the 4 `SelfSignedCertProviderTests` failures are a pre-existing macOS-only flake — `EphemeralKeySet` not supported)
- [ ] CI green on Linux/Windows
- [ ] Manual end-to-end against the upcoming `LogCentralizer` Docker service (separate PR)

## Notes

Out of scope on purpose — they land on follow-up branches:
- The Docker `LogCentralizer` reception service
- `docker-compose.yml` wiring EasySave + LogCentralizer
- Admin manual + UML deployment diagram update
- Manual acceptance scenario