### PR TITLE
feat(backup): auto-pause v3 jobs when business software is detected

### DIFF
--- a/docs/recettes/v3-business-software-auto-pause.md
+++ b/docs/recettes/v3-business-software-auto-pause.md
@@ -1,0 +1,111 @@
+# Recette V3 — Pause / reprise auto sur logiciel métier
+
+**Critère grille tuteur V3** : « Si le logiciel détecte le fonctionnement
+d'un logiciel métier, il doit obligatoirement mettre en pause les
+travaux. Celles-ci redémarrent automatiquement dès que le logiciel
+métier est arrêté. »
+
+Cette recette valide le chemin V3 : la détection du logiciel métier
+appelle `IJobController.PauseAll()` sur l'orchestrateur parallèle (vrai
+PauseGate, pas une annulation), et `ResumeAll()` au moment où la dernière
+instance disparaît. Chaque transition est tracée dans le log journalier
+avec `LogEvent.BusinessSoftwareAutoPaused` / `BusinessSoftwareAutoResumed`.
+
+## Pré-requis
+
+- EasySave v3 buildé en Release (`dotnet build EasySave.sln -c Release`).
+- GUI Avalonia lancée (`dotnet run --project src/EasySave.UI`).
+- Un dossier source contenant **≥ 50 fichiers** pour avoir le temps
+  d'observer la pause.
+- La calculatrice Windows (`calc.exe`) disponible — sert de logiciel
+  métier de démonstration.
+
+## Configuration
+
+Éditer `src/EasySave/appsettings.json` (ou la copie live
+`%AppData%\ProSoft\EasySave\settings.json`) :
+
+```json
+{
+  "language": "fr",
+  "business_software": ["calc"],
+  "max_parallel_jobs": 2,
+  "log_format": "json"
+}
+```
+
+> Note : `business_software` accepte indifféremment `"calc"` ou
+> `"calc.exe"` — le détecteur normalise le suffixe `.exe`.
+
+Relancer la GUI pour que `BusinessWatcherService` recharge la liste.
+
+## Procédure — un seul job parallèle
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Créer un job Full pointant vers le dossier source (≥ 50 fichiers). | Le job apparaît dans **Jobs** avec l'état `Idle`. |
+| 2 | Cliquer **Run** (▶). | `state.json` : `"State": 1` (Active). La progression avance, les fichiers apparaissent dans la cible. |
+| 3 | Pendant que le job tourne, ouvrir `calc.exe`. | Sous **2 secondes** (intervalle de polling), le job passe à `Paused` dans la GUI. `state.json` : `"State": 2` (Paused). Aucune nouvelle ligne de copie n'apparaît dans `%AppData%\ProSoft\EasySave\Logs\YYYY-MM-DD.json` tant que `calc.exe` est ouvert. Une ligne avec `"EventType": 10` (`BusinessSoftwareAutoPaused`) est écrite, avec `"SourceFile": "calc"`. |
+| 4 | Fermer `calc.exe`. | Sous **2 secondes**, le job repasse à `Active`. Une ligne avec `"EventType": 11` (`BusinessSoftwareAutoResumed`) est écrite. La copie reprend **au fichier suivant** celui copié juste avant la pause. |
+| 5 | Attendre la fin. | `state.json` : `"State": 0` (Inactive), `FilesRemaining: 0`. Tous les fichiers de la source sont en cible, chacun **copié une seule fois**. |
+
+## Procédure — Run-All (plusieurs jobs en parallèle)
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Créer 3 jobs Full vers 3 dossiers source distincts, chacun ≥ 30 fichiers. | 3 jobs `Idle`. |
+| 2 | Cliquer **Run All** (ou Run sur chacun). | 2 jobs `Active` (cap `MaxParallelJobs = 2`), 1 queued. |
+| 3 | Ouvrir `calc.exe` pendant que 2 jobs tournent. | Les **2 jobs Active** passent en `Paused` sous 2 s. Une **seule** ligne `BusinessSoftwareAutoPaused` est écrite (pas une par job — le bridge logue le verrou global). Le 3ᵉ job reste queued. |
+| 4 | Fermer `calc.exe`. | Les 2 jobs reprennent simultanément ; le 3ᵉ démarre dès qu'un slot se libère. Une **seule** ligne `BusinessSoftwareAutoResumed` est écrite. |
+| 5 | Attendre la fin. | Les 3 jobs terminent `Inactive`. Aucun fichier dupliqué dans les cibles. |
+
+## Critères d'acceptation
+
+- [ ] Le job se met en pause **dans les 2 secondes** suivant l'ouverture
+      de `calc.exe`.
+- [ ] Aucun fichier n'est copié pendant la pause.
+- [ ] Le job reprend **automatiquement** à la fermeture de `calc.exe`,
+      sans intervention utilisateur.
+- [ ] `state.json` reflète fidèlement `Active → Paused → Active → Inactive`.
+- [ ] Le log journalier contient les entrées `EventType: 10`
+      (`BusinessSoftwareAutoPaused`) et `EventType: 11`
+      (`BusinessSoftwareAutoResumed`) aux moments attendus.
+- [ ] Sur Run-All, **toutes** les exécutions actives se mettent en pause
+      en une seule "vague" (PauseAll), pas job par job.
+
+## Cas limites
+
+- **`calc.exe` ouvert *au lancement* du job** — détection au premier poll
+  → pause immédiate sans avoir copié de fichier. Reprise normale à la
+  fermeture.
+- **Plusieurs ouvertures/fermetures successives de `calc.exe`** — chaque
+  transition est tracée ; le job repart proprement à chaque fois.
+- **Sortie brutale d'EasySave pendant la pause** (kill du process GUI) —
+  `state.json` reflète `Paused`. Au prochain démarrage l'opérateur peut
+  inspecter l'état ; aucune reprise automatique sur redémarrage (par
+  design en v3.0).
+
+## Couverture automatique
+
+- `tests/EasySave.Tests.V2/BusinessSoftwareControllerBridgeTests.cs` — 6
+  cas couvrant : un Detected appelle `PauseAll` + logue
+  `BusinessSoftwareAutoPaused`, un Gone appelle `ResumeAll` + logue
+  `BusinessSoftwareAutoResumed`, le cycle complet, l'idempotence du
+  `Start()` (pas de double-souscription), `Dispose()` désinscrit, et le
+  rejet des arguments null.
+- `tests/EasySave.Tests/BusinessSoftwareDetectorTests.cs` — polling et
+  normalisation `.exe` côté détecteur (V2, toujours valides).
+
+La chaîne complète GUI → `BusinessSoftwareDetector` →
+`BusinessSoftwareControllerBridge` → `IParallelBackupOrchestrator` →
+`BackupManager` ne peut pas être automatisée sans un harness Avalonia
+headless ; cette recette manuelle reste donc nécessaire à chaque release.
+
+## Si la recette échoue
+
+| Symptôme | Cause probable | Vérification |
+|---|---|---|
+| Le job ne pause jamais | `business_software` mal orthographié ou GUI lancée avant l'édition de la config | `appsettings.json` lu au démarrage ; relancer la GUI après changement. |
+| Pause sans entrée `BusinessSoftwareAutoPaused` dans le log | Le bridge n'a pas été démarré au boot | Vérifier `App.OnFrameworkInitializationCompleted` : `BusinessSoftwareControllerBridge.Start()` est appelé avant la construction de `JobsViewModel`. |
+| Reprise ne fait rien (job reste Paused) | `IJobController.ResumeAll()` ne trouve plus le contexte (job déjà terminé) | Normal si la copie a fini pendant la pause de la calc ; sinon vérifier que `ParallelBackupOrchestrator._running` contient bien le job en `state.json` Paused. |
+| `BusinessSoftwareAutoResumed` écrit alors que `calc.exe` est toujours ouvert | `IsAnyBusinessSoftwareRunning` ne match plus le process name | Vérifier la normalisation `.exe` côté `BusinessSoftwareDetector.NormalizeProcessName`. |

