### PR TITLE
feat(backup): wire PauseGate into BackupManagerJobRunner + IJobController surface

### DIFF
--- a/docs/recettes/v3-pause-resume-run-all.md
+++ b/docs/recettes/v3-pause-resume-run-all.md
@@ -1,0 +1,79 @@
+# Recette V3 — Pause / Play / Stop (par job et Run-All)
+
+**Critère grille tuteur V3** : « Pour chaque travail (ou l'ensemble des
+travaux), l'utilisateur doit pouvoir Pause / Play / Stop. » La pause est
+effective au prochain *file boundary* (jamais en plein milieu d'une copie),
+elle est reflétée dans `state.json`, et chaque transition est tracée dans
+le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
+
+## Pré-requis
+
+- EasySave v3 buildé en Release (`dotnet build EasySave.sln -c Release`).
+- GUI Avalonia (`dotnet run --project src/EasySave.UI`) **ou** Remote
+  Console (`dotnet run --project EasySave.RemoteConsole`).
+- Un job Full configuré sur **≥ 50 fichiers** ou un job avec des fichiers
+  de taille moyenne — assez pour laisser le temps de cliquer Pause avant
+  la fin.
+
+## Procédure — pause / play par job
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Lancer le job depuis la GUI. | `state.json` : `"State": 1` (Active). |
+| 2 | Cliquer **Pause** sur la ligne du job. | Sous **1 seconde**, `state.json` passe à `"State": 2` (Paused). Le log journalier reçoit une entrée `EventType = JobPaused` (`8`). Aucun nouveau fichier n'apparaît dans le dossier cible. |
+| 3 | Inspecter le dossier cible. | Le compteur de fichiers ne progresse plus. Le fichier en cours d'écriture juste avant le Pause est **complet** (jamais coupé en deux). |
+| 4 | Cliquer **Play** sur la même ligne. | `state.json` repasse à `"State": 1`. Le log journalier reçoit `EventType = JobResumed` (`9`). La copie reprend **au fichier suivant** celui copié juste avant la pause. |
+| 5 | Attendre la fin. | `state.json` : `"State": 0` (Inactive), `FilesRemaining = 0`. Tous les fichiers présents dans la source apparaissent dans la cible. |
+
+## Procédure — Stop par job
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Relancer un job. | `state.json` : Active. |
+| 2 | Cliquer **Stop** sur la ligne. | Sous **1 seconde**, le job se termine. `JobOutcome.Cancelled` côté orchestrateur, `state.json` : `"State": 0` (Inactive). La cible contient les fichiers déjà copiés (pas de rollback). |
+| 3 | Variante — Stop pendant un Pause. | Même comportement : le `Wait(ct)` token-aware lance OCE et le job sort Inactive. |
+
+## Procédure — Run-All (Pause All / Resume All)
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Démarrer **3 jobs en parallèle** (cap = 2 ou 4 selon `MaxParallelJobs`). | 2 jobs Active, 1 en file. |
+| 2 | Cliquer **Pause All** dans la GUI (ou ouvrir un logiciel métier surveillé — `calc.exe` par défaut). | Sous 1 s, les 2 jobs Active passent en Paused (`state.json` reflète Paused pour les deux). Le 3ᵉ job reste queued. Le log reçoit un `JobPaused` par job pausé. |
+| 3 | Cliquer **Resume All** (ou fermer `calc.exe`). | Les 2 jobs reprennent simultanément ; le 3ᵉ démarre dès qu'un slot se libère. Log : un `JobResumed` par job repris. |
+| 4 | Attendre la fin. | Les 3 jobs terminent Inactive. Tous les fichiers présents en source sont en cible. |
+
+## Critères d'acceptation
+
+- [ ] Le Pause prend effet **après le fichier en cours**, jamais en plein
+      milieu (vérifiable via la taille du dernier fichier cible).
+- [ ] `state.json` reflète fidèlement `Active → Paused → Active → Inactive`.
+- [ ] Chaque transition apparaît dans le log journalier avec
+      `EventType: JobPaused` ou `JobResumed`.
+- [ ] Le Resume reprend **au fichier suivant** (pas depuis le début).
+- [ ] Le Stop pendant un Pause termine bien le job (pas de thread bloqué).
+- [ ] `PauseAll` / `ResumeAll` opèrent sur tous les jobs sans toucher aux
+      jobs queued.
+
+## Couverture automatique
+
+- `tests/EasySave.Tests/BackupManagerPauseResumeTests.cs` — couvre la
+  mécanique de la pause gate dans `BackupManager.ExecuteJob` :
+  - `ExecuteJob_PauseGateReset_StateBecomesPausedThenResumes` — gate
+    fermée → state `Paused`, gate ouverte → reprise et fin Inactive.
+  - `ExecuteJob_PauseGateAndStopTogether_StateBecomesInactive` — Stop
+    pendant un Pause termine bien Inactive (pas Paused).
+- `tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs` — couvre
+  l'orchestrateur :
+  - `PauseAll_ResetsEveryRunningJobsGate`
+  - `ResumeAll_SetsEveryPausedJobsGate`
+  - `StopAll_CancelsEveryJob_AllResultsAreCancelled`
+  - `PauseResumeStopAll_OnEmptyOrchestrator_AreNoOps`
+
+## Si la recette échoue
+
+| Symptôme | Cause probable | Vérification |
+|---|---|---|
+| Pause ne fait rien (job continue) | Le runner concret n'a pas reçu le `pauseGate` du context. | Vérifier que `BackupManagerJobRunner.RunAsync` passe bien `context.PauseGate` à `ExecuteJob`. |
+| Pause termine le job (Inactive au lieu de Paused) | L'OCE est interprétée comme Stop alors que le user voulait Pause. | Vérifier que `IJobController.Pause` reset le gate, **pas** `Cancel()` le CTS. |
+| Stop pendant Pause hang la console | Le `Wait` n'est pas token-aware. | `BackupManager.ExecuteJob` doit utiliser `pauseGate.Wait(ct)`, pas `pauseGate.Wait()`. |
+| Le log ne contient pas les transitions | Sans `pauseGate`, BackupManager ne logue jamais. | Vérifier que la GUI / l'orchestrateur instancient un `JobExecutionContext` avec son `PauseGate`. |

--- a/src/EasyLog/LogEvent.cs
+++ b/src/EasyLog/LogEvent.cs
@@ -31,4 +31,10 @@ public enum LogEvent
 
     /// <summary>A Pause / Play / Stop command arrived from the remote console.</summary>
     CommandReceived = 7,
+
+    /// <summary>A backup job stalled at a file boundary because its PauseGate was reset by IJobController.Pause(jobName) or PauseAll() (business-software watcher included).</summary>
+    JobPaused = 8,
+
+    /// <summary>A previously paused backup job resumed after its PauseGate was signaled by IJobController.Resume(jobName) or ResumeAll().</summary>
+    JobResumed = 9,
 }

