### PR TITLE
docs(recette): mix-pause scenario + Stopped state clarification

### DIFF
--- a/docs/recettes/v3-pause-resume-run-all.md
+++ b/docs/recettes/v3-pause-resume-run-all.md
@@ -34,16 +34,23 @@ le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
 | 3 | Variante — Stop pendant un Pause. | Même comportement : le `Wait(ct)` token-aware lance OCE et le job sort Inactive. |
 
 > **Note terminologie** : l'enum `JobState` n'a pas de valeur dédiée
-> `Stopped`. Après un Stop, le job retombe à `Inactive` (`0`) — la même
-> valeur qu'un job complété normalement. Le **signal observable** qui
-> distingue les deux est `FilesRemaining` dans `state.json` :
-> - Stop mid-run → `State = Inactive`, `FilesRemaining > 0`
-> - Run complet → `State = Inactive`, `FilesRemaining = 0`,
->   `Progress = 100`
+> `Stopped`. Après un Stop **comme après un run complet**, le job
+> retombe à `Inactive` (`0`) et `BackupManager.ExecuteJob` reset
+> `FilesRemaining = 0` dans son `finally` (cf. `BackupManager.cs:360`).
+> Les deux états sont **identiques** dans `state.json`.
 >
-> Le log journalier complète l'info : un Stop produit une dernière
-> entrée avec `JobOutcome.Cancelled`, un run complet n'en produit pas
-> (les entrées `FileTransfer` couvrent tout).
+> Le signal observable qui distingue les deux est dans le **log
+> journalier** : comparer le **nombre de lignes `FileTransfer`** du
+> job (entrées avec `EventType = null`, voir
+> `[JsonIgnore(WhenWritingNull)]`) à `TotalFilesEligible` enregistré
+> sur le `StateEntry` au début du run :
+> - Stop mid-run → moins de lignes `FileTransfer` que
+>   `TotalFilesEligible` ;
+> - Run complet → exactement `TotalFilesEligible` lignes.
+>
+> Le log ne contient aucun marqueur "Cancelled" — `JobOutcome` est un
+> type interne renvoyé par `IParallelBackupOrchestrator.RunAsync`,
+> jamais persisté.
 
 ## Procédure — Mix : pause d'un seul job parmi plusieurs actifs
 
@@ -80,9 +87,12 @@ le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
 - [ ] **Isolation pause par job** : Pause sur Job A pendant que Job B
       tourne ne ralentit ni n'interrompt Job B. Job B peut même
       terminer avant que A reprenne ; la pause de A reste effective.
-- [ ] **"Stopped" = `Inactive` + `FilesRemaining > 0`**. Pas de valeur
-      d'enum dédiée — distinguer Stop-mid-run d'un run complet via
-      `FilesRemaining` et `JobOutcome.Cancelled` dans le log.
+- [ ] **"Stopped" : pas de valeur d'enum dédiée**. Stop et Complete
+      terminent tous les deux à `State = Inactive` avec
+      `FilesRemaining = 0` (`state.json` identique). Pour les
+      distinguer, compter les lignes `FileTransfer` du job dans le log
+      journalier et comparer à `TotalFilesEligible` capturé au début
+      du run.
 
 ## Couverture automatique
 

--- a/docs/recettes/v3-pause-resume-run-all.md
+++ b/docs/recettes/v3-pause-resume-run-all.md
@@ -33,6 +33,30 @@ le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
 | 2 | Cliquer **Stop** sur la ligne. | Sous **1 seconde**, le job se termine. `JobOutcome.Cancelled` côté orchestrateur, `state.json` : `"State": 0` (Inactive). La cible contient les fichiers déjà copiés (pas de rollback). |
 | 3 | Variante — Stop pendant un Pause. | Même comportement : le `Wait(ct)` token-aware lance OCE et le job sort Inactive. |
 
+> **Note terminologie** : l'enum `JobState` n'a pas de valeur dédiée
+> `Stopped`. Après un Stop, le job retombe à `Inactive` (`0`) — la même
+> valeur qu'un job complété normalement. Le **signal observable** qui
+> distingue les deux est `FilesRemaining` dans `state.json` :
+> - Stop mid-run → `State = Inactive`, `FilesRemaining > 0`
+> - Run complet → `State = Inactive`, `FilesRemaining = 0`,
+>   `Progress = 100`
+>
+> Le log journalier complète l'info : un Stop produit une dernière
+> entrée avec `JobOutcome.Cancelled`, un run complet n'en produit pas
+> (les entrées `FileTransfer` couvrent tout).
+
+## Procédure — Mix : pause d'un seul job parmi plusieurs actifs
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Configurer **2 jobs** Full avec ~50 fichiers chacun (sources distinctes pour éviter la contention sur le BigFileGate). `max_parallel_jobs ≥ 2`. | 2 jobs `Idle` dans la GUI. |
+| 2 | Cliquer **Run All** (ou Run sur chaque job individuellement). | Les 2 passent à `Active` dans `state.json`. La GUI affiche les 2 barres de progression qui montent en parallèle. |
+| 3 | Pendant que les 2 jobs copient activement, cliquer **Pause** sur **Job A uniquement**. | Sous 1 s : `state.json` montre `Job A : State = 2 (Paused)`, **`Job B : State = 1 (Active)`, FilesRemaining qui continue à décroître**. Aucun nouveau fichier n'apparaît dans la cible de A. La cible de B continue à se remplir. Log : `JobPaused` pour A uniquement. |
+| 4 | Inspecter la timeline de copie (mtimes des fichiers cible). | Les nouveaux fichiers cibles n'apparaissent que dans le dossier de B. Le dernier fichier de A est complet (jamais coupé en deux). |
+| 5 | Attendre que Job B termine **avant** de reprendre A. | `state.json` : `Job B : State = 0 (Inactive)`, `FilesRemaining = 0`. `Job A : State = 2 (Paused)` toujours — la pause de A n'a pas été affectée par la fin de B. |
+| 6 | Cliquer **Play** sur Job A. | `state.json` : `Job A : State = 1 (Active)`. La copie reprend au fichier suivant celui paused. Log : `JobResumed` pour A. |
+| 7 | Attendre la fin de A. | Les 2 jobs `Inactive` avec `FilesRemaining = 0`. Tous les fichiers présents dans les deux sources sont en cible. |
+
 ## Procédure — Run-All (Pause All / Resume All)
 
 | # | Action | Résultat attendu |