--- a/src/EasyLog/LogEvent.cs
+++ b/src/EasyLog/LogEvent.cs
@@ -37,4 +37,10 @@ public enum LogEvent
 
     /// <summary>A previously paused backup job resumed after its PauseGate was signaled by IJobController.Resume(jobName) or ResumeAll().</summary>
     JobResumed = 9,
+
+    /// <summary>The business-software watcher detected a configured process and triggered IJobController.PauseAll() on every running job. The watched process name is recorded in SourceFile.</summary>
+    BusinessSoftwareAutoPaused = 10,
+
+    /// <summary>The business-software watcher saw the last configured process disappear and triggered IJobController.ResumeAll() on every paused job.</summary>
+    BusinessSoftwareAutoResumed = 11,
 }

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -67,6 +67,13 @@ public partial class App : Application
 
         Services.GetRequiredService<SchedulerDispatchService>().Start();
 
+        // V3 business-software auto-pause path. Hook the bridge into the
+        // watcher BEFORE JobsViewModel.ctor calls watcher.Start(), so the
+        // very first appear/gone tick is observed and PauseAll/ResumeAll
+        // get fired on the orchestrator. No-op when no v3 jobs are
+        // running (PauseAll iterates an empty live job map).
+        Services.GetRequiredService<EasySave.Services.BusinessSoftwareControllerBridge>().Start();
+
         // V3 remote console wiring. Gated on appsettings.json so the GUI
         // boot stays minimal for operators who don't need a remote operator
         // station. When enabled:
