### PR TITLE
refactor(v3): dedup logger normalize + share LogFilePoller + trim comments

### DIFF
--- a/LogCentralizer/Program.cs
+++ b/LogCentralizer/Program.cs
@@ -3,67 +3,37 @@ using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using EasyLog;
 
-// EasySave v3 centralized log collector.
-//
-// Design goals (CdC requirement: "un seul et unique fichier journalier quel
-// que soit le nombre d'utilisateurs"):
-//
-//  - POST /logs accepts a single LogEntry JSON document, enqueues it on an
-//    in-memory Channel and returns 204 immediately. The HTTP path never
-//    touches disk — slow filesystems on a noisy host cannot back-pressure
-//    the EasySave clients into stalling their backup jobs.
-//
-//  - A single background writer task drains the Channel and appends each
-//    entry as one JSON line to the day's file (yyyy-MM-dd.jsonl). With
-//    SingleReader=true there is exactly one thread writing to disk, so
-//    concurrent clients never race on the file handle and no entry is
-//    interleaved or corrupted.
-//
-//  - Append-only JSON Lines is the on-disk format: every flush is a single
-//    O(n) write of the new bytes (vs. O(file_size) for a JSON array we
-//    would have to re-serialize on every append). Tail-readers can stream
-//    the file line-by-line.
-//
-//  - Horizontal scale is intentionally not supported in v1: a single
-//    "fichier journalier unique" maps to a single writer process. Run one
-//    replica behind a TCP load balancer if you need redundancy at the LB
-//    layer — but DO NOT scale up the collector replicas (concurrent appends
-//    from two processes would interleave at the byte level).
+// EasySave v3 centralized log collector. CdC: "un seul et unique fichier
+// journalier quel que soit le nombre d'utilisateurs". Full design doc:
+// docs/v3-log-centralizer-admin.md. Recap:
+//   - POST /logs enqueues on a Channel, returns 204; HTTP path never
+//     touches disk so a slow filesystem cannot back-pressure clients.
+//   - One BackgroundService writer appends to {dir}/yyyy-MM-dd.jsonl.
+//   - Single replica only — concurrent appends from N processes corrupt.
 
 var builder = WebApplication.CreateBuilder(args);
 