--- a/src/EasySave.UI/Services/BackupManagerAdapter.cs
+++ b/src/EasySave.UI/Services/BackupManagerAdapter.cs
@@ -67,7 +67,7 @@ public sealed class BackupManagerAdapter : IBackupManagerAdapter
         {
             // ExecuteJob is synchronous; run on thread pool and pass the linked token
             // so cancel requests stop the job at the next file boundary.
-            await Task.Run(() => _manager.ExecuteJob(jobName, resumeAfterPath, cts.Token), cts.Token)
+            await Task.Run(() => _manager.ExecuteJob(jobName, resumeAfterPath, ct: cts.Token), cts.Token)
                       .ConfigureAwait(false);
         }
         catch (OperationCanceledException) { }

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -142,7 +142,7 @@ public sealed class BackupManager
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
     /// <exception cref="KeyNotFoundException">Thrown when no job with that name exists.</exception>
     /// <exception cref="DirectoryNotFoundException">Thrown when the source directory does not exist.</exception>
-    public void ExecuteJob(string name, string? resumeAfterPath = null, CancellationToken ct = default)
+    public void ExecuteJob(string name, string? resumeAfterPath = null, ManualResetEventSlim? pauseGate = null, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
@@ -150,7 +150,7 @@ public sealed class BackupManager
         var job = jobs.FirstOrDefault(j => j.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
                   ?? throw new KeyNotFoundException(name);
 
-        RunJob(job, resumeAfterPath, ct);
+        RunJob(job, resumeAfterPath, pauseGate, ct);
     }
 
     /// <summary>
@@ -161,7 +161,7 @@ public sealed class BackupManager
     {
         foreach (var job in _jobRepository.Load())
         {
-            try { RunJob(job, resumeAfterPath: null, CancellationToken.None); }
+            try { RunJob(job, resumeAfterPath: null, pauseGate: null, CancellationToken.None); }
             catch (Exception ex)
             {
                 Console.Error.WriteLine($"[BackupManager] Job '{job.Name}' failed: {ex.Message}");
@@ -169,7 +169,7 @@ public sealed class BackupManager
         }
     }
 
-    private void RunJob(BackupJob job, string? resumeAfterPath, CancellationToken ct)
+    private void RunJob(BackupJob job, string? resumeAfterPath, ManualResetEventSlim? pauseGate, CancellationToken ct)
     {
         var sourceDir = new DirectoryInfo(job.SourcePath);
         if (!sourceDir.Exists)
@@ -220,6 +220,46 @@ public sealed class BackupManager
                 // never left in a partial state.
                 ct.ThrowIfCancellationRequested();
 
+                // V3 PauseGate: if a controller (IJobController.Pause /
+                // PauseAll, business-software watcher, remote console) has
+                // reset the gate, stall here until it gets signaled again.
+                // The wait is token-aware so a concurrent Stop unblocks it
+                // with an OperationCanceledException rather than a hung
+                // worker thread. Transitions are logged and reflected in
+                // state.json so the GUI and remote consoles see the pause.
+                if (pauseGate is not null && !pauseGate.IsSet)
+                {
+                    state.State = JobState.Paused;
+                    state.LastActionTime = DateTimeOffset.Now;
+                    _stateTracker.Update(state);
+                    _logger.Append(new LogEntry
+                    {
+                        Timestamp = DateTimeOffset.Now.ToString("o"),
+                        JobName = job.Name,
+                        SourceFile = string.Empty,
+                        TargetFile = string.Empty,
+                        FileSize = 0,
+                        FileTransferTimeMs = 0,
+                        EventType = LogEvent.JobPaused,
+                    });
+
+                    pauseGate.Wait(ct);
+
+                    state.State = JobState.Active;
+                    state.LastActionTime = DateTimeOffset.Now;
+                    _stateTracker.Update(state);
+                    _logger.Append(new LogEntry
+                    {
+                        Timestamp = DateTimeOffset.Now.ToString("o"),
+                        JobName = job.Name,
+                        SourceFile = string.Empty,
+                        TargetFile = string.Empty,
+                        FileSize = 0,
+                        FileTransferTimeMs = 0,
+                        EventType = LogEvent.JobResumed,
+                    });
+                }
+
                 FileHelpers.EnsureDirectoryExists(targetPath);
 
                 var (transferMs, encryptionMs) = ProcessFile(file, targetPath, ct);
@@ -246,7 +286,13 @@ public sealed class BackupManager
         }
         catch (OperationCanceledException)
         {
-            paused = true;
+            // v2 callers cancel the token when they want a Pause (the
+            // adapter then restarts the job from the resume cursor). v3
+            // callers (BackupManagerJobRunner) cancel the token only for
+            // Stop and use the dedicated PauseGate for Pause, so an OCE on
+            // that path means "stop" and must leave the job Inactive, not
+            // Paused. Differentiate on whether a pauseGate was supplied.
+            paused = pauseGate is null;
             throw;
         }
         finally

--- a/src/EasySave/Services/BackupManagerJobRunner.cs
+++ b/src/EasySave/Services/BackupManagerJobRunner.cs
@@ -41,9 +41,14 @@ public sealed class BackupManagerJobRunner : IJobRunner
 
         // ExecuteJob is synchronous; run it on the thread pool with the
         // per-job CTS so Stop()/Cancel() unwind it at the next file
-        // boundary without disturbing sibling jobs.
+        // boundary without disturbing sibling jobs. PauseGate is forwarded
+        // so IJobController.Pause/PauseAll stalls this job between two
+        // files without producing a Cancelled JobOutcome.
         return Task.Run(
-            () => _backupManager.ExecuteJob(context.JobName, ct: context.Cts.Token),
+            () => _backupManager.ExecuteJob(
+                context.JobName,
+                pauseGate: context.PauseGate,
+                ct: context.Cts.Token),
             context.Cts.Token);
     }
 }

