### PR TITLE
feat(backup): priority extensions + cross-job gate

### DIFF
--- a/docs/recettes/v3-priority-extensions.md
+++ b/docs/recettes/v3-priority-extensions.md
@@ -1,0 +1,108 @@
+# Recette V3 — Extensions prioritaires (gate cross-jobs)
+
+**Critère grille tuteur V3 (obligatoire)** :
+
+> *« Aucune sauvegarde d'un fichier non prioritaire ne peut se faire tant
+> qu'il y a des extensions prioritaires en attente sur au moins un
+> travail. »*
+
+L'implémentation v3 utilise un `IPriorityGate` partagé entre tous les
+jobs : chaque job s'enregistre en début de course avec son nombre de
+fichiers prioritaires, décrémente le compteur après chaque prio copié,
+et se désinscrit en fin de boucle. Les fichiers **non prioritaires** de
+n'importe quel job se garent sur le gate tant que la somme cross-jobs
+des prio restants est non nulle.
+
+## Pré-requis
+
+- EasySave v3 buildé en Release (`dotnet build EasySave.sln -c Release`).
+- GUI Avalonia (`dotnet run --project src/EasySave.UI`).
+- Deux dossiers source distincts pour deux jobs parallèles :
+  - **Job A** : `Demo\A\` contenant 1 `.docx` et 5 `.txt`.
+  - **Job B** : `Demo\B\` contenant 3 `.docx` et 5 `.txt`.
+
+## Configuration
+
+Éditer `appsettings.json` :
+
+```json
+{
+  "priority_extensions": [".docx"],
+  "max_parallel_jobs": 2,
+  "log_format": "json"
+}
+```
+
+Le matching est case-insensitive. La forme attendue est celle retournée
+par `Path.GetExtension` (leading dot inclus). Relancer la GUI pour que
+le BackupManager prenne en compte la nouvelle liste.
+
+## Procédure — un seul job
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Créer Job A pointant vers `Demo\A\`. Cliquer **Run**. | Les fichiers `.docx` sont copiés **avant** les `.txt` dans la cible (vérifier via les mtimes côté cible ou la séquence dans le log journalier). |
+| 2 | Inspecter le log JSON. | Les lignes `FileTransfer` apparaissent d'abord pour les `.docx`, ensuite pour les `.txt`. Pas de mélange. |
+
+## Procédure — deux jobs en parallèle (le vrai test V3)
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Créer Job A et Job B comme décrit ci-dessus. | 2 jobs `Idle` dans la GUI. |
+| 2 | Cliquer **Run All**. | Les 2 jobs passent à `Active`. |
+| 3 | Observer la séquence de copie côté cible (mtimes) **et** dans le log journalier. | **Aucun `.txt`** (ni A ni B) n'apparaît avant que **tous les `.docx`** des deux jobs soient copiés. Job A finit son seul `.docx` puis se met à attendre sur le gate ; Job B copie ses 3 `.docx` ; à la dernière `.docx` de B, les 5 `.txt` de A peuvent commencer (en parallèle avec les `.txt` de B). |
+| 4 | Attendre la fin. | Les 2 jobs `Inactive`, tous les fichiers en cible, chacun copié une seule fois. |
+
+## Critères d'acceptation
+
+- [ ] Dans **un job seul**, les fichiers prioritaires sont copiés avant
+      les non prioritaires.
+- [ ] Dans **deux jobs parallèles**, **aucun** fichier non prioritaire
+      (peu importe le job) n'est copié tant qu'un autre job a encore une
+      `.docx` en attente.
+- [ ] Quand un job est annulé en plein milieu (Stop), ses fichiers
+      prioritaires non encore copiés **ne bloquent pas indéfiniment** les
+      non-prio des autres jobs (l'`UnregisterJob` en `finally` les
+      abandonne).
+- [ ] Le critère reste vérifiable via les **mtimes des fichiers cibles**
+      ou la **séquence des lignes `FileTransfer`** dans le log JSON.
+
+## Cas limites
+
+- **Aucune extension prioritaire configurée** (`priority_extensions: []`) :
+  le tri intra-job devient un no-op, le gate est toujours signalé, aucun
+  ralentissement par rapport à v2. **Le système doit se comporter
+  exactement comme avant la feature.**
+- **Tous les fichiers d'un job sont prioritaires** : le gate ne bloque
+  jamais ce job pour ses propres fichiers ; il peut bloquer d'autres
+  jobs tant qu'il n'a pas fini ses prio.
+- **Un job échoue / est stoppé avant d'avoir copié toutes ses prio** :
+  l'`UnregisterJob` en `finally` du `BackupManager` jette ses prio
+  restantes ; le gate se signale dès que les autres jobs ont terminé
+  leurs prio.
+- **Resume** : les fichiers déjà copiés avant la pause ne réapparaissent
+  pas dans `toCopy` au resume (le cursor les filtre), donc la
+  re-registration au PriorityGate utilise le nombre de **prio restants**,
+  pas le nombre initial.
+
+## Couverture automatique
+
+- `tests/EasySave.Tests.V2/PriorityGateTests.cs` — 10 cas sur le gate
+  pur : signalisation immédiate avec 0 prio, blocage avec N prio
+  pending, cross-job avec un job qui n'a que des non-prio, abandon des
+  prio restantes via `UnregisterJob`, token cancelled sans corruption,
+  no-op sur `MarkPriorityFileDone` d'un nom inconnu, garde contre les
+  comptes négatifs, validation des args.
+- `tests/EasySave.Tests/BackupManagerPriorityTests.cs` — 2 cas
+  d'intégration : ordre prio-d'abord dans un job seul (vérifié via la
+  séquence des `LogEntry`), et **JobA.txt attend JobB.docx** sur un
+  gate partagé.
+
+## Si la recette échoue
+
+| Symptôme | Cause probable | Vérification |
+|---|---|---|
+| Les `.txt` partent **avant** les `.docx` dans un même job | `priority_extensions` mal orthographié (`docx` au lieu de `.docx` ?) | Confirmer le matching dans `BackupManager.IsPriority` — `Path.GetExtension` renvoie avec le leading dot, donc `priority_extensions` doit lui aussi avoir le dot. |
+| Job A ne attend pas Job B | Les deux jobs n'utilisent pas le même `IPriorityGate` singleton | Vérifier que `App.axaml.cs` enregistre `IPriorityGate` en singleton (un seul `PriorityGate()` partagé). |
+| Job A reste bloqué à vie même après que Job B a fini | `UnregisterJob` n'a pas été appelé sur B (exception non rattrapée ?) | `BackupManager.RunJob` doit `UnregisterJob` dans le `finally` — vérifier qu'aucune exception ne saute par-dessus. |
+| `state.json` montre `FilesRemaining` qui ne décroît pas pendant l'attente sur le gate | Comportement attendu : le job est parqué avant la copie, son `FilesRemaining` ne bouge que quand un fichier est effectivement copié. | Pas un bug — observable dans la GUI sous forme d'un job `Active` mais sans progression visible le temps que les autres jobs finissent leurs prio. |

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -132,6 +132,14 @@ public partial class App : Application
         services.AddSingleton<IBigFileGate>(_ =>
             new BigFileGate(userSettings.LargeFileThresholdKb * 1024L));
 
+        // V3 priority gate. Cross-job barrier enforcing the CdC rule
+        // « Aucune sauvegarde d'un fichier non prioritaire ne peut se
+        //   faire tant qu'il y a des extensions prioritaires en attente
+        //   sur au moins un travail. »
+        // Shared by every job; non-priority files of any job park here
+        // until every job has finished its priority files.
+        services.AddSingleton<IPriorityGate>(_ => new PriorityGate());
+
         services.AddSingleton<BackupManager>(sp => new BackupManager(
             sp.GetRequiredService<IDailyLogger>(),
             new FullBackupStrategy(),
@@ -140,7 +148,9 @@ public partial class App : Application
             JobRepository.Instance,
             sp.GetRequiredService<IEncryptionService>(),
             userSettings.EncryptedExtensions,
-            sp.GetRequiredService<IBigFileGate>()));
+            sp.GetRequiredService<IBigFileGate>(),
+            sp.GetRequiredService<IPriorityGate>(),
+            userSettings.PriorityExtensions));
 
         // V3 parallel orchestrator + BackupManager-backed job runner.
         // The orchestrator wraps RunAllAsync (see JobsViewModel) so multiple
@@ -313,5 +323,6 @@ public partial class App : Application
         // orchestrator's job runners may still hold transiently.
         Services?.GetService<IParallelBackupOrchestrator>()?.Dispose();
         (Services?.GetService<IBigFileGate>() as IDisposable)?.Dispose();
+        (Services?.GetService<IPriorityGate>() as IDisposable)?.Dispose();
     }
 }

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -54,12 +54,14 @@ public sealed class AppSettings
     [JsonPropertyName("log_centralized_endpoint")]
     public string LogCentralizedEndpoint { get; init; } = string.Empty;
 
-    // CdC V3: extensions listées ici ont priorité de sauvegarde.
-    // « Aucune sauvegarde d'un fichier non prioritaire ne peut se faire
-    //   tant qu'il y a des extensions prioritaires en attente sur au
-    //   moins un travail. »
-    // Forme attendue : [".docx", ".xlsx"]. Matching case-insensitive
-    // (Path.GetExtension renvoie déjà avec le leading dot).
+    // V3 priority extensions, per the cahier rule:
+    //   « Aucune sauvegarde d'un fichier non prioritaire ne peut se faire
+    //     tant qu'il y a des extensions prioritaires en attente sur au
+    //     moins un travail. »
+    // (« No non-priority file from any job may be backed up while
+    // priority-extension files are still pending on at least one job. »)
+    // Expected shape: [".docx", ".xlsx"]. Matching is case-insensitive
+    // and expects the leading dot returned by Path.GetExtension.
     [JsonPropertyName("priority_extensions")]
     public IReadOnlyList<string> PriorityExtensions { get; init; } = Array.Empty<string>();
 }

--- a/src/EasySave/Models/AppSettings.cs
+++ b/src/EasySave/Models/AppSettings.cs
@@ -53,6 +53,15 @@ public sealed class AppSettings
 
     [JsonPropertyName("log_centralized_endpoint")]
     public string LogCentralizedEndpoint { get; init; } = string.Empty;
+
+    // CdC V3: extensions listées ici ont priorité de sauvegarde.
+    // « Aucune sauvegarde d'un fichier non prioritaire ne peut se faire
+    //   tant qu'il y a des extensions prioritaires en attente sur au
+    //   moins un travail. »
+    // Forme attendue : [".docx", ".xlsx"]. Matching case-insensitive
+    // (Path.GetExtension renvoie déjà avec le leading dot).
+    [JsonPropertyName("priority_extensions")]
+    public IReadOnlyList<string> PriorityExtensions { get; init; } = Array.Empty<string>();
 }
 
 public sealed class CryptoSoftSettings

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -18,6 +18,10 @@ var logger = new JsonDailyLogger(AppConfig.Instance.LogDirectory);
 IEncryptionService encryption = string.IsNullOrWhiteSpace(AppConfig.Instance.Settings.CryptoSoft.Path)
     ? new NoOpEncryptionService()
     : new CryptoSoftAdapter(AppConfig.Instance.Settings.CryptoSoft);
+// V3 priority extensions still apply in v1 console mode for the in-job
+// order (priority files copy first within a single job). The cross-job
+// gate is null because the v1 console runs jobs sequentially, never in
+// parallel — no other job can hold the gate.
 var backupManager = new BackupManager(
     logger,
     new FullBackupStrategy(),
@@ -25,7 +29,10 @@ var backupManager = new BackupManager(
     StateTracker.Instance,
     JobRepository.Instance,
     encryption,
-    AppConfig.Instance.Settings.EncryptedExtensions);
+    AppConfig.Instance.Settings.EncryptedExtensions,
+    bigFileGate: null,
+    priorityGate: null,
+    priorityExtensions: AppConfig.Instance.Settings.PriorityExtensions);
 var langService = new LanguageService(AppConfig.Instance.Settings);
 
 if (AppConfig.Instance.Settings.RemoteConsoleEnabled)

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -319,8 +319,14 @@ public sealed class BackupManager
                 state.LastActionTime = DateTimeOffset.Now;
                 _stateTracker.Update(state);
 
-                // Tick the cross-job barrier AFTER the copy succeeds so a
-                // failed transfer doesn't prematurely unblock waiters.
+                // Tick the cross-job barrier unconditionally after the copy
+                // attempt. A failed transfer is still "this priority file
+                // is no longer pending" — re-trying it later won't help
+                // (ProcessFile signals failure via transferMs < 0 in the
+                // log entry, not by retrying), and leaving the slot
+                // occupied would hold every other job's non-priority
+                // files hostage forever. The CdC rule is "pending", not
+                // "successfully copied".
                 if (isPriority)
                     _priorityGate?.MarkPriorityFileDone(job.Name);
             }

--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -20,7 +20,9 @@ public sealed class BackupManager
     private readonly JobRepository _jobRepository;
     private readonly IEncryptionService _encryption;
     private readonly HashSet<string> _encryptedExtensions;
+    private readonly HashSet<string> _priorityExtensions;
     private readonly IBigFileGate? _bigFileGate;
+    private readonly IPriorityGate? _priorityGate;
 
     /// <summary>
     /// Wires the manager with its dependencies. All parameters are required;
@@ -47,7 +49,9 @@ public sealed class BackupManager
         JobRepository jobRepository,
         IEncryptionService encryption,
         IEnumerable<string> encryptedExtensions,
-        IBigFileGate? bigFileGate = null)
+        IBigFileGate? bigFileGate = null,
+        IPriorityGate? priorityGate = null,
+        IEnumerable<string>? priorityExtensions = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(fullStrategy);
@@ -64,7 +68,10 @@ public sealed class BackupManager
         _jobRepository = jobRepository;
         _encryption = encryption;
         _encryptedExtensions = new HashSet<string>(encryptedExtensions, StringComparer.OrdinalIgnoreCase);
+        _priorityExtensions = new HashSet<string>(
+            priorityExtensions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         _bigFileGate = bigFileGate;
+        _priorityGate = priorityGate;
     }
 
     /// <summary>
@@ -198,6 +205,21 @@ public sealed class BackupManager
             ? eligible.Where(x => StringComparer.Ordinal.Compare(x.file.FullName, resumeAfterPath) > 0).ToList()
             : eligible;
 
+        // CdC V3: priority-extension files copy before non-priority files
+        // inside the SAME job. The cross-job barrier (PriorityGate.Wait)
+        // already prevents non-priority files of any job from starting
+        // while priorities are pending anywhere; this in-job reordering
+        // is a pure optimization that lets the gate clear faster (each
+        // job drains its priorities first instead of interleaving).
+        // When no priority extension is configured, all files are non-
+        // priority and the OrderBy is a stable no-op on the existing
+        // ordinal sort.
+        toCopy = toCopy
+            .OrderByDescending(x => IsPriority(x.file))
+            .ThenBy(x => x.file.FullName, StringComparer.Ordinal)
+            .ToList();
+        var priorityFilesRemaining = toCopy.Count(x => IsPriority(x.file));
+
         var state = new StateEntry
         {
             Name = job.Name,
@@ -210,6 +232,11 @@ public sealed class BackupManager
         };
         _stateTracker.Update(state);
 
+        // Register the job's priority count with the cross-job gate before
+        // the loop starts so a parallel non-priority file from another job
+        // sees the pending priorities and waits.
+        _priorityGate?.RegisterJob(job.Name, priorityFilesRemaining);
+
         bool succeeded = false;
         bool paused = false;
         try
@@ -219,6 +246,16 @@ public sealed class BackupManager
                 // Check at file boundary — never mid-copy — so the target file is
                 // never left in a partial state.
                 ct.ThrowIfCancellationRequested();
+
+                bool isPriority = IsPriority(file);
+
+                // CdC V3 hard rule: « Aucune sauvegarde d'un fichier non
+                // prioritaire ne peut se faire tant qu'il y a des
+                // extensions prioritaires en attente sur au moins un
+                // travail. » The PriorityGate is signaled when every
+                // registered job has zero priority files left.
+                if (!isPriority && _priorityGate is not null)
+                    _priorityGate.WaitForNonPriorityWindow(ct);
 
                 // V3 PauseGate: if a controller (IJobController.Pause /
                 // PauseAll, business-software watcher, remote console) has
@@ -281,6 +318,11 @@ public sealed class BackupManager
                 state.CurrentTarget = targetPath;
                 state.LastActionTime = DateTimeOffset.Now;
                 _stateTracker.Update(state);
+
+                // Tick the cross-job barrier AFTER the copy succeeds so a
+                // failed transfer doesn't prematurely unblock waiters.
+                if (isPriority)
+                    _priorityGate?.MarkPriorityFileDone(job.Name);
             }
             succeeded = true;
         }
@@ -297,6 +339,11 @@ public sealed class BackupManager
         }
         finally
         {
+            // Unregister from the priority gate regardless of how the loop
+            // exited: leftover priorities on a stopped / failed job would
+            // otherwise hold every other job's non-priority files hostage.
+            _priorityGate?.UnregisterJob(job.Name);
+
             // Always transition the state. On pause, preserve progress counters
             // so the adapter can compute the resume index from FilesRemaining.
             try
@@ -401,5 +448,16 @@ public sealed class BackupManager
         if (_encryptedExtensions.Count == 0) return false;
         var ext = Path.GetExtension(fileName);
         return !string.IsNullOrEmpty(ext) && _encryptedExtensions.Contains(ext);
+    }
+
+    // True when the file's extension is configured as a CdC V3 priority
+    // extension. Used to order files inside a job (priorities first) and
+    // to count the per-job priority budget registered with the
+    // cross-job PriorityGate.
+    private bool IsPriority(FileInfo file)
+    {
+        if (_priorityExtensions.Count == 0) return false;
+        var ext = file.Extension;
+        return !string.IsNullOrEmpty(ext) && _priorityExtensions.Contains(ext);
     }
 }

--- a/src/EasySave/Services/IPriorityGate.cs
+++ b/src/EasySave/Services/IPriorityGate.cs
@@ -1,0 +1,44 @@
+namespace EasySave.Services;
+
+// Cross-job barrier enforcing the v3 CdC rule:
+//
+//   « Aucune sauvegarde d'un fichier non prioritaire ne peut se faire
+//     tant qu'il y a des extensions prioritaires en attente sur au moins
+//     un travail. »
+//
+// Each running job registers its count of priority-extension files up
+// front, decrements the count after copying each one, and unregisters
+// when it finishes. Non-priority files inside any running job block on
+// WaitForNonPriorityWindow until the sum of priority counts across every
+// job in the gate reaches zero — at which point every parked thread is
+// released and subsequent non-priority files pass straight through.
+//
+// Thread-safe; designed for the v3 ParallelBackupOrchestrator's worker
+// threads. A single PriorityGate instance is shared across every job in
+// the engine so the cross-job barrier is global.
+public interface IPriorityGate
+{
+    // Adds jobName to the live set with priorityFileCount files pending.
+    // Idempotent — calling it twice for the same name overwrites the
+    // count. Negative counts are rejected.
+    void RegisterJob(string jobName, int priorityFileCount);
+
+    // Decrements jobName's priority count by one. No-op when jobName is
+    // not registered or its count is already zero. When the cross-job
+    // total reaches zero the gate signals and every WaitForNonPriority
+    // Window blocked thread wakes.
+    void MarkPriorityFileDone(string jobName);
+
+    // Blocks until the sum of priority counts across every registered
+    // job is zero. Token-aware: a cancelled token throws
+    // OperationCanceledException on the standard ManualResetEventSlim
+    // contract — the slot is not consumed (there's no slot, it's a gate).
+    // Returns immediately when there are no priority files anywhere.
+    void WaitForNonPriorityWindow(CancellationToken ct);
+
+    // Removes jobName from the live set. Should be called in the job's
+    // finally — leftover priority counts (job cancelled or failed before
+    // copying all priority files) are discarded so other jobs' non-
+    // priority files are not held hostage forever.
+    void UnregisterJob(string jobName);
+}

--- a/src/EasySave/Services/PriorityGate.cs
+++ b/src/EasySave/Services/PriorityGate.cs
@@ -11,7 +11,12 @@ namespace EasySave.Services;
 public sealed class PriorityGate : IPriorityGate, IDisposable
 {
     private readonly object _lock = new();
-    private readonly Dictionary<string, int> _remaining = new(StringComparer.Ordinal);
+    // Job names canonicalised by JobRepository are case-stable, but the
+    // rest of the system compares them with OrdinalIgnoreCase (see
+    // BackupManager.ExecuteJob's job lookup); aligning the gate's lookup
+    // removes a future footgun if a caller ever supplies a different-
+    // case variant of the same job name.
+    private readonly Dictionary<string, int> _remaining = new(StringComparer.OrdinalIgnoreCase);
     private readonly ManualResetEventSlim _cleared = new(initialState: true);
 
     public void RegisterJob(string jobName, int priorityFileCount)

--- a/src/EasySave/Services/PriorityGate.cs
+++ b/src/EasySave/Services/PriorityGate.cs
@@ -1,0 +1,74 @@
+namespace EasySave.Services;
+
+// Concrete IPriorityGate using a ManualResetEventSlim as the cross-job
+// barrier and a single lock protecting the per-job count map. The
+// signaled state of the gate represents "no priority work pending
+// anywhere"; non-priority files Wait the gate, priority files don't.
+//
+// All public methods are thread-safe. The lock scope is short and never
+// straddles the underlying Wait — waiters never hold the lock while
+// blocked.
+public sealed class PriorityGate : IPriorityGate, IDisposable
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<string, int> _remaining = new(StringComparer.Ordinal);
+    private readonly ManualResetEventSlim _cleared = new(initialState: true);
+
+    public void RegisterJob(string jobName, int priorityFileCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+        ArgumentOutOfRangeException.ThrowIfNegative(priorityFileCount);
+
+        lock (_lock)
+        {
+            _remaining[jobName] = priorityFileCount;
+            UpdateGateUnsafe();
+        }
+    }
+
+    public void MarkPriorityFileDone(string jobName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+
+        lock (_lock)
+        {
+            if (!_remaining.TryGetValue(jobName, out var n) || n <= 0) return;
+            _remaining[jobName] = n - 1;
+            UpdateGateUnsafe();
+        }
+    }
+
+    public void WaitForNonPriorityWindow(CancellationToken ct)
+    {
+        // Snapshot is taken inside the gate's own internal lock; no
+        // explicit user-side lock needed here. Token-aware overload
+        // surfaces OperationCanceledException through the standard
+        // ManualResetEventSlim contract.
+        _cleared.Wait(ct);
+    }
+
+    public void UnregisterJob(string jobName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+
+        lock (_lock)
+        {
+            if (!_remaining.Remove(jobName)) return;
+            UpdateGateUnsafe();
+        }
+    }
+
+    private void UpdateGateUnsafe()
+    {
+        var total = 0;
+        foreach (var n in _remaining.Values)
+        {
+            total += n;
+            if (total > 0) break;
+        }
+        if (total == 0) _cleared.Set();
+        else _cleared.Reset();
+    }
+
+    public void Dispose() => _cleared.Dispose();
+}

--- a/tests/EasySave.Tests.V2/PriorityGateTests.cs
+++ b/tests/EasySave.Tests.V2/PriorityGateTests.cs
@@ -1,0 +1,157 @@
+using EasySave.Services;
+
+namespace EasySave.Tests.V2;
+
+public class PriorityGateTests
+{
+    private static readonly TimeSpan PendingProbe = TimeSpan.FromMilliseconds(100);
+
+    [Fact]
+    public void Constructor_NewGate_AllowsNonPriorityImmediately()
+    {
+        using var gate = new PriorityGate();
+        // No job registered → gate is signaled → Wait returns immediately.
+        gate.WaitForNonPriorityWindow(CancellationToken.None);
+    }
+
+    [Fact]
+    public void RegisterJob_WithZeroPriorityFiles_DoesNotBlockWaiters()
+    {
+        using var gate = new PriorityGate();
+        gate.RegisterJob("A", priorityFileCount: 0);
+        gate.WaitForNonPriorityWindow(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task RegisterJob_WithPriorityFiles_BlocksNonPriorityUntilAllDone()
+    {
+        // Single job with 3 priority files: a non-priority waiter must
+        // stay parked until all 3 are marked done.
+        using var gate = new PriorityGate();
+        gate.RegisterJob("A", priorityFileCount: 3);
+
+        var waitTask = Task.Run(() => gate.WaitForNonPriorityWindow(CancellationToken.None));
+
+        // Still pending after 100 ms — 3 priorities outstanding.
+        var winner = await Task.WhenAny(waitTask, Task.Delay(PendingProbe));
+        Assert.NotSame(waitTask, winner);
+
+        gate.MarkPriorityFileDone("A");
+        gate.MarkPriorityFileDone("A");
+        // 1 priority left — still blocked.
+        var winner2 = await Task.WhenAny(waitTask, Task.Delay(PendingProbe));
+        Assert.NotSame(waitTask, winner2);
+
+        gate.MarkPriorityFileDone("A");
+        // Total reached zero — waiter must unblock promptly.
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task CrossJob_ANonPriorityBlocksWhileBHasPrioritiesPending()
+    {
+        // Two jobs. A has zero priorities, B has one. A's non-priority
+        // file must wait for B to finish even though A itself has no
+        // priorities — that's the CdC rule.
+        using var gate = new PriorityGate();
+        gate.RegisterJob("A", priorityFileCount: 0);
+        gate.RegisterJob("B", priorityFileCount: 1);
+
+        var waitTask = Task.Run(() => gate.WaitForNonPriorityWindow(CancellationToken.None));
+
+        var winner = await Task.WhenAny(waitTask, Task.Delay(PendingProbe));
+        Assert.NotSame(waitTask, winner);
+
+        gate.MarkPriorityFileDone("B");
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task UnregisterJob_DiscardsLeftoverPrioritiesAndUnblocksOthers()
+    {
+        // Job A registered with 5 priorities, no MarkDone calls (think:
+        // the job was cancelled mid-run). Unregister must drop the live
+        // count so any other job's non-priority files stop waiting.
+        using var gate = new PriorityGate();
+        gate.RegisterJob("A", priorityFileCount: 5);
+        gate.RegisterJob("B", priorityFileCount: 0);
+
+        var waitTask = Task.Run(() => gate.WaitForNonPriorityWindow(CancellationToken.None));
+
+        var winner = await Task.WhenAny(waitTask, Task.Delay(PendingProbe));
+        Assert.NotSame(waitTask, winner);
+
+        gate.UnregisterJob("A");
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task WaitForNonPriorityWindow_CancelledToken_ThrowsWithoutCorruptingGate()
+    {
+        // A cancelled waiter does not consume any slot (this is a gate,
+        // not a semaphore) and does not change the priority count, so a
+        // subsequent waiter sees the same outstanding priorities.
+        using var gate = new PriorityGate();
+        gate.RegisterJob("A", priorityFileCount: 1);
+
+        using var cts = new CancellationTokenSource();
+        var firstWait = Task.Run(() =>
+            Assert.ThrowsAny<OperationCanceledException>(
+                () => gate.WaitForNonPriorityWindow(cts.Token)));
+
+        var winner = await Task.WhenAny(firstWait, Task.Delay(PendingProbe));
+        Assert.NotSame(firstWait, winner);
+        cts.Cancel();
+        await firstWait;
+
+        // Sanity: second waiter still blocks (priority count untouched).
+        var secondWait = Task.Run(() => gate.WaitForNonPriorityWindow(CancellationToken.None));
+        var winner2 = await Task.WhenAny(secondWait, Task.Delay(PendingProbe));
+        Assert.NotSame(secondWait, winner2);
+
+        gate.MarkPriorityFileDone("A");
+        await secondWait.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void MarkPriorityFileDone_OnUnknownJobName_IsNoOp()
+    {
+        using var gate = new PriorityGate();
+        // Should not throw even though nothing is registered.
+        gate.MarkPriorityFileDone("ghost");
+        gate.WaitForNonPriorityWindow(CancellationToken.None);
+    }
+
+    [Fact]
+    public void MarkPriorityFileDone_OnAlreadyZeroJob_IsNoOpDoesNotGoNegative()
+    {
+        // Register with 1 priority, mark twice. Second mark must not
+        // drive the count negative (would break the "total > 0" check).
+        using var gate = new PriorityGate();
+        gate.RegisterJob("A", priorityFileCount: 1);
+        gate.MarkPriorityFileDone("A");
+        gate.MarkPriorityFileDone("A");
+
+        // Register a new job with 1 priority; the gate must block again.
+        gate.RegisterJob("B", priorityFileCount: 1);
+        Assert.Throws<OperationCanceledException>(() =>
+            gate.WaitForNonPriorityWindow(new CancellationToken(canceled: true)));
+    }
+
+    [Fact]
+    public void RegisterJob_NegativeCount_Throws()
+    {
+        using var gate = new PriorityGate();
+        Assert.Throws<ArgumentOutOfRangeException>(() => gate.RegisterJob("A", -1));
+    }
+
+    [Fact]
+    public void RegisterJob_NullOrWhitespaceName_Throws()
+    {
+        using var gate = new PriorityGate();
+        Assert.Throws<ArgumentException>(() => gate.RegisterJob("", 1));
+        Assert.Throws<ArgumentException>(() => gate.RegisterJob("   ", 1));
+    }
+}

--- a/tests/EasySave.Tests/BackupManagerPriorityTests.cs
+++ b/tests/EasySave.Tests/BackupManagerPriorityTests.cs
@@ -1,0 +1,163 @@
+using EasyLog;
+using EasySave.Models;
+using EasySave.Services;
+
+namespace EasySave.Tests;
+
+[Collection("StateCollection")]
+public class BackupManagerPriorityTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _sourceDir;
+    private readonly string _targetDir;
+    private readonly string _logDir;
+    private readonly string _dataDir;
+
+    public BackupManagerPriorityTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "bm-prio-tests-" + Guid.NewGuid().ToString("N"));
+        _sourceDir = Path.Combine(_tempDir, "source");
+        _targetDir = Path.Combine(_tempDir, "target");
+        _logDir = Path.Combine(_tempDir, "logs");
+        _dataDir = Path.Combine(_tempDir, "data");
+        Directory.CreateDirectory(_sourceDir);
+        Directory.CreateDirectory(_targetDir);
+        Directory.CreateDirectory(_logDir);
+        Directory.CreateDirectory(_dataDir);
+
+        var configPath = Path.Combine(_tempDir, "appsettings.json");
+        File.WriteAllText(configPath, System.Text.Json.JsonSerializer.Serialize(new
+        {
+            LogDirectory = _logDir,
+            StateFilePath = Path.Combine(_dataDir, "state.json"),
+            JobsFilePath = Path.Combine(_dataDir, "jobs.json"),
+        }));
+        AppConfig.Load(configPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private BackupManager CreateManager(
+        IPriorityGate? priorityGate,
+        IEnumerable<string> priorityExtensions,
+        IDailyLogger? logger = null)
+    {
+        return new BackupManager(
+            logger ?? new JsonDailyLogger(_logDir),
+            new FullBackupStrategy(),
+            new DifferentialBackupStrategy(),
+            StateTracker.Instance,
+            JobRepository.Instance,
+            new NoOpEncryptionService(),
+            Array.Empty<string>(),
+            bigFileGate: null,
+            priorityGate: priorityGate,
+            priorityExtensions: priorityExtensions);
+    }
+
+    private void SeedJob(string name, string sourceDir)
+    {
+        JobRepository.Instance.Save(new List<BackupJob>
+        {
+            new() { Name = name, SourcePath = sourceDir, TargetPath = _targetDir, Type = BackupType.Full },
+        });
+    }
+
+    // Captures the order of file-transfer log entries so the test can
+    // assert that priority files were copied before non-priority files.
+    private sealed class CapturingLogger : IDailyLogger
+    {
+        public List<LogEntry> Entries { get; } = new();
+        public void Append(LogEntry entry)
+        {
+            lock (Entries) Entries.Add(entry);
+        }
+    }
+
+    [Fact]
+    public void ExecuteJob_PriorityFilesAreCopiedFirstWithinAJob()
+    {
+        // Source: 2 non-priority + 2 priority. Priorities must appear
+        // first in the log, regardless of the ordinal file-name order.
+        File.WriteAllText(Path.Combine(_sourceDir, "a-plain.txt"), "x");
+        File.WriteAllText(Path.Combine(_sourceDir, "b-plain.txt"), "x");
+        File.WriteAllText(Path.Combine(_sourceDir, "c-doc.docx"), "x");
+        File.WriteAllText(Path.Combine(_sourceDir, "d-doc.docx"), "x");
+        SeedJob("prio-order", _sourceDir);
+
+        var logger = new CapturingLogger();
+        var manager = CreateManager(
+            priorityGate: null,
+            priorityExtensions: new[] { ".docx" },
+            logger: logger);
+
+        manager.ExecuteJob("prio-order");
+
+        var transferred = logger.Entries
+            .Where(e => !string.IsNullOrEmpty(e.SourceFile))
+            .Select(e => Path.GetFileName(e.SourceFile))
+            .ToList();
+
+        Assert.Equal(4, transferred.Count);
+        // First two transferred must be the priorities, last two the plain files.
+        Assert.All(transferred.Take(2),
+            n => Assert.EndsWith(".docx", n, StringComparison.OrdinalIgnoreCase));
+        Assert.All(transferred.Skip(2),
+            n => Assert.EndsWith(".txt", n, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ExecuteJob_NonPriorityWaitsForOtherJobsPriorities()
+    {
+        // Two jobs, one shared PriorityGate. Job A has only one non-
+        // priority file. Job B has one .docx (priority). Job A must
+        // wait until B's .docx is done before copying its .txt.
+        // Lay them out in two source dirs so each job sees its own
+        // single file.
+        var srcA = Path.Combine(_tempDir, "srcA");
+        var srcB = Path.Combine(_tempDir, "srcB");
+        Directory.CreateDirectory(srcA);
+        Directory.CreateDirectory(srcB);
+        File.WriteAllText(Path.Combine(srcA, "a.txt"), "x");
+        File.WriteAllText(Path.Combine(srcB, "b.docx"), "x");
+
+        JobRepository.Instance.Save(new List<BackupJob>
+        {
+            new() { Name = "JobA", SourcePath = srcA, TargetPath = Path.Combine(_targetDir, "A"), Type = BackupType.Full },
+            new() { Name = "JobB", SourcePath = srcB, TargetPath = Path.Combine(_targetDir, "B"), Type = BackupType.Full },
+        });
+
+        using var gate = new PriorityGate();
+        // Pre-register JobB with one priority before either ExecuteJob
+        // call so JobA's WaitForNonPriorityWindow sees the pending
+        // priority and parks. JobB.ExecuteJob will (re-)register and then
+        // MarkPriorityFileDone after its .docx copy.
+        gate.RegisterJob("JobB", priorityFileCount: 1);
+
+        var loggerA = new CapturingLogger();
+        var loggerB = new CapturingLogger();
+        var managerA = CreateManager(gate, new[] { ".docx" }, loggerA);
+        var managerB = CreateManager(gate, new[] { ".docx" }, loggerB);
+
+        var aTask = Task.Run(() => managerA.ExecuteJob("JobA"));
+
+        // A must still be parked on the gate (waiting for JobB to mark
+        // its .docx done). 100 ms probe is generous on any CI runner.
+        var winner = await Task.WhenAny(aTask, Task.Delay(TimeSpan.FromMilliseconds(150)));
+        Assert.NotSame(aTask, winner);
+        Assert.Empty(loggerA.Entries.Where(e => !string.IsNullOrEmpty(e.SourceFile)));
+
+        var bTask = Task.Run(() => managerB.ExecuteJob("JobB"));
+        await bTask;
+
+        // Once B is done, A's wait must clear and the .txt copies.
+        await aTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.True(File.Exists(Path.Combine(_targetDir, "A", "a.txt")));
+        Assert.True(File.Exists(Path.Combine(_targetDir, "B", "b.docx")));
+    }
+}


### PR DESCRIPTION
Phase 3 V3 — task `869d8r8p0` (Priority 1 of 3, CdC V3 obligatoire). Last of the three Phase 3 V3 tasks added recently (#180 PauseGate, #186 watcher, this one).

> *« Aucune sauvegarde d'un fichier non prioritaire ne peut se faire tant qu'il y a des extensions prioritaires en attente sur au moins un travail. »*

## Approach

**Single-pass orchestrator + blocking `IPriorityGate`** (vs the two-pass design also mentioned in the task). The gate is cheaper than a second iteration of the eligible list, plays nicely with the existing resume cursor, and is conceptually similar to the BigFileGate that's already in place.

## What changes

### Wire / settings (additive)

- `AppSettings.priority_extensions`: `IReadOnlyList<string>` (e.g. `[\".docx\"]`). Case-insensitive matching against `Path.GetExtension`.

### `IPriorityGate` (new, engine layer)

- `RegisterJob(name, count)` — before the loop starts.
- `MarkPriorityFileDone(name)` — after copying each priority file.
- `WaitForNonPriorityWindow(ct)` — non-priority files park here when any job has prio remaining; returns once the cross-job total reaches zero. Token-aware `ManualResetEventSlim.Wait` under the hood, so cancellation throws without corrupting the gate.
- `UnregisterJob(name)` — cleanup in `finally`. Leftover priorities of a stopped / failed job are discarded so other jobs' non-priority files are not held hostage.

### `PriorityGate` (concrete impl)

Dictionary + lock (tight lock scope, never held during `Wait`). `ManualResetEventSlim` toggles based on the running sum of priority counts. `Dispose` disposes the gate.

### `BackupManager.ExecuteJob`

- New optional ctor params: `IPriorityGate? priorityGate` and `IEnumerable<string>? priorityExtensions` (default `Array.Empty`). V1/V2 callers untouched.
- Loop: sort `toCopy` with priorities first **within** the job (intra-job optimization — the gate already handles cross-job ordering, this just makes the gate clear faster), register the job's priority count, then for each file:
  - non-priority → `WaitForNonPriorityWindow(ct)` before copy
  - priority → `MarkPriorityFileDone` after copy (only on success)
- `finally` → `UnregisterJob`.
- `ShouldEncrypt`-mirror helper `IsPriority(file)`.

### DI / wiring

- `App.axaml.cs` registers `IPriorityGate` as a singleton (one shared across the engine), passes it + `userSettings.PriorityExtensions` to the `BackupManager` constructor, and disposes it in `DisposeServices` alongside the BigFileGate.
- `Program.cs` (v1 console) passes `priorityExtensions` for the in-job ordering but leaves the gate `null` — the v1 console runs jobs sequentially, no cross-job race to coordinate.

## Tests

### `PriorityGateTests` (V2, 10 cases)

- Constructor / new gate signaled by default.
- Register-with-zero doesn't block.
- Register-with-N blocks until N MarkDone calls.
- **Cross-job: JobA non-prio waits while JobB has prio**, deterministic via a 100 ms 'still pending' probe.
- `UnregisterJob` discards leftover priorities.
- Cancelled `Wait` throws **without** corrupting the gate (verified by a follow-up wait).
- No-ops on unknown job names / re-marking past zero.
- Argument validation (negative count, null/whitespace name).

### `BackupManagerPriorityTests` (V1, 2 integration cases)

- `ExecuteJob_PriorityFilesAreCopiedFirstWithinAJob` — `.docx` precedes `.txt` in the `LogEntry` sequence.
- `ExecuteJob_NonPriorityWaitsForOtherJobsPriorities` — JobA (1 `.txt`) and JobB (1 `.docx`) share one `PriorityGate`. JobA's `.txt` is verified to stay parked for 150 ms while JobB's `.docx` hasn't been marked done; once JobB completes the `.txt` falls through.

## Recette manuelle

`docs/recettes/v3-priority-extensions.md` couvre :

- un job seul (ordre intra-job),
- **le vrai test V3** : deux jobs parallèles, gate cross-jobs vérifiée via les mtimes côté cible **et** la séquence des `FileTransfer` dans le log JSON,
- les critères d'acceptation,
- les edge cases (no prio configured = no-op, all-prio job, mid-run stop avec `UnregisterJob`, resume avec le bon compte de prio restantes),
- un tableau de troubleshooting.

## Test plan

- [x] `dotnet build EasySave.sln -c Release` → 0 warnings, 0 errors
- [x] `dotnet test EasySave.Tests.V2` → **157 / 157 passing** (gate suite 10 / 10)
- [x] `dotnet test --filter BackupManagerPriorityTests` → **2 / 2 passing**
- [ ] Manual smoke via `docs/recettes/v3-priority-extensions.md` (2 jobs avec mix de `.docx` et `.txt`)