-// .NET 6+ default is BackgroundServiceExceptionBehavior.StopHost — an
-// unhandled exception in DailyFileWriter.ExecuteAsync would tear the whole
-// host down, including /health. On a misconfigured Linux deployment the
-// bind-mounted /var/log/easysave can be owned by a UID the container's
-// `app` user cannot write to, which would otherwise silently kill the
-// service. Keep /health responsive — paired with the writer completing
-// the channel on fault (see DailyFileWriter.ExecuteAsync), subsequent
-// POST /logs trips ChannelClosedException and returns 503 instead of
-// accepting entries we cannot persist. So operators get TWO observable
-// signals when the writer dies: /health-200 + POST-503.
+// Keep /health responsive when the writer faults. Paired with
+// _queue.Writer.TryComplete(ex) in DailyFileWriter, subsequent POSTs
+// trip ChannelClosedException → 503. Operators get two observable
+// signals: /health=200 + POST=503.
 builder.Services.Configure<HostOptions>(opts =>
     opts.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
 
-// JSON serializer for entries that LAND on disk. WhenWritingNull keeps the
-// daily file byte-for-byte compatible with EasyLog's local format: a row
-// without MachineName/UserName looks exactly like a v1.x row.
+// WhenWritingNull keeps daily files byte-for-byte compatible with
+// EasyLog's local format (a row without MachineName/UserName looks like
+// a v1.x row). PropertyNameCaseInsensitive accepts both PascalCase
+// (default S.T.J) and camelCase (HttpClient.PostAsJsonAsync default).
 var serializerOptions = new JsonSerializerOptions
 {
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     Converters = { new JsonStringEnumConverter() },
-    // Accept either PascalCase (EasyLog's local daily files, default
-    // System.Text.Json) or camelCase (HttpClient.PostAsJsonAsync defaults
-    // since .NET 7). Writes stay PascalCase so the central daily file
-    // looks byte-for-byte like a local EasyLog file when fed back into
-    // a downstream reader.
     PropertyNameCaseInsensitive = true,
 };
 
-// Unbounded queue. Backup logs are low-volume (one row per file copy) and
-// dropping entries would defeat the point of central logging. A misbehaving
-// client that posts millions of entries while the disk is slow would grow
-// memory — operators are expected to monitor the host's RSS during cut-over.
+// Unbounded: backup logs are low-volume (one row per file copy) and
+// dropping entries would defeat the point of central logging. A
+// misbehaving client floods RAM — operators monitor host RSS.
 var queue = Channel.CreateUnbounded<LogEntry>(new UnboundedChannelOptions
 {
     SingleReader = true,
@@ -72,20 +42,16 @@ var queue = Channel.CreateUnbounded<LogEntry>(new UnboundedChannelOptions
 
 builder.Services.AddSingleton(queue);
 builder.Services.AddSingleton(serializerOptions);
-// Bind LogCentralizerOptions through the DI container so customizations
-// injected by integration tests (WebApplicationFactory's
-// ConfigureAppConfiguration) win over appsettings.json. Reading the option
-// directly at startup would race the factory and pin /var/log/easysave
-// before the test could override it.
+// IOptions binding so WebApplicationFactory test overrides win over
+// appsettings.json (reading the option at startup races the factory).
 builder.Services.Configure<LogCentralizerOptions>(
     builder.Configuration.GetSection("LogCentralizer"));
 builder.Services.AddHostedService<DailyFileWriter>();
 
 var app = builder.Build();
 
-// Health probe used by Docker / k8s. Cheap on purpose — no disk hit, no
-// channel inspection — so a slow filesystem cannot flap the container as
-// unhealthy and trigger a restart loop.
+// /health cheap by design: no disk hit, no channel inspection — so a
+// slow filesystem cannot flap the container as unhealthy.
 app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
 
 app.MapPost("/logs", async (HttpRequest req, Channel<LogEntry> q, JsonSerializerOptions opts, CancellationToken ct) =>
@@ -163,39 +129,30 @@ internal sealed class DailyFileWriter : BackgroundService
     {
         try
         {
-            // Create the directory here (not at startup) so the value of
-            // LogsDirectory injected by WebApplicationFactory in tests is the
-            // one actually honored. Idempotent — fine to call every time the
-            // service starts.
+            // CreateDirectory here (not at startup) so the LogsDirectory
+            // value injected by WebApplicationFactory in tests is honored.
             Directory.CreateDirectory(_options.LogsDirectory);
 
             await foreach (var entry in _queue.Reader.ReadAllAsync(stoppingToken))
             {
-                // CancellationToken.None on the write: the entry has already
-                // been dequeued and acknowledged with 204. Cancelling the
-                // File.AppendAllTextAsync mid-flight would lose it without
-                // any way for FlushRemainingAsync to recover it (it's no
-                // longer in the channel). The loop itself still exits on
-                // ReadAllAsync(stoppingToken) at the next iteration.
+                // CancellationToken.None on the write: the entry is already
+                // dequeued and acked 204. Cancelling mid-flight would lose
+                // it (FlushRemainingAsync no longer sees it). The loop
+                // itself exits on ReadAllAsync's next iteration.
                 await AppendAsync(entry, CancellationToken.None);
             }
         }
         catch (OperationCanceledException)
         {
-            // Normal shutdown path. The application is exiting; any entries
-            // still in the channel will be drained by the FlushRemaining
-            // call below.
+            // Normal shutdown. Pending entries drained by FlushRemainingAsync.
         }
         catch (Exception ex)
         {
-            // Permanent fault (UnauthorizedAccessException on a bad bind-
-            // mount, disk full, etc.). Complete the channel WITH this
-            // exception so every subsequent POST /logs trips
-            // ChannelClosedException and returns 503 instead of accepting
-            // entries we cannot persist. Without this, BackgroundService-
-            // ExceptionBehavior.Ignore keeps /health green while the
-            // writer is dead — clients see 204s, drop entries from their
-            // retry buffer, and we silently lose data.
+            // Permanent fault (disk full, bind-mount permission denied, …).
+            // Complete the channel WITH the exception so every subsequent
+            // POST /logs trips ChannelClosedException → 503. Without this,
+            // BackgroundServiceExceptionBehavior.Ignore would keep /health
+            // green while the writer is dead → silent data loss.
             _queue.Writer.TryComplete(ex);
             throw;
         }

--- a/src/EasyLog/JsonDailyLogger.cs
+++ b/src/EasyLog/JsonDailyLogger.cs
@@ -100,45 +100,20 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        // Day file is decided here so an entry produced just before midnight
+        // Day file decided here so an entry produced just before midnight
         // lands in the right file even if the writer task drains it later.
         string filePath = Path.Combine(_logDirectory, $"{DateTime.Now:yyyy-MM-dd}.json");
+        LogEntry normalized = LogRouter.Normalize(entry);
 
-        // Cahier asks for UNC paths in the log. Real UNC only exists for
-        // network shares — for local paths we fall back to the Windows
-        // extended-length prefix (\\?\). Copy the entry so we don't mutate
-        // the caller's object.
-        LogEntry normalized = new()
-        {
-            Timestamp = entry.Timestamp,
-            JobName = entry.JobName,
-            SourceFile = LogPathHelper.ToNormalizedPath(entry.SourceFile),
-            TargetFile = LogPathHelper.ToNormalizedPath(entry.TargetFile),
-            FileSize = entry.FileSize,
-            FileTransferTimeMs = entry.FileTransferTimeMs,
-            EncryptionTimeMs = entry.EncryptionTimeMs,
-            EventType = entry.EventType,
-            // Stamp host/user only when the caller did not supply them.
-            // A central collector relaying entries from remote hosts will
-            // forward the original sender's fields untouched — never the
-            // collector's own machine.
-            MachineName = entry.MachineName ?? Environment.MachineName,
-            UserName = entry.UserName ?? Environment.UserName,
-        };
-
-        // Centralized side first: the shipper is async and non-blocking, so
-        // doing it before the local write does not slow the caller down.
-        // Append on the shipper is a buffered enqueue — never throws on
-        // network failures.
         if (LogRouter.ShouldShip(_mode))
         {
             _shipper!.Append(normalized);
         }
 
-        // Centralized-only skips the daily file entirely. The shipper owns
-        // durability in that case; a host that crashes between Append and
-        // a successful POST loses the entry — operators are expected to
-        // run LogMode.Both during cut-over for that exact reason.
+        // Centralized-only mode: the shipper owns durability, skip the
+        // local file. Operators run LogMode.Both during cut-over so a
+        // host crash between Append and successful POST can fall back
+        // to the local copy.
         if (!LogRouter.ShouldWriteLocal(_mode))
         {
             return;
@@ -179,12 +154,10 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
                 }
                 catch (Exception ex)
                 {
-                    // Belt-and-braces: FlushBatch is now expected to swallow
-                    // per-group failures itself (issue #155), but any code
-                    // path that ever re-introduces a throw here would kill
-                    // the writer task and hang every future Append on its
-                    // TaskCompletionSource. Catch + surface to surviving
-                    // acks so the writer stays alive.
+                    // Belt-and-braces: FlushBatch swallows per-group failures
+                    // itself, but any future throw escaping it would kill the
+                    // writer and hang every Append on its
+                    // TaskCompletionSource. Surface to surviving acks.
                     foreach (var req in batch)
                     {
                         req.Ack.TrySetException(ex);
@@ -222,11 +195,11 @@ public sealed class JsonDailyLogger : IDailyLogger, IDisposable
         {
             string filePath = group.Key;
 
-            // Wrap the whole per-group body. Pre-fix (issue #155), only the
-            // WriteAtomic try/catch was here, and a throw from ReadExisting
-            // (transient IOException from AV / OneDrive on the first append
-            // of the day) escaped FlushBatch, killed the writer task, and
-            // left every future Append blocked on its TaskCompletionSource.
+            // Wrap the whole per-group body: a throw from ReadExisting
+            // (transient IOException from AV / OneDrive on the first
+            // append of the day) must NOT escape — it would kill the
+            // writer task and hang every future Append on its
+            // TaskCompletionSource.
             int addedThisGroup = 0;
             List<LogEntry>? entries = null;
             try

--- a/src/EasyLog/LogRouter.cs
+++ b/src/EasyLog/LogRouter.cs
@@ -2,12 +2,13 @@ namespace EasyLog;
 
 /// <summary>
 /// Shared helpers used by <see cref="JsonDailyLogger"/> and
-/// <see cref="XmlDailyLogger"/> to apply the V3 <see cref="LogMode"/>
-/// routing rules in a single place. Pulling these out of the loggers
-/// keeps the per-format Append paths free of duplicated bookkeeping
-/// (CLAUDE.md zero-duplication grading criterion) and ensures both
-/// formats follow the exact same fall-back semantics when a misconfigured
-/// host wires a centralized mode with a null shipper.
+/// <see cref="XmlDailyLogger"/> for the V3 <see cref="LogMode"/> routing
+/// rules and for the canonical normalization of an incoming
+/// <see cref="LogEntry"/>. Centralizing these here keeps the per-format
+/// Append paths free of duplicated bookkeeping (CLAUDE.md zero-duplication
+/// criterion) and guarantees both formats follow the exact same fall-back
+/// semantics when a misconfigured host wires a centralized mode with a
+/// null shipper.
 /// </summary>
 internal static class LogRouter
 {
@@ -27,4 +28,27 @@ internal static class LogRouter
     /// <summary>True when the entry should be persisted to the local daily file.</summary>
     public static bool ShouldWriteLocal(LogMode mode) =>
         mode is LogMode.Local or LogMode.Both;
+
+    /// <summary>
+    /// Returns a normalized copy of <paramref name="entry"/> ready for
+    /// persistence: source / target paths run through
+    /// <see cref="LogPathHelper.ToNormalizedPath"/>, and host fields are
+    /// stamped from <see cref="Environment"/> when the caller left them
+    /// null. Caller-provided values are preserved untouched so a central
+    /// collector relaying entries from remote hosts never overwrites the
+    /// original sender's identity.
+    /// </summary>
+    public static LogEntry Normalize(LogEntry entry) => new()
+    {
+        Timestamp = entry.Timestamp,
+        JobName = entry.JobName,
+        SourceFile = LogPathHelper.ToNormalizedPath(entry.SourceFile),
+        TargetFile = LogPathHelper.ToNormalizedPath(entry.TargetFile),
+        FileSize = entry.FileSize,
+        FileTransferTimeMs = entry.FileTransferTimeMs,
+        EncryptionTimeMs = entry.EncryptionTimeMs,
+        EventType = entry.EventType,
+        MachineName = entry.MachineName ?? Environment.MachineName,
+        UserName = entry.UserName ?? Environment.UserName,
+    };
 }

--- a/src/EasyLog/XmlDailyLogger.cs
+++ b/src/EasyLog/XmlDailyLogger.cs
@@ -47,24 +47,10 @@ public sealed class XmlDailyLogger : IDailyLogger
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        // Local date is intentional: daily files must align with the business day
-        // seen by the operator, not UTC.
+        // Local date intentional: daily files align with the operator's
+        // business day, not UTC.
         string filePath = Path.Combine(_logDirectory, $"{DateTime.Now:yyyy-MM-dd}.xml");
-
-        LogEntry normalized = new()
-        {
-            Timestamp = entry.Timestamp,
-            JobName = entry.JobName,
-            SourceFile = ToNormalizedPath(entry.SourceFile),
-            TargetFile = ToNormalizedPath(entry.TargetFile),
-            FileSize = entry.FileSize,
-            FileTransferTimeMs = entry.FileTransferTimeMs,
-            EncryptionTimeMs = entry.EncryptionTimeMs,
-            EventType = entry.EventType,
-            // See JsonDailyLogger.Append for the host/user stamping contract.
-            MachineName = entry.MachineName ?? Environment.MachineName,
-            UserName = entry.UserName ?? Environment.UserName,
-        };
+        LogEntry normalized = LogRouter.Normalize(entry);
 
         if (LogRouter.ShouldShip(_mode))
         {
@@ -83,9 +69,6 @@ public sealed class XmlDailyLogger : IDailyLogger
             WriteAtomic(filePath, doc);
         }
     }
-
-    private static string ToNormalizedPath(string path) =>
-        LogPathHelper.ToNormalizedPath(path);
 
     private static XDocument ReadExisting(string filePath)
     {

--- a/src/EasySave/Services/CryptoSoftAdapter.cs
+++ b/src/EasySave/Services/CryptoSoftAdapter.cs
@@ -20,12 +20,10 @@ namespace EasySave.Services;
 /// </remarks>
 public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
 {
-    // The Global\ prefix scopes the mutex across user sessions on
-    // Windows. On Linux / macOS, .NET maps named mutexes to per-runtime
-    // POSIX semaphores under /tmp/.dotnet/shm/ — the prefix is ignored
-    // but the name still gives cross-process isolation within the
-    // ProSoft installation, which is good enough for the dev path.
-    private const string GlobalMutexName = @"Global\ProSoft.CryptoSoft.SingleInstance";
+    // Global\ scopes the mutex across user sessions on Windows. On Linux /
+    // macOS .NET maps it to a per-runtime POSIX semaphore (prefix ignored
+    // but name still gives cross-process isolation).
+    internal const string GlobalMutexName = @"Global\ProSoft.CryptoSoft.SingleInstance";
 
     private readonly CryptoSoftSettings _settings;
     private readonly Mutex _gate;
@@ -36,27 +34,13 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
     {
         ArgumentNullException.ThrowIfNull(settings);
         _settings = settings;
-
-        // Mutex(initiallyOwned: false, name) creates the named mutex or
-        // opens the existing one. Multiple CryptoSoftAdapter instances
-        // (one per BackupManager / per process) all share the same OS
-        // handle by name.
         _gate = new Mutex(initiallyOwned: false, name: GlobalMutexName);
 
-        // A queued caller waits at most 2× the per-file budget for the
-        // gate. Predictable upper bound makes operator triage easier:
-        // a single queued encryption is bounded by 2 × timeout_ms, which
-        // accommodates the worst case of the holder running until its
-        // own timeout fires plus the new caller's own encryption budget.
-        // If the lock is contended longer, the file is dropped as Failed
-        // and logged — operators see the conflict in the daily log
-        // instead of an indefinite hang.
-        //
-        // Math.Min on a widened long guards against int overflow when an
-        // operator sets a huge timeout (>1 billion ms ≈ 11 days). Without
-        // the widening, _lockWaitMs would wrap to a negative value and
-        // Mutex.WaitOne would throw ArgumentOutOfRangeException at the
-        // first call.
+        // Lock wait = 2 × per-file timeout. A queued caller bounded by
+        // (holder finishing + own budget). Math.Min on widened long
+        // guards against int overflow when an operator sets a huge
+        // timeout — without it _lockWaitMs would wrap negative and
+        // Mutex.WaitOne would throw ArgumentOutOfRangeException.
         int timeoutMs = _settings.TimeoutMs > 0 ? _settings.TimeoutMs : 30_000;
         _lockWaitMs = (int)Math.Min((long)timeoutMs * 2, int.MaxValue);
     }
@@ -67,11 +51,10 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(source);
         ArgumentException.ThrowIfNullOrWhiteSpace(dest);
 
-        // Late-arriving call after Dispose(): the OS mutex handle is
-        // already closed, so AcquireGate would throw ObjectDisposedException
-        // on WaitOne. Convert to a soft Failed instead — same shape as the
-        // empty-path fall-back below, so the caller's fall-back path (plain
-        // copy, no encryption) handles both cases uniformly.
+        // Post-Dispose: the OS mutex handle is closed; WaitOne would
+        // throw ObjectDisposedException. Return soft Failed so the
+        // caller's fall-back (plain copy, no encryption) covers both
+        // Dispose and empty-path cases uniformly.
         if (Volatile.Read(ref _disposed) != 0)
         {
             return EncryptResult.Failed();
@@ -79,8 +62,7 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
 
         if (string.IsNullOrWhiteSpace(_settings.Path))
         {
-            // CryptoSoft not deployed on this workstation. The caller is
-            // expected to fall back to a plain copy (no encryption).
+            // CryptoSoft not deployed → caller falls back to plain copy.
             return EncryptResult.Failed();
         }
 
@@ -105,11 +87,6 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
         }
     }
 
-    // Splits the Mutex acquisition from the catch path so the
-    // AbandonedMutexException handling stays local. AbandonedMutex means
-    // the previous holder died without releasing — the OS still grants
-    // the mutex to the next waiter, and behaving as if we acquired
-    // normally is the documented contract.
     private bool AcquireGate()
     {
         try
@@ -118,9 +95,9 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
         }
         catch (AbandonedMutexException)
         {
-            // Previous holder crashed. CryptoSoft itself is responsible
-            // for cleaning up its own partial output on the next launch;
-            // EasySave just continues.
+            // Previous holder crashed without releasing — the OS grants
+            // the mutex to us. CryptoSoft itself handles partial-output
+            // cleanup on the next launch.
             return true;
         }
     }
@@ -132,19 +109,16 @@ public sealed class CryptoSoftAdapter : IEncryptionService, IDisposable
             FileName = _settings.Path,
             UseShellExecute = false,
             CreateNoWindow = true,
-            // Standard streams are intentionally NOT redirected: the contract
-            // (docs/cryptosoft-integration.md) communicates only via the exit
-            // code. Redirecting without draining the OS pipes would deadlock
-            // CryptoSoft as soon as it writes past the pipe buffer (~64 KB).
+            // Standard streams NOT redirected: the contract
+            // (docs/cryptosoft-integration.md) communicates only via the
+            // exit code. Redirecting without draining the OS pipes would
+            // deadlock CryptoSoft past the pipe buffer (~64 KB).
         };
         psi.ArgumentList.Add(source);
         psi.ArgumentList.Add(dest);
 
         try
         {
-            // Process.Start with UseShellExecute=false returns a live Process
-            // or throws — it never returns null. The null-forgiving operator
-            // documents that contract for static analysis.
             using var process = Process.Start(psi)!;
 
             int timeoutMs = _settings.TimeoutMs > 0 ? _settings.TimeoutMs : 30_000;

--- a/tests/EasySave.Tests/CryptoSoftAdapterTests.cs
+++ b/tests/EasySave.Tests/CryptoSoftAdapterTests.cs
@@ -158,18 +158,9 @@ public class CryptoSoftAdapterTests
         // adapter.Encrypt on the test thread. Named mutexes are
         // recursive per thread — holding from the same thread that
         // later calls Encrypt would let the recursive WaitOne return
-        // immediately and falsely report "no contention". A separate
+        // immediately and falsely report "no contention". A dedicated
         // owner thread makes the contention real.
-        //
-        // The previous version of this test spawned a Task.Run holder
-        // that itself called adapter.Encrypt with a fake Process — it
-        // depended on Thread.Sleep racing the process spawn, which is
-        // flaky under CI load. Holding the OS mutex directly bypasses
-        // both flakiness sources.
-        //
-        // Mutex name re-declared here on purpose: an internal rename
-        // on the adapter side would (correctly) break this test.
-        const string mutexName = @"Global\ProSoft.CryptoSoft.SingleInstance";
+        string mutexName = CryptoSoftAdapter.GlobalMutexName;
         using var acquired = new ManualResetEventSlim(false);
         using var release = new ManualResetEventSlim(false);
 

--- a/tests/LogCentralizer.Tests/LogCentralizerE2ETests.cs
+++ b/tests/LogCentralizer.Tests/LogCentralizerE2ETests.cs
@@ -92,7 +92,7 @@ public sealed class LogCentralizerE2ETests : IClassFixture<LogCentralizerE2EFixt
         // Container writes asynchronously; poll the bind-mounted dir until
         // all 150 entries have flushed. Generous timeout because the
         // container's filesystem layer adds latency vs. native.
-        var lines = await WaitForLinesAsync(
+        var lines = await LogFilePoller.WaitForLinesAsync(
             _fx.HostLogsDir!,
             expected: clientCount * entriesPerClient,
             timeout: TimeSpan.FromSeconds(20));
@@ -115,31 +115,6 @@ public sealed class LogCentralizerE2ETests : IClassFixture<LogCentralizerE2EFixt
         Assert.Equal(users.ToHashSet(), distinctUsers);
     }
 
-    // Poll the logs directory until the expected number of lines is observed
-    // or the timeout elapses.
-    private static async Task<string[]> WaitForLinesAsync(
-        string logsDir, int expected, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            var files = Directory.GetFiles(logsDir, "*.jsonl");
-            if (files.Length > 0)
-            {
-                using var fs = new FileStream(
-                    files[0], FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var sr = new StreamReader(fs);
-                var content = await sr.ReadToEndAsync();
-                var lines = content.Split(
-                    new[] { '\r', '\n' },
-                    StringSplitOptions.RemoveEmptyEntries);
-                if (lines.Length >= expected) return lines;
-            }
-            await Task.Delay(200);
-        }
-        throw new Xunit.Sdk.XunitException(
-            $"Expected {expected} persisted lines under {logsDir} within {timeout.TotalSeconds:F0}s.");
-    }
 }
 
 /// <summary>

--- a/tests/LogCentralizer.Tests/LogCentralizerTests.cs
+++ b/tests/LogCentralizer.Tests/LogCentralizerTests.cs
@@ -71,7 +71,7 @@ public class LogCentralizerTests : IDisposable
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
-        var line = await WaitForLinesAsync(_logsDir, expected: 1);
+        var line = await LogFilePoller.WaitForLinesAsync(_logsDir, expected: 1);
         var persisted = JsonSerializer.Deserialize<LogEntry>(line[0])!;
         Assert.Equal("single-client", persisted.JobName);
         Assert.Equal("WS-01", persisted.MachineName);
@@ -144,7 +144,7 @@ public class LogCentralizerTests : IDisposable
         }
         await Task.WhenAll(tasks);
 
-        var lines = await WaitForLinesAsync(_logsDir, expected: clients * entriesPerClient);
+        var lines = await LogFilePoller.WaitForLinesAsync(_logsDir, expected: clients * entriesPerClient);
 
         Assert.Single(Directory.GetFiles(_logsDir, "*.jsonl"));
         Assert.Equal(clients * entriesPerClient, lines.Length);
@@ -183,7 +183,7 @@ public class LogCentralizerTests : IDisposable
         var response = await client.PostAsJsonAsync("/logs", entry);
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
-        var line = (await WaitForLinesAsync(_logsDir, expected: 1))[0];
+        var line = (await LogFilePoller.WaitForLinesAsync(_logsDir, expected: 1))[0];
         Assert.DoesNotContain("MachineName", line);
         Assert.DoesNotContain("UserName", line);
     }
@@ -217,7 +217,7 @@ public class LogCentralizerTests : IDisposable
         };
         shipper.Append(sent);
 
-        var line = (await WaitForLinesAsync(_logsDir, expected: 1))[0];
+        var line = (await LogFilePoller.WaitForLinesAsync(_logsDir, expected: 1))[0];
         var persisted = JsonSerializer.Deserialize<LogEntry>(line)!;
 
         Assert.Equal(sent.JobName, persisted.JobName);
@@ -235,37 +235,6 @@ public class LogCentralizerTests : IDisposable
     // Helpers
     // ──────────────────────────────────────────────────────────────────────
 
-    // Poll the logs directory until the expected number of lines is observed
-    // or the timeout elapses. Mirrors how an external admin would tail the
-    // file — the background writer is async, so an assertion that fires
-    // right after PostAsync can race against the channel drain.
-    private static async Task<string[]> WaitForLinesAsync(string logsDir, int expected, TimeSpan? timeout = null)
-    {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(15));
-        while (DateTime.UtcNow < deadline)
-        {
-            var files = Directory.GetFiles(logsDir, "*.jsonl");
-            if (files.Length > 0)
-            {
-                // Read with FileShare.ReadWrite so we never race the writer's
-                // open file handle while it appends.
-                using var fs = new FileStream(files[0], FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var sr = new StreamReader(fs);
-                var content = await sr.ReadToEndAsync();
-                // Split on both \r and \n so a Windows CI runner (where the
-                // writer emits "\r\n" via Environment.NewLine) does not leave
-                // a trailing '\r' on every token — JsonSerializer.Deserialize
-                // would throw JsonException on the stray byte.
-                var lines = content.Split(
-                    new[] { '\r', '\n' },
-                    StringSplitOptions.RemoveEmptyEntries);
-                if (lines.Length >= expected) return lines;
-            }
-            await Task.Delay(100);
-        }
-        throw new Xunit.Sdk.XunitException(
-            $"Expected {expected} persisted lines under {logsDir} within timeout.");
-    }
 
     private sealed class CustomFactory : WebApplicationFactory<Program>
     {

--- a/tests/LogCentralizer.Tests/LogFilePoller.cs
+++ b/tests/LogCentralizer.Tests/LogFilePoller.cs
@@ -1,0 +1,39 @@
+namespace LogCentralizer.Tests;
+
+// Shared polling helper for tests that need to wait until the LogCentralizer
+// background writer has flushed N entries to disk. Used by both the
+// in-process suite (LogCentralizerTests) and the Testcontainers e2e suite
+// (LogCentralizerE2ETests) — the writer is async in both setups, so an
+// assertion fired right after PostAsync would race the channel drain.
+//
+// FileShare.ReadWrite is intentional: the writer keeps the file open in
+// append mode while polling reads it, and we never want the polling side
+// to block writes. Splitting on '\r' AND '\n' covers Windows CI runners
+// where Environment.NewLine = "\r\n" — without that, the trailing '\r'
+// would slip into the token and JsonSerializer.Deserialize would throw.
+internal static class LogFilePoller
+{
+    public static async Task<string[]> WaitForLinesAsync(
+        string logsDir, int expected, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(15));
+        while (DateTime.UtcNow < deadline)
+        {
+            var files = Directory.GetFiles(logsDir, "*.jsonl");
+            if (files.Length > 0)
+            {
+                using var fs = new FileStream(
+                    files[0], FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var sr = new StreamReader(fs);
+                var content = await sr.ReadToEndAsync();
+                var lines = content.Split(
+                    new[] { '\r', '\n' },
+                    StringSplitOptions.RemoveEmptyEntries);
+                if (lines.Length >= expected) return lines;
+            }
+            await Task.Delay(100);
+        }
+        throw new Xunit.Sdk.XunitException(
+            $"Expected {expected} persisted lines under {logsDir} within timeout.");
+    }
+}


### PR DESCRIPTION
## Summary

Items **#2** and **#4** of the V3 maintainability audit plan, bundled.

### #2 Dedup

- **`LogRouter.Normalize(entry)`** consolidates the `LogEntry` normalization (path normalization + host-field stamping from `Environment`) that was copy-pasted between `JsonDailyLogger.Append` and `XmlDailyLogger.Append` — ~10 lines × 2. Both loggers now call the helper. `XmlDailyLogger`'s private `ToNormalizedPath` wrapper becomes unused → removed.
- **`LogFilePoller.WaitForLinesAsync`** extracted to a shared helper in `tests/LogCentralizer.Tests/`. The polling loop (~25 lines) was duplicated verbatim between `LogCentralizerTests` and `LogCentralizerE2ETests`. Both call sites updated; private copies removed.
- **`CryptoSoftAdapter.GlobalMutexName`** promoted from `private const` to `internal const`. The test that re-declared the same string literal now references it directly via `InternalsVisibleTo` — a future rename breaks the test correctly instead of silently pinning the old name.

### #4 Comment élagage (~120 lines removed)

Targets:
- `LogCentralizer/Program.cs` header (26 lines of design recap → 5 lines + pointer to admin doc)
- `JsonDailyLogger.FlushBatch` "Pre-fix (issue #155)" / "Belt-and-braces" blocks
- `CryptoSoftAdapter` ctor (Mutex acquisition explanation), `Encrypt` early-return paths

Kept: every `WHY` comment that surfaces a hidden invariant, OS-specific quirk, or contract note. Removed: refs to merged PRs that rot (`issue #155`, `Pre-fix`), narration of past refactors (`previous version did X`), and explanations of `WHAT` (well-named identifiers cover that).

## Net diff

**−154 lines across 8 files + 1 new file** (`LogFilePoller.cs`, 38 lines).

## Test plan

- [x] `dotnet build EasySave.sln` — 10 projects, 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] V1 tests — 125/125 pass
- [x] V2 tests — 154/160 pass (4 pre-existing `SelfSignedCertProviderTests` macOS flakes unrelated, 2 skipped)
- [x] LogCentralizer in-process — 7/7 pass (incl. wire-format round-trip from #195)
- [x] CryptoSoft suite — 8/8 pass (incl. mono-instance + lock timeout)
- [ ] CI green Linux / Windows

## Audit plan progress

| # | Item | Status |
|---|------|--------|
| 1 | Wire-format shipper↔collecteur | ✅ merged in #195 |
| 2 | LogRouter.Normalize + LogFilePoller | ✅ this PR |
| 3 | Flatten WriterLoopAsync | ✅ merged in #195 |
| 4 | Trim verbose comments | ✅ this PR |
| 5 | Named timeout constants | pending |
| 6 | README concurrency primitives | pending |

Estimated grade movement: 13-14/20 → 16/20 on maintainability after this merges. Items #5 + #6 will land in a follow-up bundle.