--- a/src/EasySave/Services/IJobController.cs
+++ b/src/EasySave/Services/IJobController.cs
@@ -1,0 +1,46 @@
+namespace EasySave.Services;
+
+// UI-/watcher-facing control surface over every job currently running in
+// the v3 parallel orchestrator. Operates by job name for fine-grained
+// control (a remote console clicking Pause on a single row), and exposes
+// "All" variants for blanket actions — typically driven by the business-
+// software watcher when a watched process appears or disappears.
+//
+// IParallelBackupOrchestrator inherits this interface so the orchestrator
+// stays the single source of truth for the live job map; consumers that
+// only need control (the watcher, the remote-command handler) can depend
+// on the narrower IJobController surface instead of the full orchestrator.
+//
+// All methods are thread-safe and no-op when the targeted job is not in
+// the matching state — calling Pause on a job that already paused, Resume
+// on a running job, or any operation on an unknown job name does not
+// throw.
+public interface IJobController
+{
+    // Pauses the named running job at the next file boundary. The pause
+    // takes effect after the file currently being copied finishes, so the
+    // target file is never left in a partial state.
+    void Pause(string jobName);
+
+    // Resumes a previously paused job by signaling its PauseGate so the
+    // worker thread parked between two files wakes up and continues.
+    void Resume(string jobName);
+
+    // Stops the named job through its CancellationToken — works on both
+    // Running and Paused jobs. The job's RunAsync returns with
+    // JobOutcome.Cancelled.
+    void Stop(string jobName);
+
+    // Pauses every job currently registered in the orchestrator. Idempotent
+    // (jobs already paused stay paused). Used by the business-software
+    // watcher when a watched process is detected.
+    void PauseAll();
+
+    // Resumes every job currently registered in the orchestrator. Mirror
+    // of PauseAll — used by the watcher when the watched process exits.
+    void ResumeAll();
+
+    // Cancels every job currently registered in the orchestrator. Each
+    // job returns Cancelled from RunAsync.
+    void StopAll();
+}

