### PR TITLE
feat(easylog): add optional MachineName + UserName on LogEntry (v1.2.0)

### DIFF
--- a/docs/schemas/easysave-log.xsd
+++ b/docs/schemas/easysave-log.xsd
@@ -27,6 +27,9 @@
       <xs:element name="FileTransferTimeMs" type="xs:long"/>
       <xs:element name="EncryptionTimeMs"   type="xs:long" minOccurs="0"/>
       <xs:element name="EventType"          type="LogEventName" minOccurs="0"/>
+      <!-- v1.2+ optional host/user stamping. Absent on v1 / v2 logs. -->
+      <xs:element name="MachineName"        type="xs:string" minOccurs="0"/>
+      <xs:element name="UserName"           type="xs:string" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/src/EasyLog/EasyLog.csproj
+++ b/src/EasyLog/EasyLog.csproj
@@ -5,6 +5,12 @@
     <AssemblyName>EasyLog</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Daily JSON and XML logger reusable across ProSoft applications.</Description>
+    <!-- 1.2.0: adds optional MachineName / UserName on LogEntry. v1.0 and
+         v1.1 consumers stay compatible — new fields are nullable and
+         omitted from the JSON / XML output when null. -->
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -118,6 +118,12 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
             FileTransferTimeMs = entry.FileTransferTimeMs,
             EncryptionTimeMs = entry.EncryptionTimeMs,
             EventType = entry.EventType,
+            // Stamp host/user only when the caller did not supply them.
+            // A central collector relaying entries from remote hosts will
+            // forward the original sender's fields untouched — never the
+            // collector's own machine.
+            MachineName = entry.MachineName ?? Environment.MachineName,
+            UserName = entry.UserName ?? Environment.UserName,
         };
 
         // Centralized side first: the shipper is async and non-blocking, so

--- a/src/EasyLog/LogEntry.cs
+++ b/src/EasyLog/LogEntry.cs
@@ -61,4 +61,22 @@ public sealed class LogEntry
     [JsonConverter(typeof(JsonStringEnumConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public LogEvent? EventType { get; set; }
+
+    /// <summary>
+    /// Host that produced the entry (EasyLog v1.2+). Lets a centralized
+    /// collector demultiplex entries coming from multiple workstations into
+    /// a single daily file. Null on v1 / v2 logs and on v3+ entries that
+    /// the producer chose not to stamp — the daily-file readers must treat
+    /// the field as optional.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MachineName { get; set; }
+
+    /// <summary>
+    /// User account that produced the entry (EasyLog v1.2+). Same retro-
+    /// compat contract as <see cref="MachineName"/>: optional, null on
+    /// pre-v3 logs, never required by readers.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? UserName { get; set; }
 }

--- a/src/EasyLog/README.md
+++ b/src/EasyLog/README.md
@@ -132,6 +132,10 @@ The POCO that describes a single logged operation. Fields:
 | `TargetFile` | `string` | Full target path (UNC recommended) |
 | `FileSize` | `long` | Source size in bytes |
 | `FileTransferTimeMs` | `long` | Transfer duration; `< 0` on error |
+| `EncryptionTimeMs` | `long?` | v1.1+ — encryption duration; `< 0` on encryption error, `null` when no encryption was performed |
+| `EventType` | `LogEvent?` | v1.1+ — V3 event category (`null` on v1/v2 file-transfer rows) |
+| `MachineName` | `string?` | v1.2+ — host that produced the entry (`null` on v1/v2 rows; auto-stamped by the daily loggers when the caller leaves it null) |
+| `UserName` | `string?` | v1.2+ — user account that produced the entry (same retro-compat contract as `MachineName`) |
 
 ### `JsonDailyLogger`
 

--- a/src/EasyLog/XmlDailyLogger.cs
+++ b/src/EasyLog/XmlDailyLogger.cs
@@ -61,6 +61,9 @@ public sealed class XmlDailyLogger : IDailyLogger
             FileTransferTimeMs = entry.FileTransferTimeMs,
             EncryptionTimeMs = entry.EncryptionTimeMs,
             EventType = entry.EventType,
+            // See JsonDailyLogger.Append for the host/user stamping contract.
+            MachineName = entry.MachineName ?? Environment.MachineName,
+            UserName = entry.UserName ?? Environment.UserName,
         };
 
         if (LogRouter.ShouldShip(_mode))

--- a/src/EasyLog/XmlFormatter.cs
+++ b/src/EasyLog/XmlFormatter.cs
@@ -47,6 +47,18 @@ public sealed class XmlFormatter : ILogFormatter
             element.Add(new XElement("EventType", entry.EventType.Value.ToString()));
         }
 
