### PR TITLE
fix(v3): make LogCentralizer Docker image readable by the app user

### DIFF
--- a/LogCentralizer/Dockerfile
+++ b/LogCentralizer/Dockerfile
@@ -54,7 +54,15 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /app/publish ./
+# --chown=app:app explicitly transfers ownership of the published
+# files to the runtime user. Without this, COPY preserves whatever
+# uid/gid existed in the build stage (root) and some Docker builders
+# (notably BuildKit on Testcontainers) end up producing files the
+# `app` user cannot read — the app then crashes on startup with
+# UnauthorizedAccessException on /app/appsettings.json. Tested fine
+# with `docker compose build` (classic builder) but reproduced
+# reliably on the Testcontainers BuildKit-driven path.
+COPY --from=build --chown=app:app /app/publish ./
 
 # Run as a non-root user. The aspnet:8.0 image ships with the
 # `app` user (UID 1654 on .NET 8). Pre-create the logs dir with the

--- a/tests/LogCentralizer.Tests/LogCentralizerE2ETests.cs
+++ b/tests/LogCentralizer.Tests/LogCentralizerE2ETests.cs
@@ -168,20 +168,6 @@ public sealed class LogCentralizerE2EFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        // Skip on CI. GitHub Actions sets CI=true on every runner. Even when
-        // the daemon is technically present, the e2e suite consistently hangs
-        // at "Wait for Docker container to complete readiness checks" — the
-        // Linux bind-mount + UID-1654 interaction is a known footgun that
-        // doesn't reproduce on Docker Desktop (macOS/Windows do transparent
-        // UID translation). The in-process suite covers the same functional
-        // contract for the CI gate; this suite stays valuable on dev
-        // workstations to validate the actual Docker image before tag.
-        if (string.Equals(Environment.GetEnvironmentVariable("CI"), "true", StringComparison.OrdinalIgnoreCase))
-        {
-            SkipReason = "Skipped on CI runners — run locally with Docker daemon to exercise the real image.";
-            return;
-        }
-
         try
         {
             HostLogsDir = Path.Combine(
@@ -216,15 +202,35 @@ public sealed class LogCentralizerE2EFixture : IAsyncLifetime
                 .WithImage(ImageTag)
                 .WithPortBinding(ContainerLogsPort, assignRandomHostPort: true)
                 .WithBindMount(HostLogsDir, "/var/log/easysave")
-                .WithWaitStrategy(Wait.ForUnixContainer()
-                    .UntilHttpRequestIsSucceeded(req => req
-                        .ForPath("/health")
-                        .ForPort(ContainerLogsPort)))
+                // Intentionally NO WithWaitStrategy: Testcontainers .NET
+                // issue #1639 — UntilHttpRequestIsSucceeded has a hardcoded
+                // 100 s HttpClient timeout whose TaskCanceledException is
+                // not caught by the wait-strategy retry loop, so the probe
+                // loops silently until the container default start-timeout
+                // fires (60 min). We do the readiness probe ourselves
+                // below with an explicit, bounded poll loop.
                 .Build();
             await _container.StartAsync().ConfigureAwait(false);
 
             int hostPort = _container.GetMappedPublicPort(ContainerLogsPort);
             Http = new HttpClient { BaseAddress = new Uri($"http://localhost:{hostPort}") };
+
+            try
+            {
+                await WaitForHealthAsync(Http, TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                // Capture the container's stdout / stderr so a failed
+                // readiness probe surfaces what actually happened inside
+                // (app crashed at startup? bound to a different port?
+                // wrote a stack trace?) — without these logs the
+                // SkippableFact reason is useless.
+                (string stdout, string stderr) = await _container.GetLogsAsync().ConfigureAwait(false);
+                throw new TimeoutException(
+                    $"LogCentralizer /health unreachable. Container stdout/stderr:\n" +
+                    $"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+            }
         }
         catch (Exception ex)
         {
@@ -283,5 +289,45 @@ public sealed class LogCentralizerE2EFixture : IAsyncLifetime
                 "Could not locate repo root (EasySave.sln) from the test assembly path.");
         }
         return dir.FullName;
+    }
+
+    // Bounded poll loop on /health. Replaces Testcontainers'
+    // UntilHttpRequestIsSucceeded which silently hangs for 60 min on a
+    // probe timeout (Testcontainers .NET issue #1639 — hardcoded 100 s
+    // HttpClient timeout whose TaskCanceledException escapes the
+    // wait-strategy retry catch block). Here we own the timeout and the
+    // exception filter, so a failed probe surfaces as a clean
+    // TimeoutException within 30 s — the InitializeAsync catch then
+    // records the message in SkipReason for the inline-test skip.
+    private static async Task WaitForHealthAsync(HttpClient client, TimeSpan timeout)
+    {
+        // Per-request budget short enough that we can probe multiple times
+        // inside the overall timeout, but long enough to ride out a
+        // momentarily slow Kestrel boot inside the container.
+        using var probeClient = new HttpClient
+        {
+            BaseAddress = client.BaseAddress,
+            Timeout = TimeSpan.FromSeconds(2),
+        };
+
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? lastError = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                using var response = await probeClient.GetAsync("/health").ConfigureAwait(false);
+                if (response.IsSuccessStatusCode) return;
+                lastError = new HttpRequestException($"/health returned {(int)response.StatusCode}");
+            }
+            catch (HttpRequestException ex) { lastError = ex; }
+            catch (TaskCanceledException ex) { lastError = ex; }
+
+            await Task.Delay(250).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            $"LogCentralizer /health did not become reachable within {timeout.TotalSeconds:F0}s. " +
+            $"Last error: {lastError?.GetType().Name}: {lastError?.Message}");
     }
 }