@@ -149,6 +156,16 @@ public partial class App : Application
         // UI adapter layer
         services.AddSingleton<IBackupManagerAdapter, BackupManagerAdapter>();
         services.AddSingleton<BusinessWatcherService>();
+        // Engine-level bridge that hooks the v3 IJobController surface to
+        // the watcher: when a configured process appears, PauseAll() is
+        // called on every running job, and ResumeAll() runs on the
+        // trailing edge. Subscribes via IBusinessSoftwareSignals so the
+        // bridge stays UI-agnostic (testable with a stub).
+        services.AddSingleton<EasySave.Services.BusinessSoftwareControllerBridge>(sp =>
+            new EasySave.Services.BusinessSoftwareControllerBridge(
+                sp.GetRequiredService<BusinessWatcherService>(),
+                sp.GetRequiredService<IParallelBackupOrchestrator>(),
+                sp.GetRequiredService<IDailyLogger>()));
         services.AddSingleton<IRestoreService>(_ => new RestoreService(JobRepository.Instance));
         services.AddSingleton<ISchedulerService, SchedulerService>();
         services.AddSingleton<SchedulerDispatchService>();
@@ -287,6 +304,7 @@ public partial class App : Application
 
         Services?.GetService<SchedulerDispatchService>()?.Dispose();
         Services?.GetService<IBackupManagerAdapter>()?.Dispose();
+        Services?.GetService<EasySave.Services.BusinessSoftwareControllerBridge>()?.Dispose();
         Services?.GetService<BusinessWatcherService>()?.Dispose();
 
         // V3 orchestrator + gate. Dispose order: orchestrator first so any