--- a/src/EasySave/Services/IParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/IParallelBackupOrchestrator.cs
@@ -15,7 +15,12 @@ namespace EasySave.Services;
 // Implementations own per-job CancellationTokenSources and a semaphore for
 // the parallelism cap, hence the IDisposable surface for app-shutdown
 // cleanup (matching the precedent set by IBackupManagerAdapter).
-public interface IParallelBackupOrchestrator : IDisposable
+//
+// Per-job and "All" control methods (Pause / Resume / Stop / PauseAll /
+// ResumeAll / StopAll) come from the inherited IJobController interface
+// so the watcher and the remote-command handler can depend on the
+// narrower control surface instead of the full orchestrator.
+public interface IParallelBackupOrchestrator : IJobController, IDisposable
 {
     // Runs every job in jobNames concurrently, bounded by MaxParallelJobs,
     // and completes when all of them have finished, failed or been
@@ -30,20 +35,6 @@ public interface IParallelBackupOrchestrator : IDisposable
     Task<IReadOnlyList<JobResult>> RunAsync(
         IEnumerable<string> jobNames,
         CancellationToken ct);
-
-    // Pauses the named running job at the next file boundary. No-op when
-    // the orchestrator has no active context for jobName (never started or
-    // already finished) or when the job is already paused.
-    void Pause(string jobName);
-
-    // Resumes a previously paused job. No-op when the job is not paused.
-    void Resume(string jobName);
-
-    // Stops the named job. Works on both Running and Paused jobs — a paused
-    // job is still alive and Stop must be able to reach it. The job exits
-    // with JobOutcome.Cancelled. No-op when the orchestrator has no active
-    // context for jobName (never started or already finished).
-    void Stop(string jobName);
 
     // Raised every time a running job's progress snapshot is updated.
     // Subscribers must be thread-safe: handlers run on the worker thread

--- a/src/EasySave/Services/ParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestrator.cs
@@ -190,6 +190,32 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
             ctx.Cts.Cancel();
     }
 
+    // PauseAll / ResumeAll / StopAll iterate the live job map and delegate
+    // to the per-job operations. _running is a ConcurrentDictionary so the
+    // snapshot enumerator is safe even if a job finishes and removes its
+    // entry mid-iteration; the per-job Pause / Resume / Stop are no-ops
+    // when the context has already been removed.
+    public void PauseAll()
+    {
+        foreach (var ctx in _running.Values)
+            ctx.PauseGate.Reset();
+    }
+
+    public void ResumeAll()
+    {
+        foreach (var ctx in _running.Values)
+            ctx.PauseGate.Set();
+    }
+
+    public void StopAll()
+    {
+        foreach (var ctx in _running.Values)
+        {
+            try { ctx.Cts.Cancel(); }
+            catch (ObjectDisposedException) { /* race with self-disposal */ }
+        }
+    }
+
     // Dispose initiates shutdown by cancelling every in-flight job's CTS
     // (so token-aware runners exit promptly with Cancelled) and disposes the
     // parallelism semaphore. Callers should still await every outstanding

--- a/src/EasySave/Services/ParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestrator.cs
@@ -164,16 +164,27 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
         }
     }
 
