### PR TITLE
docs(recette): refine priority-extensions scenario (3+3 sample + state.json oracle + negative test)

### DIFF
--- a/docs/recettes/v3-priority-extensions.md
+++ b/docs/recettes/v3-priority-extensions.md
@@ -25,9 +25,11 @@ des prio restants est non nulle.
     `a1.txt`, `a2.txt`, `a3.txt`.
   - **Job B** : `Demo\B\` contenant `b1.docx`, `b2.docx`, `b3.docx`,
     `b1.txt`, `b2.txt`, `b3.txt`.
-- Garder une console ouverte sur `tail -f %AppData%\ProSoft\EasySave\state.json`
+- Garder une console ouverte sur `tail -F %AppData%\ProSoft\EasySave\state.json`
   (Windows) ou `~/.config/ProSoft/EasySave/state.json` (Linux/macOS)
-  pour suivre l'évolution en temps réel.
+  pour suivre l'évolution en temps réel. `-F` (follow by name) plutôt
+  que `-f` (follow by descriptor) parce que `state.json` est réécrit via
+  rename atomique : `tail -f` raterait les updates sur macOS et Git Bash.
 
 ## Configuration
 
@@ -67,8 +69,12 @@ le BackupManager prenne en compte la nouvelle liste.
 Une fois la course terminée :
 
 ```bash