+        // v1.2+ host stamping. Both fields are optional in the schema and
+        // omitted from the XML when null so v1 / v2 readers continue to see
+        // the exact element set they always had.
+        if (!string.IsNullOrEmpty(entry.MachineName))
+        {
+            element.Add(new XElement("MachineName", entry.MachineName));
+        }
+        if (!string.IsNullOrEmpty(entry.UserName))
+        {
+            element.Add(new XElement("UserName", entry.UserName));
+        }
+
         return element.ToString(SaveOptions.None);
     }
 

--- a/tests/EasySave.Tests.V2/LogEntryHostFieldsTests.cs
+++ b/tests/EasySave.Tests.V2/LogEntryHostFieldsTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using EasyLog;
+
+namespace EasySave.Tests.V2;
+
+/// <summary>
+/// Verifies EasyLog 1.2.0 host stamping: MachineName / UserName are
+/// optional, auto-populated from <see cref="Environment"/> when the
+/// caller leaves them null, preserved across the logger's path
+/// normalization step, and omitted from the JSON / XML output when null
+/// so v1 / v2 readers stay compatible byte-for-byte.
+/// </summary>
+public class LogEntryHostFieldsTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public LogEntryHostFieldsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "easylog-hostfields-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void Deserialize_OldV1V2Json_WithoutHostFields_StillWorks()
+    {
+        // A pre-1.2 daily file (no MachineName / UserName elements) must
+        // continue to deserialize cleanly into the v1.2 LogEntry POCO.
+        const string v1Json = """
+            [
+              {
+                "Timestamp": "2026-01-15T10:00:00+01:00",
+                "JobName": "legacy",
+                "SourceFile": "\\\\nas\\share\\a.txt",
+                "TargetFile": "\\\\nas\\share\\b.txt",
+                "FileSize": 1024,
+                "FileTransferTimeMs": 12
+              }
+            ]
+            """;
+
+        var entries = JsonSerializer.Deserialize<List<LogEntry>>(v1Json);
+
+        Assert.NotNull(entries);
+        Assert.Single(entries!);
+        Assert.Equal("legacy", entries![0].JobName);
+        // Default null on a pre-1.2 row — readers must treat the fields
+        // as optional and never assume they are populated.
+        Assert.Null(entries[0].MachineName);
+        Assert.Null(entries[0].UserName);
+    }
+
+    [Fact]
+    public void Serialize_LogEntry_WithoutHostFields_OmitsThemFromJson()
+    {
+        // Regression: a v1.x caller that does not set the new fields must
+        // see the exact same JSON shape as before — no empty "MachineName":
+        // null pollution in the daily file.
+        var entry = new LogEntry
+        {
+            Timestamp = "2026-05-12T10:00:00+02:00",
+            JobName = "v1-caller",
+            SourceFile = "src",
+            TargetFile = "dst",
+            FileSize = 1,
+            FileTransferTimeMs = 1,
+        };
+
+        string json = JsonSerializer.Serialize(entry);
+
+        Assert.DoesNotContain("MachineName", json);
+        Assert.DoesNotContain("UserName", json);
+    }
+
+    [Fact]
+    public void JsonDailyLogger_AutoStamps_HostFields_WhenCallerLeavesThemNull()
+    {
+        using (var logger = new JsonDailyLogger(_tempDir))
+        {
+            logger.Append(new LogEntry
+            {
+                Timestamp = "2026-05-12T10:00:00+02:00",
+                JobName = "stamp-me",
+                SourceFile = "src",
+                TargetFile = "dst",
+                FileSize = 1,
+                FileTransferTimeMs = 1,
+            });
+        }
+
+        var file = Directory.GetFiles(_tempDir, "*.json").Single();
+        var entries = JsonSerializer.Deserialize<List<LogEntry>>(File.ReadAllText(file))!;
+
+        Assert.Equal(Environment.MachineName, entries[0].MachineName);
+        Assert.Equal(Environment.UserName, entries[0].UserName);
+    }
+
+    [Fact]
+    public void JsonDailyLogger_PreservesCallerProvidedHostFields_AcrossNormalization()
+    {
+        // A central collector receiving an entry from a remote host writes
+        // it to its own daily file. The original sender's MachineName / UserName
+        // must survive normalization — the collector must not overwrite them
+        // with its own Environment values.
+        using (var logger = new JsonDailyLogger(_tempDir))
+        {
+            logger.Append(new LogEntry
+            {
+                Timestamp = "2026-05-12T10:00:00+02:00",
+                JobName = "from-remote",
+                SourceFile = "src",
+                TargetFile = "dst",
+                FileSize = 1,
+                FileTransferTimeMs = 1,
+                MachineName = "WS-OPERATOR-07",
+                UserName = "alice",
+            });
+        }
+
+        var file = Directory.GetFiles(_tempDir, "*.json").Single();
+        var entries = JsonSerializer.Deserialize<List<LogEntry>>(File.ReadAllText(file))!;
+
+        Assert.Equal("WS-OPERATOR-07", entries[0].MachineName);
+        Assert.Equal("alice", entries[0].UserName);
+    }
+
+    [Fact]
+    public void XmlDailyLogger_AutoStamps_HostFields_WhenCallerLeavesThemNull()
+    {
+        var logger = new XmlDailyLogger(_tempDir);
+        logger.Append(new LogEntry
+        {
+            Timestamp = "2026-05-12T10:00:00+02:00",
+            JobName = "stamp-me-xml",
+            SourceFile = "src",
+            TargetFile = "dst",
+            FileSize = 1,
+            FileTransferTimeMs = 1,
+        });
+
+        var file = Directory.GetFiles(_tempDir, "*.xml").Single();
+        var doc = XDocument.Load(file);
+        var entry = doc.Root!.Element("Entry")!;
+
+        Assert.Equal(Environment.MachineName, entry.Element("MachineName")?.Value);
+        Assert.Equal(Environment.UserName, entry.Element("UserName")?.Value);
+    }
+
+    [Fact]
+    public void XmlFormatter_OmitsHostElements_WhenFieldsAreNull()
+    {
+        // Regression: a v1 / v2 entry without host fields must produce the
+        // exact element set v1 / v2 readers expect — no empty <MachineName/>
+        // sneaking into the file.
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry
+        {
+            Timestamp = "2026-05-12T10:00:00+02:00",
+            JobName = "v1-row",
+            SourceFile = "src",
+            TargetFile = "dst",
+            FileSize = 1,
+            FileTransferTimeMs = 1,
+        };
+
+        string xml = formatter.Format(entry);
+
+        Assert.DoesNotContain("<MachineName", xml);
+        Assert.DoesNotContain("<UserName", xml);
+    }
+
+    [Fact]
+    public void XmlFormatter_EmitsHostElements_WhenFieldsAreSet()
+    {
+        var formatter = new XmlFormatter();
+        var entry = new LogEntry
+        {
+            Timestamp = "2026-05-12T10:00:00+02:00",
+            JobName = "v1.2-row",
+            SourceFile = "src",
+            TargetFile = "dst",
+            FileSize = 1,
+            FileTransferTimeMs = 1,
+            MachineName = "BUILD-VM-01",
+            UserName = "ci",
+        };
+
+        var doc = XDocument.Parse(formatter.Format(entry));
+
+        Assert.Equal("BUILD-VM-01", doc.Root!.Element("MachineName")?.Value);
+        Assert.Equal("ci", doc.Root.Element("UserName")?.Value);
+    }
+}