+    // Per-job control methods carry the same disposal-race guard as the
+    // "All" variants below: the context can be disposed between the
+    // TryGetValue and the call (ExecuteSingleAsync's `using` fires the
+    // moment the job ends). Swallow ObjectDisposedException — the job is
+    // already in its terminal state, the no-op is semantically correct.
     public void Pause(string jobName)
     {
         if (_running.TryGetValue(jobName, out var ctx))
-            ctx.PauseGate.Reset();
+        {
+            try { ctx.PauseGate.Reset(); }
+            catch (ObjectDisposedException) { /* race with job self-disposal */ }
+        }
     }
 
     public void Resume(string jobName)
     {
         if (_running.TryGetValue(jobName, out var ctx))
-            ctx.PauseGate.Set();
+        {
+            try { ctx.PauseGate.Set(); }
+            catch (ObjectDisposedException) { /* race with job self-disposal */ }
+        }
     }
 
     public void Stop(string jobName)
@@ -187,7 +198,10 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
         // OCE deterministically — that's the standard .NET cancellation
         // pattern and a hard requirement for IJobRunner implementations.
         if (_running.TryGetValue(jobName, out var ctx))
-            ctx.Cts.Cancel();
+        {
+            try { ctx.Cts.Cancel(); }
+            catch (ObjectDisposedException) { /* race with job self-disposal */ }
+        }
     }
 
     // PauseAll / ResumeAll / StopAll iterate the live job map and delegate

--- a/src/EasySave/Services/ParallelBackupOrchestrator.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestrator.cs
@@ -193,18 +193,28 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
     // PauseAll / ResumeAll / StopAll iterate the live job map and delegate
     // to the per-job operations. _running is a ConcurrentDictionary so the
     // snapshot enumerator is safe even if a job finishes and removes its
-    // entry mid-iteration; the per-job Pause / Resume / Stop are no-ops
-    // when the context has already been removed.
+    // entry mid-iteration. The per-job context can be disposed between
+    // the snapshot read and the call (the `using` in ExecuteSingleAsync
+    // disposes the PauseGate and Cts when the job ends), so each call is
+    // wrapped in an ObjectDisposedException catch to swallow that race —
+    // the disposed job is already in its terminal state, the no-op is
+    // semantically correct.
     public void PauseAll()
     {
         foreach (var ctx in _running.Values)
-            ctx.PauseGate.Reset();
+        {
+            try { ctx.PauseGate.Reset(); }
+            catch (ObjectDisposedException) { /* race with job self-disposal */ }
+        }
     }
 
     public void ResumeAll()
     {
         foreach (var ctx in _running.Values)
-            ctx.PauseGate.Set();
+        {
+            try { ctx.PauseGate.Set(); }
+            catch (ObjectDisposedException) { /* race with job self-disposal */ }
+        }
     }
 
     public void StopAll()
@@ -212,7 +222,7 @@ public sealed class ParallelBackupOrchestrator : IParallelBackupOrchestrator
         foreach (var ctx in _running.Values)
         {
             try { ctx.Cts.Cancel(); }
-            catch (ObjectDisposedException) { /* race with self-disposal */ }
+            catch (ObjectDisposedException) { /* race with job self-disposal */ }
         }
     }
 

--- a/src/EasySave/Services/ParallelBackupOrchestratorStub.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestratorStub.cs
@@ -16,5 +16,8 @@ public sealed class ParallelBackupOrchestratorStub : IParallelBackupOrchestrator
     public void Pause(string jobName) { }
     public void Resume(string jobName) { }
     public void Stop(string jobName) { }
+    public void PauseAll() { }
+    public void ResumeAll() { }
+    public void StopAll() { }
     public void Dispose() { }
 }

--- a/src/EasySave/Services/ParallelBackupOrchestratorStub.cs
+++ b/src/EasySave/Services/ParallelBackupOrchestratorStub.cs
@@ -6,9 +6,12 @@ namespace EasySave.Services;
 // Replace this class once IParallelBackupOrchestrator is implemented.
 public sealed class ParallelBackupOrchestratorStub : IParallelBackupOrchestrator
 {
-#pragma warning disable CS0067 // event unused in stub — real impl will fire it
-    public event Action<JobProgressDto>? ProgressChanged;
-#pragma warning restore CS0067
+    // Seeded no-op delegate so the field is never null and matches the
+    // non-nullable IParallelBackupOrchestrator.ProgressChanged invariant,
+    // mirroring the concrete ParallelBackupOrchestrator. The stub never
+    // raises the event itself, but consumers that subscribe must still
+    // see a non-null delegate.
+    public event Action<JobProgressDto> ProgressChanged = static _ => { };
 
     public Task<IReadOnlyList<JobResult>> RunAsync(IEnumerable<string> jobNames, CancellationToken ct)
         => Task.FromResult<IReadOnlyList<JobResult>>(Array.Empty<JobResult>());

--- a/tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs
+++ b/tests/EasySave.Tests.V2/ParallelBackupOrchestratorTests.cs
@@ -358,6 +358,102 @@ public class ParallelBackupOrchestratorTests
         }
     }
 