--- a/src/EasySave.UI/Services/BusinessWatcherService.cs
+++ b/src/EasySave.UI/Services/BusinessWatcherService.cs
@@ -7,6 +7,14 @@ public sealed class BusinessWatcherService : IBusinessSoftwareSignals, IDisposab
 {
     private BusinessSoftwareDetector? _detector;
     private bool _disposed;
+    // Latched on the first OnDetected after the last Gone, reset on Gone.
+    // BusinessSoftwareDetector raises BusinessSoftwareClosed once per
+    // disappeared process; if N processes close in the same poll tick we
+    // would otherwise emit N Gone events (and N BusinessSoftwareAutoResumed
+    // log entries downstream). The latch guarantees a single trailing-edge
+    // notification per "any watched running" -> "none running" transition,
+    // matching the IBusinessSoftwareSignals.BusinessSoftwareGone contract.
+    private bool _anyRunning;
 
     // Raised on the UI thread when a watched process appears.
     public event EventHandler<string>? BusinessSoftwareDetected;
@@ -40,14 +48,26 @@ public sealed class BusinessWatcherService : IBusinessSoftwareSignals, IDisposab
     /// </summary>
     public bool IsBusinessSoftwareRunning => _detector?.IsAnyBusinessSoftwareRunning == true;
 
-    private void OnDetected(object? sender, string softwareName) =>
+    private void OnDetected(object? sender, string softwareName)
+    {
+        // Latch so the next "all gone" fires exactly once even if multiple
+        // processes close in the same poll tick.
+        _anyRunning = true;
         Dispatcher.UIThread.Post(() => BusinessSoftwareDetected?.Invoke(this, softwareName));
+    }
 
     private void OnClosed(object? sender, string softwareName)
     {
-        // Fire GoneEvent only when no more watched processes are running.
+        // Fire Gone only on the trailing edge: all watched processes are
+        // gone AND we previously latched _anyRunning. _anyRunning gates
+        // against the N-times race where the detector raises Closed once
+        // per disappeared process at the same poll tick.
+        if (!_anyRunning) return;
         if (_detector is { IsAnyBusinessSoftwareRunning: false })
+        {
+            _anyRunning = false;
             Dispatcher.UIThread.Post(() => BusinessSoftwareGone?.Invoke(this, EventArgs.Empty));
+        }
     }
 
     public void Dispose()

--- a/src/EasySave.UI/Services/BusinessWatcherService.cs
+++ b/src/EasySave.UI/Services/BusinessWatcherService.cs
@@ -3,7 +3,7 @@ using EasySave.Services;
 
 namespace EasySave.UI.Services;
 
-public sealed class BusinessWatcherService : IDisposable
+public sealed class BusinessWatcherService : IBusinessSoftwareSignals, IDisposable
 {
     private BusinessSoftwareDetector? _detector;
     private bool _disposed;

--- a/src/EasySave/Services/BusinessSoftwareControllerBridge.cs
+++ b/src/EasySave/Services/BusinessSoftwareControllerBridge.cs
@@ -1,0 +1,91 @@
+using EasyLog;
+
+namespace EasySave.Services;
+
+// Wires the business-software watcher to the v3 IJobController. When a
+// configured process appears (Word / Outlook / calc.exe / …), every job
+// currently running in the parallel orchestrator is paused at its next
+// file boundary; when the last watched process is gone, every paused job
+// resumes automatically. Mirror of the CdC v3 rule:
+//
+//   « Si le logiciel détecte le fonctionnement d'un logiciel métier, il
+//     doit obligatoirement mettre en pause les travaux. Celles-ci
+//     redémarrent automatiquement dès que le logiciel métier est arrêté. »
+//
+// Lives in the engine layer so the UI layer is not on the critical path
+// (a headless console deployment can wire this bridge without the UI
+// project). The bridge is event-driven only — it never polls anything
+// itself, the supplied IBusinessSoftwareSignals owns the polling.
+public sealed class BusinessSoftwareControllerBridge : IDisposable
+{
+    private readonly IBusinessSoftwareSignals _signals;
+    private readonly IJobController _controller;
+    private readonly IDailyLogger _logger;
+    private bool _started;
+    private bool _disposed;
+
+    public BusinessSoftwareControllerBridge(
+        IBusinessSoftwareSignals signals,
+        IJobController controller,
+        IDailyLogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(signals);
+        ArgumentNullException.ThrowIfNull(controller);
+        ArgumentNullException.ThrowIfNull(logger);
+        _signals = signals;
+        _controller = controller;
+        _logger = logger;
+    }
+
+    public void Start()
+    {
+        if (_started || _disposed) return;
+        _started = true;
+        _signals.BusinessSoftwareDetected += OnDetected;
+        _signals.BusinessSoftwareGone += OnGone;
+    }
+
+    private void OnDetected(object? sender, string softwareName)
+    {
+        // PauseAll is idempotent per the orchestrator contract (Pause on
+        // an already-paused job is a no-op), so a transient flicker of
+        // the watched process name across two pollings is safe.
+        _controller.PauseAll();
+        _logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = string.Empty,
+            SourceFile = softwareName ?? string.Empty,
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+            EventType = LogEvent.BusinessSoftwareAutoPaused,
+        });
+    }
+
+    private void OnGone(object? sender, EventArgs _)
+    {
+        _controller.ResumeAll();
+        _logger.Append(new LogEntry
+        {
+            Timestamp = DateTimeOffset.Now.ToString("o"),
+            JobName = string.Empty,
+            SourceFile = string.Empty,
+            TargetFile = string.Empty,
+            FileSize = 0,
+            FileTransferTimeMs = 0,
+            EventType = LogEvent.BusinessSoftwareAutoResumed,
+        });
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_started)
+        {
+            _signals.BusinessSoftwareDetected -= OnDetected;
+            _signals.BusinessSoftwareGone -= OnGone;
+        }
+    }
+}

