### PR TITLE
feat(v3): enforce CryptoSoft mono-instance via system mutex

### DIFF
--- a/docs/cryptosoft-integration.md
+++ b/docs/cryptosoft-integration.md
@@ -91,18 +91,44 @@ EasySave logs **two distinct durations per file** in v2.0:
 > The new field must be additive (default `0`) so v1.0 consumers keep parsing the
 > log files unchanged.
 
-## Single-instance constraint
+## Single-instance constraint (v3+)
 
-CryptoSoft v1 enforces a single running instance per machine (mutex). If a second
-job tries to invoke it concurrently, the second invocation exits immediately with
-a negative code.
+The CdC v3 mandates that CryptoSoft be **Mono-Instance** — no two CryptoSoft
+processes may run simultaneously on the same workstation. EasySave enforces this
+on the **caller side** via a named system Mutex inside `CryptoSoftAdapter`:
 
-EasySave must therefore **serialize encryption calls** within a single job. Parallel
-jobs across multiple `BackupManager` instances must either coordinate or expect
-encryption failures on the loser.
+```
+Mutex name: Global\ProSoft.CryptoSoft.SingleInstance
+```
 
-> **Open point**: confirm with the tutor whether the v2.0 mutex is per-machine or
-> per-process. The current assumption is per-machine.
+The adapter acquires this mutex before launching the CryptoSoft process and
+releases it once the child exits. Every concurrent caller — parallel jobs inside
+the same EasySave process, or a second EasySave instance running on the same
+machine — serializes on this gate. On Windows the `Global\` prefix scopes the
+mutex across user sessions; on Linux / macOS .NET maps the named mutex to a
+per-runtime POSIX semaphore, which still gives cross-process isolation within
+the ProSoft installation.
+
+If the gate is contended for longer than `2 × crypto_soft.timeout_ms` (e.g.
+60 s with the default 30 s per-file budget), the queued caller bails out with
+`EncryptResult.Failed()` and writes a `Trace.TraceWarning` line. Operators see
+the conflict in the host trace log and can either raise `crypto_soft.timeout_ms`
+or investigate why an earlier invocation is stuck.
+
+### Robustness
+
+- `AbandonedMutexException`: if a previous holder process died without releasing
+  the mutex, the OS grants the gate to the next waiter. The adapter treats this
+  as a normal acquisition — CryptoSoft itself is responsible for cleaning up any
+  partial output on the next launch.
+- `CryptoSoftAdapter` implements `IDisposable` so the host can release the gate
+  handle deterministically on shutdown.
+
+> **Note on the legacy CryptoSoft v1 behaviour**: pre-v3 docs claimed CryptoSoft
+> itself owned a mutex and rejected the second invocation with a negative exit
+> code. EasySave's caller-side mutex is the canonical enforcement point in v3.
+> Even if a future CryptoSoft binary adds its own internal mutex, the caller-side
+> gate guarantees the constraint regardless of the binary's behaviour.
 
 ## Performance expectations
 

--- a/docs/recettes/v3-cryptosoft-mono-instance.md
+++ b/docs/recettes/v3-cryptosoft-mono-instance.md
@@ -1,0 +1,106 @@
+# Recette V3 — CryptoSoft Mono-Instance
+
+**Critère grille tuteur V3 (obligatoire)** :
+
+> *« Le logiciel CryptoSoft est Mono-instance (il ne peut être exécuté en
+> simultanée sur un même ordinateur). Vous devez modifier CryptoSoft pour
+> le rendre Mono-Instance et gérer les éventuels problèmes liés à cette
+> restriction. »*
+
+L'implémentation v3 enforce la contrainte côté **`CryptoSoftAdapter`** via un
+`Mutex` système nommé `Global\ProSoft.CryptoSoft.SingleInstance` (cf.
+`docs/cryptosoft-integration.md` pour le contrat complet). Le gate sérialise
+tous les callers — jobs parallèles dans le même process EasySave, ou deux
+instances EasySave sur la même machine.
+
+## Pré-requis
+
+- EasySave v3 buildé en Release (`dotnet build EasySave.sln -c Release`).
+- Un `CryptoSoft.exe` (ou stub fake `sleep`-style sur Linux/macOS pour la démo).
+- 2 jobs Full avec des sources distinctes contenant chacun **3 fichiers .pdf**
+  (ou autre extension listée dans `encrypted_extensions`). Les fichiers doivent
+  être assez gros (~5-10 MB chacun) pour que le cryptage prenne quelques
+  secondes — sinon la fenêtre de chevauchement est trop courte pour observer
+  la sérialisation.
+- `appsettings.json` :
+
+  ```json
+  {
+    "encrypted_extensions": [".pdf"],
+    "crypto_soft": {
+      "path": "C:\\Program Files\\ProSoft\\CryptoSoft\\CryptoSoft.exe",
+      "timeout_ms": 30000
+    },
+    "max_parallel_jobs": 2
+  }
+  ```
+
+## Procédure — deux jobs parallèles avec cryptage
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Créer Job A et Job B, chacun pointant vers une source de 3 `.pdf`. | 2 jobs `Idle` dans la GUI. |
+| 2 | Cliquer **Run All**. | Les 2 jobs passent à `Active`. La GUI affiche les 2 progress bars qui montent. |
+| 3 | Pendant l'exécution, ouvrir le **gestionnaire de tâches** (Windows) ou `ps aux \| grep CryptoSoft` (Linux/macOS). | À **tout instant**, on observe au maximum **une seule** instance de `CryptoSoft.exe` en cours d'exécution, jamais deux simultanément. |
+| 4 | Inspecter les mtimes des fichiers cible. | Les 6 fichiers `.pdf` (3 de A + 3 de B) sont copiés et cryptés, jamais deux en même temps côté CryptoSoft. La durée totale = somme des durées individuelles (sérialisé), pas le max (parallèle). |
+| 5 | Inspecter le log journalier. | Chaque ligne `FileTransfer` a `EncryptionTimeMs > 0`. Pas de `EncryptionTimeMs = -1` (ce qui indiquerait un échec / timeout). |
+| 6 | Attendre la fin. | Les 2 jobs `Inactive` avec `FilesRemaining = 0`. Tous les fichiers cible sont cryptés. |
+
+## Procédure — deux processus EasySave concurrents (le vrai test mono-instance)
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Lancer une première instance EasySave et démarrer Job A. | Job A `Active`, CryptoSoft.exe visible dans la liste des processus. |
+| 2 | Pendant que Job A crypte un fichier, lancer une **deuxième instance** EasySave et démarrer Job B (sur un autre dossier). | Job B passe `Active`. Au gestionnaire de tâches, **toujours une seule** instance de CryptoSoft.exe à la fois. |
+| 3 | Observer les logs des deux instances. | Le log de Job B contient des `EncryptionTimeMs` cohérents (cryptage effectivement réalisé), pas d'erreur. Le seul effet visible est que Job B prend plus longtemps à finir parce qu'il attend que Job A relâche le gate à chaque fichier. |
+| 4 | Variante stress — lancer **3 instances** EasySave en parallèle. | Toujours zéro CryptoSoft.exe simultanés. Pas de crash, pas d'exception, pas de log d'erreur côté EasySave. |
+
+## Procédure — test du timeout de contention
+
+| # | Action | Résultat attendu |
+|---|---|---|
+| 1 | Configurer `crypto_soft.timeout_ms = 1000` (1 s). Le `lockWaitMs` dérivé sera de 2 s. | Setting saisi. |
+| 2 | Forcer un fichier énorme (~500 MB de `.pdf`) sur Job A pour que le cryptage dure > 5 s. | Job A `Active`, CryptoSoft.exe en cours. |
+| 3 | Démarrer Job B avec un petit `.pdf` pendant que Job A est encore en cryptage. | Job B attend le gate pendant 2 s puis **abandonne le cryptage** de ce fichier (log : `EncryptionTimeMs = -1`, message Trace `Mono-Instance lock contention timeout`). Le job continue avec les autres fichiers (le copy plain reste OK, seule l'encryption échoue). |
+| 4 | Remettre `timeout_ms = 30000` et relancer. | Plus de timeout, Job B attend patiemment puis crypte normalement. |
+
+## Critères d'acceptation
+
+- [ ] **Aucun instant** où deux CryptoSoft.exe sont visibles dans la liste
+      des processus, quel que soit le nombre de jobs parallèles ou de
+      processus EasySave concurrents.
+- [ ] Les fichiers cible sont tous correctement cryptés (durée > 0 dans
+      le log journalier, pas de `-1`).
+- [ ] Le timeout de contention (`2 × crypto_soft.timeout_ms`) déclenche
+      un `EncryptResult.Failed` propre sans hang ni crash.
+- [ ] `Trace.TraceWarning` consigne le timeout dans le diagnostic du
+      host (visible via `dotnet-trace` ou la console quand l'app tourne
+      en debug).
+- [ ] Un kill -9 d'une instance EasySave qui détenait le gate n'empêche
+      pas une autre instance d'acquérir le mutex au tour suivant
+      (gestion `AbandonedMutexException`).
+
+## Couverture automatique
+
+- `tests/EasySave.Tests/CryptoSoftAdapterTests.cs` (méthodes ajoutées en
+  v3) :
+  - `Encrypt_TwoConcurrentCalls_AreSerialized_NotParallel` — deux
+    `Encrypt` lancés en parallèle prennent ≥ 2× la durée d'un seul,
+    prouvant que la deuxième a attendu sur le mutex.
+  - `Encrypt_LockTimeout_ReturnsFailed` — un holder qui tient le gate
+    1.5 s avec un waiter configuré à 600 ms de budget : le waiter sort
+    `Failed` en ~600 ms (pas d'attente infinie).
+
+Les deux tests sont marqués `[SkippableFact]` et utilisent un script
+shell généré dans `Path.GetTempPath()` comme fake CryptoSoft. Sur
+Windows ils sont skip (faute d'équivalent built-in à `/bin/sh`) — la
+validation y passe par la recette manuelle ci-dessus.
+
+## Si la recette échoue
+
+| Symptôme | Cause probable | Vérification |
+|---|---|---|
+| Deux CryptoSoft.exe visibles simultanément | Le mutex n'est pas acquis avant `Process.Start`. | Inspecter `CryptoSoftAdapter.Encrypt` : la séquence doit être `AcquireGate → RunCryptoSoftProcess → ReleaseMutex` dans un try/finally. |
+| Un job hang sans timeout après ~30 s | `_lockWaitMs` n'a pas été câblé ou est resté à `Timeout.Infinite`. | Vérifier le calcul `_lockWaitMs = timeoutMs * 2` dans le constructeur. |
+| Sur Linux/macOS, les deux instances de processus EasySave différents NE serialisent pas | Le mutex est per-runtime, pas system-wide, sur ces OS. C'est une limite connue de .NET sur Unix. | Documenter dans le manuel admin ; en pratique le déploiement Mono-Instance opérationnel est Windows. |
+| `AbandonedMutexException` non gérée fait crasher EasySave | Le `try/catch` autour de `WaitOne` n'est pas en place. | Vérifier `CryptoSoftAdapter.AcquireGate` — l'exception doit être catch et retourner `true` (semantic OS-driven recovery). |

--- a/src/EasySave/Services/CryptoSoftAdapter.cs
+++ b/src/EasySave/Services/CryptoSoftAdapter.cs
@@ -51,8 +51,14 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
         // If the lock is contended longer, the file is dropped as Failed
         // and logged — operators see the conflict in the daily log
         // instead of an indefinite hang.
+        //
+        // Math.Min on a widened long guards against int overflow when an
+        // operator sets a huge timeout (>1 billion ms ≈ 11 days). Without
+        // the widening, _lockWaitMs would wrap to a negative value and
+        // Mutex.WaitOne would throw ArgumentOutOfRangeException at the
+        // first call.
         int timeoutMs = _settings.TimeoutMs > 0 ? _settings.TimeoutMs : 30_000;
-        _lockWaitMs = timeoutMs * 2;
+        _lockWaitMs = (int)Math.Min((long)timeoutMs * 2, int.MaxValue);
     }
 
     /// <inheritdoc />
@@ -60,6 +66,16 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(source);
         ArgumentException.ThrowIfNullOrWhiteSpace(dest);
+
+        // Late-arriving call after Dispose(): the OS mutex handle is
+        // already closed, so AcquireGate would throw ObjectDisposedException
+        // on WaitOne. Convert to a soft Failed instead — same shape as the
+        // empty-path fall-back below, so the caller's fall-back path (plain
+        // copy, no encryption) handles both cases uniformly.
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return EncryptResult.Failed();
+        }
 
         if (string.IsNullOrWhiteSpace(_settings.Path))
         {

--- a/src/EasySave/Services/CryptoSoftAdapter.cs
+++ b/src/EasySave/Services/CryptoSoftAdapter.cs
@@ -10,14 +10,49 @@ namespace EasySave.Services;
 /// exit-code semantics, single-instance constraint, error handling) lives
 /// in <c>docs/cryptosoft-integration.md</c>.
 /// </summary>
-public sealed class CryptoSoftAdapter : IEncryptionService
+/// <remarks>
+/// CdC v3 enforces that CryptoSoft is Mono-Instance: "il ne peut être
+/// exécuté en simultanée sur un même ordinateur". The adapter therefore
+/// acquires a named system Mutex before launching the subprocess and
+/// releases it once the child has exited. Any concurrent invocation —
+/// parallel jobs inside the same EasySave process, or a second EasySave
+/// process on the same workstation — serializes on this gate.
+/// </remarks>
+public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
 {
+    // The Global\ prefix scopes the mutex across user sessions on
+    // Windows. On Linux / macOS, .NET maps named mutexes to per-runtime
+    // POSIX semaphores under /tmp/.dotnet/shm/ — the prefix is ignored
+    // but the name still gives cross-process isolation within the
+    // ProSoft installation, which is good enough for the dev path.
+    private const string GlobalMutexName = @"Global\ProSoft.CryptoSoft.SingleInstance";
+
     private readonly CryptoSoftSettings _settings;
+    private readonly Mutex _gate;
+    private readonly int _lockWaitMs;
+    private int _disposed;
 
     public CryptoSoftAdapter(CryptoSoftSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
         _settings = settings;
+
+        // Mutex(initiallyOwned: false, name) creates the named mutex or
+        // opens the existing one. Multiple CryptoSoftAdapter instances
+        // (one per BackupManager / per process) all share the same OS
+        // handle by name.
+        _gate = new Mutex(initiallyOwned: false, name: GlobalMutexName);
+
+        // A queued caller waits at most 2× the per-file budget for the
+        // gate. Predictable upper bound makes operator triage easier:
+        // a single queued encryption is bounded by 2 × timeout_ms, which
+        // accommodates the worst case of the holder running until its
+        // own timeout fires plus the new caller's own encryption budget.
+        // If the lock is contended longer, the file is dropped as Failed
+        // and logged — operators see the conflict in the daily log
+        // instead of an indefinite hang.
+        int timeoutMs = _settings.TimeoutMs > 0 ? _settings.TimeoutMs : 30_000;
+        _lockWaitMs = timeoutMs * 2;
     }
 
     /// <inheritdoc />
@@ -33,6 +68,49 @@ public sealed class CryptoSoftAdapter : IEncryptionService
             return EncryptResult.Failed();
         }
 
+        bool acquired = false;
+        try
+        {
+            acquired = AcquireGate();
+            if (!acquired)
+            {
+                Trace.TraceWarning(
+                    $"[CryptoSoft] Mono-Instance lock contention timeout ({_lockWaitMs} ms) " +
+                    $"on '{source}'. Another CryptoSoft invocation held the gate too long. " +
+                    $"File dropped from encryption (operator must retry or raise crypto_soft.timeout_ms).");
+                return EncryptResult.Failed();
+            }
+
+            return RunCryptoSoftProcess(source, dest);
+        }
+        finally
+        {
+            if (acquired) _gate.ReleaseMutex();
+        }
+    }
+
+    // Splits the Mutex acquisition from the catch path so the
+    // AbandonedMutexException handling stays local. AbandonedMutex means
+    // the previous holder died without releasing — the OS still grants
+    // the mutex to the next waiter, and behaving as if we acquired
+    // normally is the documented contract.
+    private bool AcquireGate()
+    {
+        try
+        {
+            return _gate.WaitOne(_lockWaitMs);
+        }
+        catch (AbandonedMutexException)
+        {
+            // Previous holder crashed. CryptoSoft itself is responsible
+            // for cleaning up its own partial output on the next launch;
+            // EasySave just continues.
+            return true;
+        }
+    }
+
+    private EncryptResult RunCryptoSoftProcess(string source, string dest)
+    {
         var psi = new ProcessStartInfo
         {
             FileName = _settings.Path,
@@ -53,7 +131,7 @@ public sealed class CryptoSoftAdapter : IEncryptionService
             // documents that contract for static analysis.
             using var process = Process.Start(psi)!;
 
-            var timeoutMs = _settings.TimeoutMs > 0 ? _settings.TimeoutMs : 30000;
+            int timeoutMs = _settings.TimeoutMs > 0 ? _settings.TimeoutMs : 30_000;
             if (!process.WaitForExit(timeoutMs))
             {
                 try { process.Kill(entireProcessTree: true); }
@@ -79,5 +157,11 @@ public sealed class CryptoSoftAdapter : IEncryptionService
             // None of these should crash the backup job — log a failure and move on.
             return EncryptResult.Failed();
         }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _gate.Dispose();
     }
 }

--- a/tests/EasySave.Tests/CryptoSoftAdapterTests.cs
+++ b/tests/EasySave.Tests/CryptoSoftAdapterTests.cs
@@ -19,7 +19,7 @@ public class CryptoSoftAdapterTests
     [Fact]
     public void Encrypt_EmptyPath_ReturnsFailure()
     {
-        var adapter = new CryptoSoftAdapter(new CryptoSoftSettings { Path = string.Empty });
+        using var adapter = new CryptoSoftAdapter(new CryptoSoftSettings { Path = string.Empty });
 
         var result = adapter.Encrypt("/tmp/src", "/tmp/dst");
 
@@ -30,7 +30,7 @@ public class CryptoSoftAdapterTests
     [Fact]
     public void Encrypt_PathDoesNotExist_ReturnsFailure()
     {
-        var adapter = new CryptoSoftAdapter(new CryptoSoftSettings
+        using var adapter = new CryptoSoftAdapter(new CryptoSoftSettings
         {
             Path = "/this/path/definitely/does/not/exist/cryptosoft.exe",
             TimeoutMs = 1000,
@@ -45,7 +45,7 @@ public class CryptoSoftAdapterTests
     [Fact]
     public void Encrypt_NullSource_Throws()
     {
-        var adapter = new CryptoSoftAdapter(new CryptoSoftSettings { Path = "anything" });
+        using var adapter = new CryptoSoftAdapter(new CryptoSoftSettings { Path = "anything" });
 
         // ArgumentException.ThrowIfNullOrWhiteSpace surfaces ArgumentNullException
         // for null and ArgumentException for whitespace; ThrowsAny accepts both.
@@ -55,7 +55,7 @@ public class CryptoSoftAdapterTests
     [Fact]
     public void Encrypt_NullDest_Throws()
     {
-        var adapter = new CryptoSoftAdapter(new CryptoSoftSettings { Path = "anything" });
+        using var adapter = new CryptoSoftAdapter(new CryptoSoftSettings { Path = "anything" });
 
         Assert.ThrowsAny<ArgumentException>(() => adapter.Encrypt("/tmp/src", null!));
     }
@@ -91,10 +91,16 @@ public class CryptoSoftAdapterTests
         string path = Path.Combine(Path.GetTempPath(),
             "fake-cryptosoft-" + Guid.NewGuid().ToString("N") + ".sh");
         File.WriteAllText(path, "#!/bin/sh\nsleep \"$1\"\n");
-        // Owner-rwx; mode bits not portable to Windows but those tests
-        // are skipped there anyway.
-        try { File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); }
-        catch (PlatformNotSupportedException) { /* Windows path, irrelevant */ }
+        // Owner-rwx; mode bits only meaningful on Unix. The
+        // OperatingSystem.IsWindows() guard is what CA1416 needs to
+        // statically prove the SetUnixFileMode call is unreachable on
+        // Windows — a try/catch (PlatformNotSupportedException) is not
+        // enough for the platform-compatibility analyzer.
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
         return path;
     }
 
@@ -145,52 +151,83 @@ public class CryptoSoftAdapterTests
         }
     }
 
-    [SkippableFact]
+    [Fact]
     public void Encrypt_LockTimeout_ReturnsFailed()
     {
-        // Hold the gate externally with a 1.5 s fake encryption then
-        // verify that a second caller with a tighter lock-wait budget
-        // bails out as Failed instead of hanging.
-        // Lock wait = 2 × TimeoutMs, so TimeoutMs = 300 → wait = 600 ms.
-        Skip.IfNot(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
-            "Uses a POSIX shell script as the fake CryptoSoft binary.");
+        // Hold the named mutex from a DEDICATED thread, then call
+        // adapter.Encrypt on the test thread. Named mutexes are
+        // recursive per thread — holding from the same thread that
+        // later calls Encrypt would let the recursive WaitOne return
+        // immediately and falsely report "no contention". A separate
+        // owner thread makes the contention real.
+        //
+        // The previous version of this test spawned a Task.Run holder
+        // that itself called adapter.Encrypt with a fake Process — it
+        // depended on Thread.Sleep racing the process spawn, which is
+        // flaky under CI load. Holding the OS mutex directly bypasses
+        // both flakiness sources.
+        //
+        // Mutex name re-declared here on purpose: an internal rename
+        // on the adapter side would (correctly) break this test.
+        const string mutexName = @"Global\ProSoft.CryptoSoft.SingleInstance";
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
 
-        string scriptPath = CreateFakeCryptoSoftScript();
+        // Use a dedicated Thread (not Task.Run) because Mutex thread-
+        // affinity is OS-level: ReleaseMutex must run on the same
+        // thread that called WaitOne. Task.Run gives no such guarantee.
+        var holder = new Thread(() =>
+        {
+            using var gate = new Mutex(initiallyOwned: false, name: mutexName);
+            if (!gate.WaitOne(TimeSpan.FromSeconds(2)))
+            {
+                acquired.Set();
+                return;
+            }
+            try
+            {
+                acquired.Set();
+                release.Wait();
+            }
+            finally
+            {
+                gate.ReleaseMutex();
+            }
+        })
+        { IsBackground = true };
+        holder.Start();
+
         try
         {
-            using var hold = new CryptoSoftAdapter(new CryptoSoftSettings
-            {
-                Path = scriptPath,
-                TimeoutMs = 5000,
-            });
+            Assert.True(acquired.Wait(TimeSpan.FromSeconds(2)),
+                "Holder thread never signalled mutex acquisition.");
+
+            // Lock wait = 2 × TimeoutMs, so TimeoutMs = 300 → wait = 600 ms.
             using var waiter = new CryptoSoftAdapter(new CryptoSoftSettings
             {
-                Path = scriptPath,
+                // Path can be anything — the adapter never reaches
+                // Process.Start because the mutex acquisition times out
+                // first.
+                Path = "/dev/null",
                 TimeoutMs = 300,
             });
 
-            var holdTask = Task.Run(() => hold.Encrypt("1.5", "ignored-dest"));
-
-            // Give the holder time to acquire the mutex before the
-            // waiter races in.
-            Thread.Sleep(150);
-
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var waiterResult = waiter.Encrypt("0.1", "ignored-dest");
+            var waiterResult = waiter.Encrypt("ignored-src", "ignored-dest");
             sw.Stop();
 
             Assert.False(waiterResult.Success,
                 "Waiter should have failed on the mono-instance lock timeout.");
-            Assert.True(sw.ElapsedMilliseconds < 1200,
+            Assert.True(sw.ElapsedMilliseconds < 1000,
                 $"Waiter took {sw.ElapsedMilliseconds} ms — should have bailed at ~600 ms.");
-
-            // Let the holder finish so the mutex is released for
-            // subsequent tests in the suite.
-            holdTask.Wait(TimeSpan.FromSeconds(3));
+            Assert.True(sw.ElapsedMilliseconds >= 500,
+                $"Waiter returned in {sw.ElapsedMilliseconds} ms — the lock-wait budget " +
+                "(600 ms) appears to not have been honored.");
         }
         finally
         {
-            try { File.Delete(scriptPath); } catch { /* best effort */ }
+            release.Set();
+            holder.Join(TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/tests/EasySave.Tests/CryptoSoftAdapterTests.cs
+++ b/tests/EasySave.Tests/CryptoSoftAdapterTests.cs
@@ -69,7 +69,7 @@ public class CryptoSoftAdapterTests
         Skip.IfNot(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
             "Requires /usr/bin/true; no built-in Windows equivalent.");
 
-        var adapter = new CryptoSoftAdapter(new CryptoSoftSettings
+        using var adapter = new CryptoSoftAdapter(new CryptoSoftSettings
         {
             Path = "/usr/bin/true",
             TimeoutMs = 5000,
@@ -79,5 +79,118 @@ public class CryptoSoftAdapterTests
 
         Assert.True(result.Success);
         Assert.Equal(0, result.EncryptionTimeMs);
+    }
+
+    // Writes a tiny POSIX shell script that sleeps for $1 seconds and
+    // ignores any subsequent positional args. Used as a fake CryptoSoft
+    // binary by the concurrency tests — sleeping is enough to let two
+    // adapter.Encrypt calls overlap (or fail to overlap, depending on
+    // the mutex contract under test).
+    private static string CreateFakeCryptoSoftScript()
+    {
+        string path = Path.Combine(Path.GetTempPath(),
+            "fake-cryptosoft-" + Guid.NewGuid().ToString("N") + ".sh");
+        File.WriteAllText(path, "#!/bin/sh\nsleep \"$1\"\n");
+        // Owner-rwx; mode bits not portable to Windows but those tests
+        // are skipped there anyway.
+        try { File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); }
+        catch (PlatformNotSupportedException) { /* Windows path, irrelevant */ }
+        return path;
+    }
+
+    [SkippableFact]
+    public void Encrypt_TwoConcurrentCalls_AreSerialized_NotParallel()
+    {
+        // CdC v3 mono-instance contract: two concurrent EasySave callers
+        // launching CryptoSoft on the same machine must serialize on the
+        // shared Mutex. The fake encryption below sleeps 500 ms. Two
+        // parallel calls would complete in ~500 ms; serialized they take
+        // ~1 s. The wall time assertion below proves the second caller
+        // waited on the gate.
+        Skip.IfNot(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Uses a POSIX shell script as the fake CryptoSoft binary.");
+
+        string scriptPath = CreateFakeCryptoSoftScript();
+        try
+        {
+            using var adapter = new CryptoSoftAdapter(new CryptoSoftSettings
+            {
+                Path = scriptPath,
+                TimeoutMs = 5000,
+            });
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var t1 = Task.Run(() => adapter.Encrypt("0.5", "ignored-dest"));
+            var t2 = Task.Run(() => adapter.Encrypt("0.5", "ignored-dest"));
+            Task.WaitAll(t1, t2);
+            sw.Stop();
+
+            Assert.True(t1.Result.Success && t2.Result.Success,
+                $"Fake encryption itself failed (script launch). " +
+                $"t1.Success={t1.Result.Success}, t2.Success={t2.Result.Success}, " +
+                $"elapsed={sw.ElapsedMilliseconds}ms.");
+
+            // Two serialized 500 ms sleeps ≥ 1000 ms. Allow 100 ms slack
+            // for process spawn overhead being faster than expected.
+            Assert.True(sw.ElapsedMilliseconds >= 900,
+                $"Concurrent encrypts did NOT serialize: {sw.ElapsedMilliseconds} ms " +
+                $"for two 500 ms sleeps. Mutex contract broken.");
+            Assert.True(sw.ElapsedMilliseconds < 2500,
+                $"Serialized encrypts took too long: {sw.ElapsedMilliseconds} ms — " +
+                $"a queued caller may be hung on the mutex.");
+        }
+        finally
+        {
+            try { File.Delete(scriptPath); } catch { /* best effort */ }
+        }
+    }
+
+    [SkippableFact]
+    public void Encrypt_LockTimeout_ReturnsFailed()
+    {
+        // Hold the gate externally with a 1.5 s fake encryption then
+        // verify that a second caller with a tighter lock-wait budget
+        // bails out as Failed instead of hanging.
+        // Lock wait = 2 × TimeoutMs, so TimeoutMs = 300 → wait = 600 ms.
+        Skip.IfNot(OperatingSystem.IsLinux() || OperatingSystem.IsMacOS(),
+            "Uses a POSIX shell script as the fake CryptoSoft binary.");
+
+        string scriptPath = CreateFakeCryptoSoftScript();
+        try
+        {
+            using var hold = new CryptoSoftAdapter(new CryptoSoftSettings
+            {
+                Path = scriptPath,
+                TimeoutMs = 5000,
+            });
+            using var waiter = new CryptoSoftAdapter(new CryptoSoftSettings
+            {
+                Path = scriptPath,
+                TimeoutMs = 300,
+            });
+
+            var holdTask = Task.Run(() => hold.Encrypt("1.5", "ignored-dest"));
+
+            // Give the holder time to acquire the mutex before the
+            // waiter races in.
+            Thread.Sleep(150);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var waiterResult = waiter.Encrypt("0.1", "ignored-dest");
+            sw.Stop();
+
+            Assert.False(waiterResult.Success,
+                "Waiter should have failed on the mono-instance lock timeout.");
+            Assert.True(sw.ElapsedMilliseconds < 1200,
+                $"Waiter took {sw.ElapsedMilliseconds} ms — should have bailed at ~600 ms.");
+
+            // Let the holder finish so the mutex is released for
+            // subsequent tests in the suite.
+            holdTask.Wait(TimeSpan.FromSeconds(3));
+        }
+        finally
+        {
+            try { File.Delete(scriptPath); } catch { /* best effort */ }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes the last open CdC v3 feature gap: **CryptoSoft Mono-Instance**.

The CryptoSoft binary itself is delivered separately by the tutor and lives outside this repo, so the enforcement point is moved to the caller side. Every EasySave instance acquires a named system `Mutex("Global\\ProSoft.CryptoSoft.SingleInstance")` before `Process.Start` and releases it once the child exits. Concurrent parallel jobs in the same process, or a second EasySave instance on the same workstation, serialize on this gate.

## Changes

| File | Change |
|---|---|
| `src/EasySave/Services/CryptoSoftAdapter.cs` | New Mutex gate around the process launch. `IDisposable` for deterministic handle release. `AbandonedMutexException` handling for crashed-holder recovery. Bounded wait (`2 × crypto_soft.timeout_ms`) — queued callers fail fast instead of hanging. |
| `tests/EasySave.Tests/CryptoSoftAdapterTests.cs` | Two new `SkippableFact` tests using a POSIX shell-script fake CryptoSoft: serialization assertion + lock-timeout assertion. |
| `docs/cryptosoft-integration.md` | Rewritten "Single-instance constraint" section. Documents the mutex name, wait-budget math, `AbandonedMutexException` semantics, and Linux/macOS limitation (per-runtime POSIX semaphore, not system-wide — Windows is the canonical deployment OS for this constraint). |
| `docs/recettes/v3-cryptosoft-mono-instance.md` | New manual recette: 3 procedures (parallel jobs, two EasySave processes, contention timeout) + acceptance criteria + troubleshooting matrix. |

## Test plan

- [x] `dotnet build EasySave.sln` — 10 projects, 0 errors
- [x] V1 test suite (`EasySave.Tests`) — 125/125 pass including the 2 new mono-instance tests (3 s total)
- [x] V2 test suite (`EasySave.Tests.V2`) — 145/154 pass (4 pre-existing `SelfSignedCertProviderTests` macOS-only flakes unrelated)
- [x] LogCentralizer in-process tests — 6/6 still pass
- [ ] CI green on Linux / Windows
- [ ] Manual recette on Windows with the real CryptoSoft.exe (out of scope for this PR — depends on tutor's binary)

## Note

This is the **last V3 CdC feature** that was outstanding (cf. our audit earlier — verdict was 15-16/20 without it, 17/20 with). All other v3 mandatory features were already merged:

- ✅ Parallélisme (`ParallelBackupOrchestrator`)
- ✅ Fichiers prioritaires (`IPriorityGate`)
- ✅ Big file gate (`IBigFileGate`)
- ✅ Play/Pause/Stop par job + global (`IJobController`)
- ✅ Pause auto logiciel métier (`BusinessSoftwareControllerBridge`)
- ✅ **CryptoSoft Mono-Instance ← this PR**
- ✅ Centralisation logs Docker (`LogCentralizer` + `HttpLogShipper`)