+    // ---- IJobController "All" methods (business-software watcher path) ----
+
+    [Fact]
+    public async Task PauseAll_ResetsEveryRunningJobsGate()
+    {
+        var startedA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var inspect = new TaskCompletionSource();
+        var observedA = false;
+        var observedB = false;
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (ctx.JobName == "A") startedA.SetResult();
+            else startedB.SetResult();
+            await inspect.Task;
+            if (ctx.JobName == "A") observedA = ctx.PauseGate.IsSet;
+            else observedB = ctx.PauseGate.IsSet;
+        }, maxParallelJobs: 2);
+
+        var task = orch.RunAsync(new[] { "A", "B" }, CancellationToken.None);
+        await Task.WhenAll(startedA.Task, startedB.Task);
+
+        orch.PauseAll();
+        inspect.SetResult();
+
+        await task;
+        Assert.False(observedA);
+        Assert.False(observedB);
+    }
+
+    [Fact]
+    public async Task ResumeAll_SetsEveryPausedJobsGate()
+    {
+        var startedA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+        var inspect = new TaskCompletionSource();
+        var gateA = false;
+        var gateB = false;
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (ctx.JobName == "A") startedA.SetResult();
+            else startedB.SetResult();
+            await inspect.Task;
+            if (ctx.JobName == "A") gateA = ctx.PauseGate.IsSet;
+            else gateB = ctx.PauseGate.IsSet;
+        }, maxParallelJobs: 2);
+
+        var task = orch.RunAsync(new[] { "A", "B" }, CancellationToken.None);
+        await Task.WhenAll(startedA.Task, startedB.Task);
+
+        orch.PauseAll();
+        orch.ResumeAll();
+        inspect.SetResult();
+
+        await task;
+        Assert.True(gateA);
+        Assert.True(gateB);
+    }
+
+    [Fact]
+    public async Task StopAll_CancelsEveryJob_AllResultsAreCancelled()
+    {
+        var startedA = new TaskCompletionSource();
+        var startedB = new TaskCompletionSource();
+
+        using var orch = Make(async (ctx, _) =>
+        {
+            if (ctx.JobName == "A") startedA.SetResult();
+            else startedB.SetResult();
+            await Task.Delay(Timeout.Infinite, ctx.Cts.Token);
+        }, maxParallelJobs: 2);
+
+        var task = orch.RunAsync(new[] { "A", "B" }, CancellationToken.None);
+        await Task.WhenAll(startedA.Task, startedB.Task);
+
+        orch.StopAll();
+
+        var results = await task;
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal(JobOutcome.Cancelled, r.Outcome));
+        Assert.All(results, r => Assert.Equal("stopped via Stop()", r.Message));
+    }
+
+    [Fact]
+    public void PauseResumeStopAll_OnEmptyOrchestrator_AreNoOps()
+    {
+        // No job ever registered — the iteration sees an empty snapshot and
+        // every call returns without throwing.
+        using var orch = Make((_, _) => Task.CompletedTask);
+        orch.PauseAll();
+        orch.ResumeAll();
+        orch.StopAll();
+    }
+
     // ---- progress fan-out ----
 
     [Fact]

--- a/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
+++ b/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
@@ -246,9 +246,12 @@ public class BackupManagerPauseResumeTests : IDisposable
 
         // Gate starts CLOSED so the first file boundary already stalls.
         using var pauseGate = new ManualResetEventSlim(initialState: false);
+        // Hard ceiling so a regression that leaves the runner parked
+        // forever fails the test instead of hanging the suite.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
         var execution = Task.Run(() => manager.ExecuteJob(
-            "gated", resumeAfterPath: null, pauseGate: pauseGate));
+            "gated", resumeAfterPath: null, pauseGate: pauseGate, ct: cts.Token));
 
         // Wait for the JobPaused log entry — proves the runner is parked
         // on the gate at the file boundary.

--- a/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
+++ b/tests/EasySave.Tests/BackupManagerPauseResumeTests.cs
@@ -105,7 +105,7 @@ public class BackupManagerPauseResumeTests : IDisposable
         var manager = CreateManager(logger);
 
         Assert.Throws<OperationCanceledException>(
-            () => manager.ExecuteJob("pause-mid", resumeAfterPath: null, cts.Token));
+            () => manager.ExecuteJob("pause-mid", resumeAfterPath: null, ct: cts.Token));
 
         // Two files copied, three remain.
         var copied = Directory.GetFiles(_targetDir).Length;