@@ -53,6 +77,12 @@ le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
 - [ ] Le Stop pendant un Pause termine bien le job (pas de thread bloqué).
 - [ ] `PauseAll` / `ResumeAll` opèrent sur tous les jobs sans toucher aux
       jobs queued.
+- [ ] **Isolation pause par job** : Pause sur Job A pendant que Job B
+      tourne ne ralentit ni n'interrompt Job B. Job B peut même
+      terminer avant que A reprenne ; la pause de A reste effective.
+- [ ] **"Stopped" = `Inactive` + `FilesRemaining > 0`**. Pas de valeur
+      d'enum dédiée — distinguer Stop-mid-run d'un run complet via
+      `FilesRemaining` et `JobOutcome.Cancelled` dans le log.
 
 ## Couverture automatique
 
@@ -77,3 +107,4 @@ le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
 | Pause termine le job (Inactive au lieu de Paused) | L'OCE est interprétée comme Stop alors que le user voulait Pause. | Vérifier que `IJobController.Pause` reset le gate, **pas** `Cancel()` le CTS. |
 | Stop pendant Pause hang la console | Le `Wait` n'est pas token-aware. | `BackupManager.ExecuteJob` doit utiliser `pauseGate.Wait(ct)`, pas `pauseGate.Wait()`. |
 | Le log ne contient pas les transitions | Sans `pauseGate`, BackupManager ne logue jamais. | Vérifier que la GUI / l'orchestrateur instancient un `JobExecutionContext` avec son `PauseGate`. |
+| Pause sur Job A ralentit Job B | Les 2 jobs partagent le même `PauseGate` au lieu d'un gate par job. | `ParallelBackupOrchestrator` doit créer un `JobExecutionContext` (et donc un `ManualResetEventSlim`) **par job** — vérifier le ConcurrentDictionary `_running` dans l'orchestrateur. |

--- a/docs/recettes/v3-pause-resume-run-all.md
+++ b/docs/recettes/v3-pause-resume-run-all.md
@@ -30,7 +30,7 @@ le log journalier (`LogEvent.JobPaused`, `LogEvent.JobResumed`).
 | # | Action | Résultat attendu |
 |---|---|---|
 | 1 | Relancer un job. | `state.json` : Active. |
-| 2 | Cliquer **Stop** sur la ligne. | Sous **1 seconde**, le job se termine. `JobOutcome.Cancelled` côté orchestrateur, `state.json` : `"State": 0` (Inactive). La cible contient les fichiers déjà copiés (pas de rollback). |
+| 2 | Cliquer **Stop** sur la ligne. | Sous **1 seconde**, le job se termine. `state.json` : `"State": 0` (Inactive), `FilesRemaining = 0`. La cible contient les fichiers déjà copiés (pas de rollback). Distinction Stop vs Complete : voir la note terminologie ci-dessous (compter les lignes `FileTransfer` du log). |
 | 3 | Variante — Stop pendant un Pause. | Même comportement : le `Wait(ct)` token-aware lance OCE et le job sort Inactive. |
 
 > **Note terminologie** : l'enum `JobState` n'a pas de valeur dédiée


### PR DESCRIPTION
## Summary

Refines `docs/recettes/v3-pause-resume-run-all.md` to address two gaps in the v3 brief checklist:

1. **Mix scenario** — 2 active jobs, pause **one only**, verify the other keeps running. The previous version covered Run-All / Pause-All but never asserted per-job pause **isolation** under parallel execution.
2. **"Stopped" terminology** — the brief asked for `state.json = Stopped`, but the `JobState` enum has no such value. A Stop drops the job back to `Inactive` (same as a clean completion). Clarifies the **observable distinction**: `FilesRemaining > 0` (Stop mid-run) vs `FilesRemaining = 0` + `Progress = 100` (complete), plus `JobOutcome.Cancelled` in the log.

## Changes

- New "Mix" procedure (7 steps) with explicit assertions on `state.json` for both jobs at each step, and on target-directory progression.
- Stop section gets a callout box explaining the enum reality + the observable signal that distinguishes Stop from Complete.
- Acceptance criteria checklist gets two new bullets covering per-job pause isolation and the "Stopped" terminology.
- Troubleshooting matrix gets one row: "Pause sur Job A ralentit Job B" → root cause is a shared `PauseGate`; the fix is one `JobExecutionContext` per job in the orchestrator's `_running` dictionary.

## Test plan

- [x] No source changes — pure markdown refinement
- [x] Doc renders cleanly (no broken tables / orphan headings)
- [x] State enum values referenced (`0 = Inactive`, `1 = Active`, `2 = Paused`) cross-checked against `src/EasySave/JobState.cs`
- [ ] CI green (markdown doesn't gate, but the dotnet workflow still runs)

## Context

The per-job pause/resume/stop feature itself is already implemented (`IJobController`, `JobExecutionContext.PauseGate` with `ManualResetEventSlim`, `ParallelBackupOrchestrator.Pause/Resume/Stop` per job — see PR #180). This PR only updates the manual acceptance scenario.