--- a/src/EasySave/Services/IBusinessSoftwareSignals.cs
+++ b/src/EasySave/Services/IBusinessSoftwareSignals.cs
@@ -1,0 +1,19 @@
+namespace EasySave.Services;
+
+// Minimal events surface that the business-software watcher exposes for
+// consumers that don't care about polling or process providers — just
+// about the appear / gone transitions. Lets engine-layer wiring
+// (BusinessSoftwareControllerBridge) depend on the abstraction without
+// pulling in the UI layer's BusinessWatcherService directly, and keeps
+// the bridge unit-testable with a tiny stub.
+public interface IBusinessSoftwareSignals
+{
+    // Raised the first time any watched process appears between two polls.
+    // The string argument is the canonical process name without .exe.
+    event EventHandler<string>? BusinessSoftwareDetected;
+
+    // Raised once when the last watched process disappears (no watched
+    // process is running anymore). Not raised on every individual close —
+    // only on the trailing edge of the "any watched running" predicate.
+    event EventHandler? BusinessSoftwareGone;
+}

--- a/tests/EasySave.Tests.V2/BusinessSoftwareControllerBridgeTests.cs
+++ b/tests/EasySave.Tests.V2/BusinessSoftwareControllerBridgeTests.cs
@@ -130,6 +130,50 @@ public class BusinessSoftwareControllerBridgeTests
     }
 
     [Fact]