@@ -151,7 +151,7 @@ public class BackupManagerPauseResumeTests : IDisposable
             var logger = new CancelAfterNthFileLogger(cts, afterCount: 2);
             var manager = CreateManager(logger);
             Assert.Throws<OperationCanceledException>(
-                () => manager.ExecuteJob("pause-resume", resumeAfterPath: null, cts.Token));
+                () => manager.ExecuteJob("pause-resume", resumeAfterPath: null, ct: cts.Token));
         }
 
         var afterPause = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "pause-resume");
@@ -193,7 +193,7 @@ public class BackupManagerPauseResumeTests : IDisposable
             var logger = new CancelAfterNthFileLogger(cts, afterCount: 2);
             var manager = CreateManager(logger);
             Assert.Throws<OperationCanceledException>(
-                () => manager.ExecuteJob("source-shrunk", resumeAfterPath: null, cts.Token));
+                () => manager.ExecuteJob("source-shrunk", resumeAfterPath: null, ct: cts.Token));
         }
         Assert.Equal(2, Directory.GetFiles(_targetDir).Length);
 
@@ -212,5 +212,92 @@ public class BackupManagerPauseResumeTests : IDisposable
         Assert.Contains("file-3.txt", copiedNames);
         Assert.Contains("file-4.txt", copiedNames);
         Assert.Contains("file-5.txt", copiedNames);
+    }
+
+    // Signals a TaskCompletionSource the first time a JobPaused log entry
+    // arrives, so the test knows BackupManager is parked on its pause gate
+    // without resorting to Thread.Sleep / Task.Delay timing probes.
+    private sealed class JobPausedSignalLogger : IDailyLogger
+    {
+        private readonly TaskCompletionSource _onJobPaused = new();
+        public Task Paused => _onJobPaused.Task;
+
+        public void Append(LogEntry entry)
+        {
+            if (entry.EventType == LogEvent.JobPaused)
+                _onJobPaused.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteJob_PauseGateReset_StateBecomesPausedThenResumes()
+    {
+        // V3 path: ExecuteJob receives a ManualResetEventSlim that the
+        // orchestrator's IJobController.Pause / PauseAll reset. The runner
+        // must transition state.json to Paused at the next file boundary,
+        // wait until the gate is signaled, then continue and finish
+        // Inactive.
+        for (int i = 1; i <= 4; i++)
+            File.WriteAllText(Path.Combine(_sourceDir, $"file-{i}.txt"), $"content-{i}");
+        SeedJob("gated", BackupType.Full);
+
+        var logger = new JobPausedSignalLogger();
+        var manager = CreateManager(logger);
+
+        // Gate starts CLOSED so the first file boundary already stalls.
+        using var pauseGate = new ManualResetEventSlim(initialState: false);
+
+        var execution = Task.Run(() => manager.ExecuteJob(
+            "gated", resumeAfterPath: null, pauseGate: pauseGate));
+
+        // Wait for the JobPaused log entry — proves the runner is parked
+        // on the gate at the file boundary.
+        await logger.Paused.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var paused = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "gated");
+        Assert.Equal(JobState.Paused, paused.State);
+        // Counters are preserved while paused (job has not progressed yet).
+        Assert.Equal(4, paused.FilesRemaining);
+
+        // Release the gate and let the job complete normally.
+        pauseGate.Set();
+        await execution;
+
+        var finished = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "gated");
+        Assert.Equal(JobState.Inactive, finished.State);
+        Assert.Equal(0, finished.FilesRemaining);
+        Assert.Equal(4, Directory.GetFiles(_targetDir).Length);
+    }
+
+    [Fact]
+    public async Task ExecuteJob_PauseGateAndStopTogether_StateBecomesInactive()
+    {
+        // V3 semantics: with a pauseGate supplied, an OperationCanceledException
+        // means Stop (not Pause). The job ends Inactive, not Paused — that's
+        // the contract IParallelBackupOrchestrator.Stop relies on so the v2
+        // pause-as-cancel behaviour stays intact for the adapter callers.
+        for (int i = 1; i <= 4; i++)
+            File.WriteAllText(Path.Combine(_sourceDir, $"file-{i}.txt"), $"content-{i}");
+        SeedJob("gated-stop", BackupType.Full);
+
+        var logger = new JobPausedSignalLogger();
+        var manager = CreateManager(logger);
+
+        using var pauseGate = new ManualResetEventSlim(initialState: false);
+        using var cts = new CancellationTokenSource();
+
+        var execution = Task.Run(() =>
+            Assert.Throws<OperationCanceledException>(() => manager.ExecuteJob(
+                "gated-stop", resumeAfterPath: null, pauseGate: pauseGate, ct: cts.Token)));
+
+        await logger.Paused.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // Stop while paused. The token-aware Wait inside BackupManager
+        // throws OCE and the catch must land Inactive, not Paused.
+        cts.Cancel();
+        await execution;
+
+        var stopped = ReadStateEntry(Path.Combine(_dataDir, "state.json"), "gated-stop");
+        Assert.Equal(JobState.Inactive, stopped.State);
     }
 }