### PR DESCRIPTION
## Summary

Fixes the LogCentralizer e2e suite (merged in #188 with a CI-skip workaround) that hung indefinitely on every host — CI Linux and local macOS alike.

## Root cause

```
Unhandled exception. System.UnauthorizedAccessException: Access to the path '/app/appsettings.json' is denied.
    at Microsoft.Extensions.Configuration.FileConfigurationProvider.<Load>g__OpenRead|6_0(IFileInfo fileInfo)
    at Program.<Main>$(String[] args) in /src/LogCentralizer/Program.cs:line 33
```

`COPY --from=build /app/publish ./` preserved root ownership from the build stage. Most local docker builds (classic builder, `docker compose`) ended up with files world-readable, but BuildKit (which Testcontainers .NET uses) produced files the in-image `app` user (UID 1654) could not read. The app crashed at startup before binding port 8080, `/health` never replied, and Testcontainers' `UntilHttpRequestIsSucceeded` silently retried until the 60-min container start-timeout fired.

## Three fixes (reviewable together)

| File | Change |
|---|---|
| `LogCentralizer/Dockerfile` | `COPY --from=build --chown=app:app /app/publish ./` — explicit ownership transfer to the runtime user. Robust across classic and BuildKit builders. |
| `tests/LogCentralizer.Tests/LogCentralizerE2ETests.cs` | Replace `WithWaitStrategy(...UntilHttpRequestIsSucceeded)` with a bounded `WaitForHealthAsync` poll. Testcontainers .NET issue [#1639](https://github.com/testcontainers/testcontainers-dotnet/issues/1639) makes the built-in strategy swallow the 100s `HttpClient` `TaskCanceledException`; a probe that never succeeds becomes a 1h hang instead of the 60s the wait strategy promises. |
| Same file | On health-probe timeout, capture the container's stdout/stderr via `_container.GetLogsAsync()`. That is how this `--chown` bug was finally diagnosed; without those logs the `SkippableFact` reason is useless. |
| Same file | Remove the `CI=true` skip guard. With the permission fix the e2e suite no longer hangs on Linux runners. |

## Test plan

- [x] `dotnet build EasySave.sln` — 10 projects, 0 errors
- [x] Local e2e: **2/2 pass in 4.6s** (3.1s image build + 1s test bodies)
- [x] Local in-process suite (6 tests) unchanged
- [ ] CI green on Linux (the real proof — was failing/hanging before this PR)

## Depends on

Nothing — this PR is independent of any open work. It applies as a single commit on top of staging.

## Closes

The CI-skip workaround introduced in #188 commit `07aba47`. Once this PR is green, e2e Testcontainers runs as a normal CI gate.