### PR DESCRIPTION
## Summary

- `LogEntry` gains two nullable string properties: `MachineName` and `UserName`.
- `JsonDailyLogger` / `XmlDailyLogger` auto-stamp the fields from `Environment.MachineName` / `Environment.UserName` when the caller leaves them null. Caller-provided values are preserved across normalization (a central collector forwarding a remote sender's entry never overwrites the original identity).
- `XmlFormatter` emits the elements only when set; XSD schema marks both `minOccurs=\"0\"`.
- EasyLog bumped to **1.2.0** (additive, minor — no break to the v1.0 frozen contract).
- README's `LogEntry` table updated with the new fields.

## Backwards compatibility

- Old v1 / v2 JSON daily files (without `MachineName` / `UserName`) deserialize cleanly into the v1.2 POCO — covered by `Deserialize_OldV1V2Json_WithoutHostFields_StillWorks`.
- A v1.x caller that does not set the new fields produces byte-for-byte the same JSON / XML shape as before — covered by `Serialize_LogEntry_WithoutHostFields_OmitsThemFromJson` + `XmlFormatter_OmitsHostElements_WhenFieldsAreNull`.
- `EasyLog 1.0` / `1.1` consumers can keep consuming `EasyLog.dll` without recompilation.

## Test plan

- [x] `dotnet build EasySave.sln` — 0 errors
- [x] `dotnet test tests/EasySave.Tests/EasySave.Tests.csproj` — 123/123 pass (v1 retrocompat)
- [x] 7 new tests in `LogEntryHostFieldsTests` pass (V1/V2 JSON deserialization, auto-stamp, caller-override, XML omission/emission)
- [x] No regression on the 122 other V2 tests (the 4 `SelfSignedCertProviderTests` failures are a pre-existing macOS-only flake — `EphemeralKeySet` not supported)
- [ ] CI green on Linux / Windows

## Notes

- `JobId` was mentioned in the task brief but does not actually exist on `LogEntry` today (`JobName` is the only job identifier). Out of scope — happy to add it in a follow-up if a numeric / GUID identifier is needed.
- The `HttpLogShipper` introduced in #179 still uses a `CentralizedLogPayload` wrapper for `MachineName` / `UserName`. Now that the fields live on `LogEntry` itself, that wrapper is redundant — small follow-up PR will drop it so the shipper just POSTs the raw `LogEntry` JSON.