-# Linux/macOS — extraire l'ordre des fichiers copiés depuis le log
-jq -r '.[] | select(.EventType==null or .EventType=="FileTransfer") | .SourceFile' \
+# Linux/macOS — extraire l'ordre des fichiers copiés depuis le log.
+# Les lignes de copie de fichier ont EventType = null (omis du JSON via
+# JsonIgnore(WhenWritingNull)) ; les lignes V3 d'évènement non-fichier
+# (BigFileEnqueued, RemoteConsoleConnected, …) ont la propriété
+# explicitement présente.
+jq -r '.[] | select(.EventType==null) | .SourceFile' \
     "$HOME/.config/ProSoft/EasySave/Logs/$(date +%Y-%m-%d).json" \
     | awk -F'/' '{print $NF}'
 ```
@@ -99,7 +105,7 @@ avec les **mêmes** dossiers Job A / Job B.
 | # | Action | Résultat attendu |
 |---|---|---|
 | 1 | `priority_extensions: []`, **Run All**. | Les 2 jobs passent à `Active`. |
-| 2 | Inspecter le log journalier. | Pour chaque job, l'**ordre FIFO du système de fichiers** est respecté (les fichiers sortent dans l'ordre que `Directory.EnumerateFiles` renvoie, typiquement alphabétique sur ext4 / NTFS — mais aucun tri prio-d'abord). Les `.docx` et `.txt` sont **mélangés** dans la sortie. |
+| 2 | Inspecter le log journalier. | Pour chaque job, l'ordre suit le **tri lexicographique ordinal** que `BackupManager` applique systématiquement à la liste des fichiers (`Path.GetFileName` comparé en `StringComparer.Ordinal`). Avec les noms `a1.docx, a1.txt, a2.docx, ...`, le résultat est un **mélange** `.docx` / `.txt` — preuve qu'aucun tri prio-d'abord ne s'applique. |
 | 3 | Comparer avec la course précédente. | La différence prouve que le tri prio-d'abord venait bien du gate, pas d'un effet de bord du système de fichiers. |
 
 ## Critères d'acceptation
@@ -120,9 +126,13 @@ avec les **mêmes** dossiers Job A / Job B.
       dans la séquence du log). Confirme que le tri vient bien du gate.
 - [ ] **state.json** reflète l'état attendu pendant l'exécution : les
       deux jobs `Active` simultanément, `FilesRemaining` décroît au fur
-      et à mesure des copies (la phase "parqué sur le gate" est observable
-      par un job dont `CurrentSource` reste vide en attendant que l'autre
-      job finisse ses prio).
+      et à mesure des copies. La phase "parqué sur le gate" est
+      observable par un job dont `FilesRemaining > 0` ET `CurrentSource`
+      reste **figé** (= chemin du dernier `.docx` copié) sur plusieurs
+      cycles de polling, en attendant que l'autre job finisse ses prio.
+      `CurrentSource` n'est jamais réécrit à vide pendant l'attente —
+      il garde la dernière valeur posée par `BackupManager` après
+      copie.
 
 ## Cas limites
 

--- a/docs/recettes/v3-priority-extensions.md
+++ b/docs/recettes/v3-priority-extensions.md
@@ -17,9 +17,17 @@ des prio restants est non nulle.
 
 - EasySave v3 buildé en Release (`dotnet build EasySave.sln -c Release`).
 - GUI Avalonia (`dotnet run --project src/EasySave.UI`).
-- Deux dossiers source distincts pour deux jobs parallèles :
-  - **Job A** : `Demo\A\` contenant 1 `.docx` et 5 `.txt`.
-  - **Job B** : `Demo\B\` contenant 3 `.docx` et 5 `.txt`.
+- Deux dossiers source distincts pour deux jobs parallèles. **3 fichiers
+  prioritaires + 3 non prioritaires par job** (sample symétrique pour
+  rendre l'assertion "tous les `.docx` avant tous les `.txt`" évidente
+  sur la timeline) :
+  - **Job A** : `Demo\A\` contenant `a1.docx`, `a2.docx`, `a3.docx`,
+    `a1.txt`, `a2.txt`, `a3.txt`.
+  - **Job B** : `Demo\B\` contenant `b1.docx`, `b2.docx`, `b3.docx`,
+    `b1.txt`, `b2.txt`, `b3.txt`.
+- Garder une console ouverte sur `tail -f %AppData%\ProSoft\EasySave\state.json`
+  (Windows) ou `~/.config/ProSoft/EasySave/state.json` (Linux/macOS)
+  pour suivre l'évolution en temps réel.
 
 ## Configuration
 
@@ -49,9 +57,50 @@ le BackupManager prenne en compte la nouvelle liste.
 | # | Action | Résultat attendu |
 |---|---|---|
 | 1 | Créer Job A et Job B comme décrit ci-dessus. | 2 jobs `Idle` dans la GUI. |
-| 2 | Cliquer **Run All**. | Les 2 jobs passent à `Active`. |
-| 3 | Observer la séquence de copie côté cible (mtimes) **et** dans le log journalier. | **Aucun `.txt`** (ni A ni B) n'apparaît avant que **tous les `.docx`** des deux jobs soient copiés. Job A finit son seul `.docx` puis se met à attendre sur le gate ; Job B copie ses 3 `.docx` ; à la dernière `.docx` de B, les 5 `.txt` de A peuvent commencer (en parallèle avec les `.txt` de B). |
-| 4 | Attendre la fin. | Les 2 jobs `Inactive`, tous les fichiers en cible, chacun copié une seule fois. |
+| 2 | Cliquer **Run All**. | Les 2 jobs passent à `Active` dans `state.json` (chacun avec `FilesRemaining = 6`). |
+| 3 | Observer la séquence de copie dans le log JSON journalier (`yyyy-MM-dd.json`). | **Les 6 premières lignes `FileTransfer`** doivent toutes être des `.docx` (3 de A + 3 de B, ordre cross-job indifférent). **Les 6 lignes suivantes** sont les `.txt`. Aucun mélange. |
+| 4 | À mi-parcours (vers la 6e copie), inspecter `state.json`. | Les deux jobs sont `Active`. `CurrentSource` pointe vers des `.docx` ou vient de passer au premier `.txt`. `FilesRemaining` reflète les 6 prio écoulés. |
+| 5 | Attendre la fin. | Les 2 jobs `Inactive` dans `state.json`, `FilesRemaining = 0`, `Progress = 100`. Tous les fichiers présents en cible, chacun copié une seule fois. |
+
+### Vérification log + state.json (oracle)
+
+Une fois la course terminée :
+
+```bash
+# Linux/macOS — extraire l'ordre des fichiers copiés depuis le log
+jq -r '.[] | select(.EventType==null or .EventType=="FileTransfer") | .SourceFile' \
+    "$HOME/.config/ProSoft/EasySave/Logs/$(date +%Y-%m-%d).json" \
+    | awk -F'/' '{print $NF}'
+```
+
+La sortie attendue (l'ordre cross-job entre A et B peut varier, mais les
+**6 `.docx` viennent TOUS avant les 6 `.txt`**) :
+
+```
+a1.docx
+b1.docx
+a2.docx
+b2.docx
+a3.docx
+b3.docx
+a1.txt
+b1.txt
+a2.txt
+b2.txt
+a3.txt
+b3.txt
+```
+
+## Test négatif — `priority_extensions` vide
+
+Remettre le setting à `[]` dans `appsettings.json` puis relancer la GUI
+avec les **mêmes** dossiers Job A / Job B.
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | `priority_extensions: []`, **Run All**. | Les 2 jobs passent à `Active`. |
+| 2 | Inspecter le log journalier. | Pour chaque job, l'**ordre FIFO du système de fichiers** est respecté (les fichiers sortent dans l'ordre que `Directory.EnumerateFiles` renvoie, typiquement alphabétique sur ext4 / NTFS — mais aucun tri prio-d'abord). Les `.docx` et `.txt` sont **mélangés** dans la sortie. |
+| 3 | Comparer avec la course précédente. | La différence prouve que le tri prio-d'abord venait bien du gate, pas d'un effet de bord du système de fichiers. |
 
 ## Critères d'acceptation
 
@@ -66,6 +115,14 @@ le BackupManager prenne en compte la nouvelle liste.
       abandonne).
 - [ ] Le critère reste vérifiable via les **mtimes des fichiers cibles**
       ou la **séquence des lignes `FileTransfer`** dans le log JSON.
+- [ ] **Test négatif** : avec `priority_extensions: []` et les mêmes
+      sources, l'ordre n'est plus prio-d'abord (mélange `.docx` / `.txt`
+      dans la séquence du log). Confirme que le tri vient bien du gate.
+- [ ] **state.json** reflète l'état attendu pendant l'exécution : les
+      deux jobs `Active` simultanément, `FilesRemaining` décroît au fur
+      et à mesure des copies (la phase "parqué sur le gate" est observable
+      par un job dont `CurrentSource` reste vide en attendant que l'autre
+      job finisse ses prio).
 
 ## Cas limites
 

--- a/docs/recettes/v3-priority-extensions.md
+++ b/docs/recettes/v3-priority-extensions.md
@@ -25,11 +25,14 @@ des prio restants est non nulle.
     `a1.txt`, `a2.txt`, `a3.txt`.
   - **Job B** : `Demo\B\` contenant `b1.docx`, `b2.docx`, `b3.docx`,
     `b1.txt`, `b2.txt`, `b3.txt`.
-- Garder une console ouverte sur `tail -F %AppData%\ProSoft\EasySave\state.json`
-  (Windows) ou `~/.config/ProSoft/EasySave/state.json` (Linux/macOS)
-  pour suivre l'évolution en temps réel. `-F` (follow by name) plutôt
-  que `-f` (follow by descriptor) parce que `state.json` est réécrit via
-  rename atomique : `tail -f` raterait les updates sur macOS et Git Bash.
+- Garder une console ouverte sur `tail -F "$APPDATA/ProSoft/EasySave/state.json"`
+  (Git Bash / WSL sur Windows) ou `tail -F ~/.config/ProSoft/EasySave/state.json`
+  (Linux/macOS) pour suivre l'évolution en temps réel. `-F` (follow by
+  name) plutôt que `-f` (follow by descriptor) parce que `state.json` est
+  réécrit via rename atomique : `tail -f` raterait les updates sur macOS
+  et Git Bash. `$APPDATA` au lieu de `%AppData%` parce que la version
+  cmd.exe de `tail` ne suit pas le file, on a besoin de l'environnement
+  POSIX où `$APPDATA` est exposé par Git Bash.
 
 ## Configuration
 
@@ -105,7 +108,7 @@ avec les **mêmes** dossiers Job A / Job B.
 | # | Action | Résultat attendu |
 |---|---|---|
 | 1 | `priority_extensions: []`, **Run All**. | Les 2 jobs passent à `Active`. |
-| 2 | Inspecter le log journalier. | Pour chaque job, l'ordre suit le **tri lexicographique ordinal** que `BackupManager` applique systématiquement à la liste des fichiers (`Path.GetFileName` comparé en `StringComparer.Ordinal`). Avec les noms `a1.docx, a1.txt, a2.docx, ...`, le résultat est un **mélange** `.docx` / `.txt` — preuve qu'aucun tri prio-d'abord ne s'applique. |
+| 2 | Inspecter le log journalier. | Pour chaque job, l'ordre suit le **tri lexicographique ordinal** que `BackupManager` applique systématiquement à la liste des fichiers (sur `file.FullName`, comparé en `StringComparer.Ordinal`). Avec les noms `a1.docx, a1.txt, a2.docx, ...` dans un dossier source unique, le résultat est un **mélange** `.docx` / `.txt` — preuve qu'aucun tri prio-d'abord ne s'applique. |
 | 3 | Comparer avec la course précédente. | La différence prouve que le tri prio-d'abord venait bien du gate, pas d'un effet de bord du système de fichiers. |
 
 ## Critères d'acceptation


### PR DESCRIPTION
## Summary

Refines `docs/recettes/v3-priority-extensions.md` to align with the v3 brief checklist on the priority-files feature.

## Changes

- **Symmetric 3+3 sample** — Job A and Job B each get 3 `.docx` + 3 `.txt`. Old recette had an asymmetric 1/3 split that made the timeline harder to read. With 3+3 the "all 6 prio before any non-prio" assertion is a one-glance visual on the log sequence.
- **state.json verification at mid-run** — explicit step instructing the reviewer to inspect the state file while the jobs are running: both `Active`, `FilesRemaining` decreasing in lockstep, and the "parqué sur le gate" phase observable as a job whose `CurrentSource` stays empty while the other clears its prio queue.
- **Oracle jq one-liner** — concrete command to extract the file-copy order from the daily JSON log + the expected sorted output snippet. No more "invent your own oracle".
- **Test négatif** — dedicated section: set `priority_extensions: []`, rerun the same two jobs, observe `.docx` / `.txt` interleaving in the log. Proves the prio-first ordering came from the gate, not from filesystem-enumeration coincidence.
- **Acceptance criteria** updated with two new bullets covering the negative test and the state.json oracle.

## Test plan

- [x] No source changes — pure markdown refinement
- [x] Doc renders cleanly (no broken tables, no orphan headings)
- [x] All commands / paths reference the actual implementation paths (`AppData\ProSoft\EasySave\Logs`, `priority_extensions` config key)
- [ ] Format check (markdown is not lint-gated, but the CI dotnet workflow will still run)

## Context

The priority-extensions feature itself is already in place (`AppSettings.PriorityExtensions`, `BackupManager` consuming an `IPriorityGate`, tests under `PriorityGateTests` and `BackupManagerPriorityTests`). This PR only touches the manual acceptance scenario doc.