### PR TITLE
feat(state): surface failed files count on StateEntry

### DIFF
--- a/src/EasySave/Services/BackupManager.cs
+++ b/src/EasySave/Services/BackupManager.cs
@@ -229,6 +229,7 @@ public sealed class BackupManager
             TotalSize = eligible.Sum(x => x.file.Length),
             FilesRemaining = toCopy.Count,
             SizeRemaining = toCopy.Sum(x => x.file.Length),
+            FailedFiles = 0,
         };
         _stateTracker.Update(state);
 
@@ -300,6 +301,9 @@ public sealed class BackupManager
                 FileHelpers.EnsureDirectoryExists(targetPath);
 
                 var (transferMs, encryptionMs) = ProcessFile(file, targetPath, ct);
+
+                if (transferMs < 0)
+                    state.FailedFiles++;
 
                 _logger.Append(new LogEntry
                 {

--- a/src/EasySave/StateEntry.cs
+++ b/src/EasySave/StateEntry.cs
@@ -26,6 +26,13 @@ public sealed class StateEntry
     // Remaining size in bytes to transfer.
     public long SizeRemaining { get; set; }
 
+    // Number of files whose transfer failed during the current (or last) run.
+    // Set to 0 on every new run start; incremented per file when ProcessFile
+    // returns FileTransferTimeMs < 0 (the v1.0 error signal). Persisted so
+    // operators can spot "this job finished but lost N files" without parsing
+    // the daily log — the JobState enum stays additive-free (v3 wire format).
+    public int FailedFiles { get; set; }
+
     // Progress between 0 and 100, derived from file counters to stay consistent.
     public double Progress =>
         TotalFilesEligible == 0

--- a/tests/EasySave.Tests/BackupManagerExecuteTests.cs
+++ b/tests/EasySave.Tests/BackupManagerExecuteTests.cs
@@ -135,6 +135,32 @@ public class BackupManagerExecuteTests : IDisposable
         Assert.Single(logFiles);
         var logContent = File.ReadAllText(logFiles[0]);
         Assert.Contains("-1", logContent);
+
+        // state.json must surface the failure count so operators do not need
+        // to grep the daily log to spot a partially-failed run.
+        var stateJson = File.ReadAllText(Path.Combine(_dataDir, "state.json"));
+        var entries = System.Text.Json.JsonSerializer.Deserialize<List<StateEntry>>(stateJson);
+        Assert.NotNull(entries);
+        var entry = Assert.Single(entries);
+        Assert.Equal(JobState.Inactive, entry.State);
+        Assert.Equal(1, entry.FailedFiles);
+    }
+
+    [Fact]
+    public void ExecuteJob_AllFilesCopy_FailedFilesIsZero()
+    {
+        File.WriteAllText(Path.Combine(_sourceDir, "a.txt"), "aaa");
+        File.WriteAllText(Path.Combine(_sourceDir, "b.txt"), "bbb");
+
+        SeedJob("no-failure", BackupType.Full);
+        var manager = CreateManager(new FullBackupStrategy(), new DifferentialBackupStrategy());
+
+        manager.ExecuteJob("no-failure");
+
+        var stateJson = File.ReadAllText(Path.Combine(_dataDir, "state.json"));
+        var entries = System.Text.Json.JsonSerializer.Deserialize<List<StateEntry>>(stateJson);
+        var entry = Assert.Single(entries!);
+        Assert.Equal(0, entry.FailedFiles);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add additive `FailedFiles` int on `StateEntry`, incremented per file when `ProcessFile` returns `FileTransferTimeMs < 0` (the v1.0 error signal).
- Reset to 0 at the start of every run; surfaces the result without resetting in the run-end `finally`.
- Two tests in `BackupManagerExecuteTests`: the existing "one file fails" scenario gains a `FailedFiles == 1` assertion, plus a happy-path `FailedFiles == 0` test.

## Motivation

Today, when a job runs into errors (USB unplugged, disk full, target locked), the engine catches `IOException` per file, logs `FileTransferTimeMs = -1`, and finishes in `JobState.Inactive` — same terminal state as a clean run. The only way to know "this job lost 50 files" is to grep the daily log. This field surfaces that signal on `state.json` directly.

## Wire format

- **`JobState` enum unchanged** (still Inactive/Active/Paused).
- **`JobStateEnum` wire format unchanged** (still Done/Running/Paused).
- New field is an additive `int` on `StateEntry`. Old consumers ignore it; new consumers can read it. Default 0 keeps backward compat for state files written by older versions.

## Test plan
- [x] `dotnet build EasySave.sln` — 0 errors
- [x] `dotnet test EasySave.sln` — 161/161 passing
- [x] `BackupManagerExecuteTests.ExecuteJob_ErrorOnOneFile_ContinuesAndLogsNegativeTime` updated and green
- [x] `BackupManagerExecuteTests.ExecuteJob_AllFilesCopy_FailedFilesIsZero` new, green
- [ ] CI green on staging