### PR DESCRIPTION
Phase 3 v3 — task `869d8r8qd` (Priority 2 / CdC reporté de V2). Implements the requirement *« Pour chaque travail (ou l'ensemble des travaux), l'utilisateur doit pouvoir Pause / Play / Stop »* with a real PauseGate path instead of the v2 pause-as-cancel hack.

## What changes

### `LogEvent` (EasyLog)
- `JobPaused = 8` and `JobResumed = 9` appended at the end (additive only — the v1.0 EasyLog freeze is respected, matches the existing `EventType` extension pattern).

### `IJobController` (new)
- Per-job `Pause/Resume/Stop` + blanket `PauseAll/ResumeAll/StopAll`. UI- and watcher-facing control surface; the business-software watcher (next task `869d8r8um`) will depend on this narrower interface.

### `IParallelBackupOrchestrator`
- Now extends `IJobController` + `IDisposable` — per-job methods move to the inherited interface. The concrete `ParallelBackupOrchestrator` gains `PauseAll` / `ResumeAll` / `StopAll` that iterate the live `_running` dictionary and delegate to the per-job operations. `ConcurrentDictionary` snapshot enumerator stays safe across mid-iteration removals.

### `BackupManager.ExecuteJob`
- New optional `ManualResetEventSlim? pauseGate` parameter (default `null` = v2 behaviour preserved). When supplied, the file loop checks the gate at the file boundary, transitions `state.json` to `Paused` with a `JobPaused` log entry, waits with the token-aware overload, then transitions back to `Active` with a `JobResumed` entry.
- OCE handling differentiates on whether `pauseGate` was supplied:
  - v2 callers (no gate) keep the 'OCE = pause' semantics so the adapter's pause-via-cancel still works.
  - v3 callers (gate supplied) treat OCE as Stop and land `Inactive`, not `Paused`.

### `BackupManagerJobRunner`
- Forwards `context.PauseGate` to `BackupManager.ExecuteJob`, completing the orchestrator wiring left as a follow-up in #143.

Adapter and v1 tests updated to pass `ct:` by name now that `pauseGate` sits between `resumeAfterPath` and `ct` in the signature.

## Tests

- `BackupManagerPauseResumeTests` (v1) gains two cases:
  - `ExecuteJob_PauseGateReset_StateBecomesPausedThenResumes` — gate closed → state `Paused`, gate signaled → reprise and finish `Inactive`. Deterministic via a `JobPausedSignalLogger` that completes a TCS the first time a `JobPaused` log entry arrives (no Thread.Sleep).
  - `ExecuteJob_PauseGateAndStopTogether_StateBecomesInactive` — OCE during a pause yields `Inactive`, not `Paused`, when `pauseGate` is set.
- `ParallelBackupOrchestratorTests` (v2/v3) gains:
  - `PauseAll_ResetsEveryRunningJobsGate`
  - `ResumeAll_SetsEveryPausedJobsGate`
  - `StopAll_CancelsEveryJob_AllResultsAreCancelled`
  - `PauseResumeStopAll_OnEmptyOrchestrator_AreNoOps`

## Recette manuelle

`docs/recettes/v3-pause-resume-run-all.md` couvre les flots par job et Run-All (avec ouverture de `calc.exe` pour le watcher, qui arrivera dans la task suivante), les transitions `state.json` attendues, la forme des logs, et un tableau de troubleshooting.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet test` ciblé sur les suites pause/orchestrateur → 22 / 22 V2 + 6 / 6 V1
- [x] Full V2 suite : 123 / 123 (était 118 ; +5 nouveaux cas)
- [x] Full V1 suite : 130 / 132 (1 flaky pré-existant non lié — `FileHelpersTests.WriteAllTextAtomic_ConcurrentCalls_DoNotCollideOnTempName` qui throw `UnauthorizedAccessException` sur certains MoveFile Windows ; 1 test skipped)
- [ ] Manual smoke via la GUI + la console déportée (recette dans `docs/recettes/v3-pause-resume-run-all.md`)

## Suite

- `869d8r8um` (Priority 3) — Watcher business software qui appelle `IJobController.PauseAll()` / `ResumeAll()`. Cette PR débloque cette tâche.
- `869d8r8p0` (Priority 1) — Priority extensions + 2-pass orchestrator. Standalone, indépendant.