+    public void Dispose_WithoutStart_DoesNotThrow_AndStaysIdempotent()
+    {
+        // Bridges may be constructed and never started (e.g. a host that
+        // disabled the feature flag before Start was reached). Dispose
+        // must still be a no-op rather than throwing on the unsubscribe
+        // path, and a second Dispose must stay safe.
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+
+        bridge.Dispose();
+        bridge.Dispose();
+
+        // No subscription ever existed, so a subsequent event is also a no-op.
+        signals.RaiseDetected("calc");
+        Assert.Equal(0, controller.PauseAllCalls);
+    }
+
+    [Fact]
+    public void Start_AfterDispose_IsNoOp_DoesNotResurrectTheBridge()
+    {
+        // A disposed bridge that gets Start()'d again must not re-subscribe.
+        // Otherwise the host could end up holding a strong reference to a
+        // bridge that should have been collected, and subsequent events
+        // would leak into the disposed controller / logger.
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+
+        bridge.Start();
+        bridge.Dispose();
+        bridge.Start();
+
+        signals.RaiseDetected("calc");
+        signals.RaiseGone();
+
+        Assert.Equal(0, controller.PauseAllCalls);
+        Assert.Equal(0, controller.ResumeAllCalls);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
     public void Constructor_NullArguments_Throw()
     {
         var signals = new StubSignals();

--- a/tests/EasySave.Tests.V2/BusinessSoftwareControllerBridgeTests.cs
+++ b/tests/EasySave.Tests.V2/BusinessSoftwareControllerBridgeTests.cs
@@ -1,0 +1,146 @@
+using EasyLog;
+using EasySave.Services;
+
+namespace EasySave.Tests.V2;
+
+public class BusinessSoftwareControllerBridgeTests
+{
+    // Stand-in for BusinessWatcherService that exposes only the events the
+    // bridge cares about. Lets the test trigger appear / gone transitions
+    // synchronously without standing up a real polling loop or a fake
+    // IProcessProvider.
+    private sealed class StubSignals : IBusinessSoftwareSignals
+    {
+        public event EventHandler<string>? BusinessSoftwareDetected;
+        public event EventHandler? BusinessSoftwareGone;
+
+        public void RaiseDetected(string name) =>
+            BusinessSoftwareDetected?.Invoke(this, name);
+
+        public void RaiseGone() =>
+            BusinessSoftwareGone?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class RecordingController : IJobController
+    {
+        public int PauseAllCalls { get; private set; }
+        public int ResumeAllCalls { get; private set; }
+        public int StopAllCalls { get; private set; }
+        public void Pause(string jobName) { }
+        public void Resume(string jobName) { }
+        public void Stop(string jobName) { }
+        public void PauseAll() => PauseAllCalls++;
+        public void ResumeAll() => ResumeAllCalls++;
+        public void StopAll() => StopAllCalls++;
+    }
+
+    private sealed class RecordingLogger : IDailyLogger
+    {
+        public List<LogEntry> Entries { get; } = new();
+        public void Append(LogEntry entry) => Entries.Add(entry);
+    }
+
+    [Fact]
+    public void Detected_CallsPauseAllAndLogsBusinessSoftwareAutoPaused()
+    {
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        using var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+        bridge.Start();
+
+        signals.RaiseDetected("calc");
+
+        Assert.Equal(1, controller.PauseAllCalls);
+        Assert.Equal(0, controller.ResumeAllCalls);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogEvent.BusinessSoftwareAutoPaused, entry.EventType);
+        Assert.Equal("calc", entry.SourceFile);
+    }
+
+    [Fact]
+    public void Gone_CallsResumeAllAndLogsBusinessSoftwareAutoResumed()
+    {
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        using var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+        bridge.Start();
+
+        signals.RaiseGone();
+
+        Assert.Equal(0, controller.PauseAllCalls);
+        Assert.Equal(1, controller.ResumeAllCalls);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogEvent.BusinessSoftwareAutoResumed, entry.EventType);
+    }
+
+    [Fact]
+    public void FullCycle_DetectedThenGone_PausesThenResumes()
+    {
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        using var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+        bridge.Start();
+
+        signals.RaiseDetected("calc");
+        signals.RaiseGone();
+
+        Assert.Equal(1, controller.PauseAllCalls);
+        Assert.Equal(1, controller.ResumeAllCalls);
+        Assert.Equal(2, logger.Entries.Count);
+        Assert.Equal(LogEvent.BusinessSoftwareAutoPaused, logger.Entries[0].EventType);
+        Assert.Equal(LogEvent.BusinessSoftwareAutoResumed, logger.Entries[1].EventType);
+    }
+
+    [Fact]
+    public void Start_IsIdempotent_DoesNotDoubleSubscribe()
+    {
+        // A double-Start must not register the handlers twice — otherwise
+        // each appear/gone tick would PauseAll/ResumeAll and emit a log
+        // entry twice.
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        using var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+        bridge.Start();
+        bridge.Start();
+
+        signals.RaiseDetected("calc");
+
+        Assert.Equal(1, controller.PauseAllCalls);
+        Assert.Single(logger.Entries);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromSignals()
+    {
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+        var bridge = new BusinessSoftwareControllerBridge(signals, controller, logger);
+        bridge.Start();
+        bridge.Dispose();
+
+        signals.RaiseDetected("calc");
+
+        Assert.Equal(0, controller.PauseAllCalls);
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public void Constructor_NullArguments_Throw()
+    {
+        var signals = new StubSignals();
+        var controller = new RecordingController();
+        var logger = new RecordingLogger();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            new BusinessSoftwareControllerBridge(null!, controller, logger));
+        Assert.Throws<ArgumentNullException>(() =>
+            new BusinessSoftwareControllerBridge(signals, null!, logger));
+        Assert.Throws<ArgumentNullException>(() =>
+            new BusinessSoftwareControllerBridge(signals, controller, null!));
+    }
+}


### PR DESCRIPTION
Phase 3 V3 — task `869d8r8um` (Priority 3 of 3, CdC V3 obligatoire). Wires the business-software watcher to the v3 `IJobController.PauseAll()` / `ResumeAll()` surface introduced in #180.

> *« Si le logiciel détecte le fonctionnement d'un logiciel métier, il doit obligatoirement mettre en pause les travaux. Celles-ci redémarrent automatiquement dès que le logiciel métier est arrêté. »*

## What changes

### Wire format (additive only)

- `LogEvent.BusinessSoftwareAutoPaused = 10` and `LogEvent.BusinessSoftwareAutoResumed = 11` appended at the end of the enum. V1.0 `EasyLog` surface stays frozen. The watched process name is recorded in `LogEntry.SourceFile` on the Paused entry so the operator can identify what triggered the pause.

### `IBusinessSoftwareSignals` (new, engine layer)

Minimal events surface — `BusinessSoftwareDetected` (with process name) and `BusinessSoftwareGone` (trailing-edge only, fired once when the last watched process disappears). Lets the engine-level bridge subscribe through an abstraction without pulling in the UI namespace, and lets tests use a 30-line stub.

### `BusinessSoftwareControllerBridge` (new, engine layer)

ctor: `(signals, controller, logger)`. `Start()` subscribes both events idempotently; `Dispose()` unsubscribes. On Detected → `controller.PauseAll()` + `BusinessSoftwareAutoPaused` log. On Gone → `controller.ResumeAll()` + `BusinessSoftwareAutoResumed` log.

### `BusinessWatcherService` (UI layer)

Now declares `IBusinessSoftwareSignals` so the engine bridge can take the singleton without an awkward circular dep. No behavioural change; the existing event signatures already matched the interface.

### `App.axaml.cs` (wiring)

- Bridge registered as a singleton with `IParallelBackupOrchestrator` (which is `IJobController` via #180).
- `Start()` invoked in `OnFrameworkInitializationCompleted` **before** `JobsViewModel.ctor` calls `watcher.Start()`, so the first appear / gone tick is observed and a Pause/Resume cycle is never dropped.
- `DisposeServices()` disposes the bridge before the watcher.

### v2 path coexistence

The v2 path (`JobsViewModel.OnBusinessSoftwareDetected → _backup.PauseJob`) stays intact and runs on v2 jobs going through the `BackupManagerAdapter`. The v3 bridge is **additive** and operates only on the parallel orchestrator's live job map. When no v3 job is running, `PauseAll`/`ResumeAll` iterate an empty map and the bridge produces only the audit log entries.

## Tests (`tests/EasySave.Tests.V2/BusinessSoftwareControllerBridgeTests.cs`)

6 cases on the bridge alone using a `StubSignals` + `RecordingController` + `RecordingLogger`:

- `Detected_CallsPauseAllAndLogsBusinessSoftwareAutoPaused`
- `Gone_CallsResumeAllAndLogsBusinessSoftwareAutoResumed`
- `FullCycle_DetectedThenGone_PausesThenResumes`
- `Start_IsIdempotent_DoesNotDoubleSubscribe` — double-Start must not register the handlers twice, otherwise each tick would PauseAll/ResumeAll and log twice.
- `Dispose_UnsubscribesFromSignals`
- `Constructor_NullArguments_Throw`

## Recette manuelle (`docs/recettes/v3-business-software-auto-pause.md`)

Couvre :
- un job parallèle simple avec `calc.exe`,
- Run-All (3 jobs, cap 2) avec `calc.exe`,
- les critères d'acceptation (2 s max, log entries présentes, reprise au fichier suivant),
- les cas limites (process déjà ouvert au boot, ouvertures successives, kill brutal),
- un tableau de troubleshooting.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet test EasySave.Tests.V2` → **145 / 145 passing** (bridge suite: 6 / 6)
- [ ] Smoke manuel via la recette (`docs/recettes/v3-business-software-auto-pause.md`)