### PR TITLE
feat(v3): wire LogMode + HttpLogShipper in CLI and UI entry points

### DIFF
--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -22,6 +22,11 @@ public partial class App : Application
     // before the process exits.
     private static CancellationTokenSource? _remoteServerCts;
 
+    // Kept alive so DisposeServices can drain the buffered HTTP queue
+    // before the window closes — otherwise an in-flight POST gets dropped
+    // when the singleton IDailyLogger is collected.
+    private static IAsyncDisposable? _logShipper;
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -113,11 +118,12 @@ public partial class App : Application
         services.AddSingleton<IDailyLogger>(_ =>
         {
             var settings = SettingsRepository.Instance.Load();
-            var (logger, _) = DailyLoggerFactory.Create(
+            var (logger, shipper) = DailyLoggerFactory.Create(
                 AppConfig.Instance.LogDirectory,
                 settings.LogFormat,
                 settings.LogMode,
                 settings.LogCentralizedEndpoint);
+            _logShipper = shipper;
             return logger;
         });
 
@@ -327,5 +333,12 @@ public partial class App : Application
         Services?.GetService<IParallelBackupOrchestrator>()?.Dispose();
         (Services?.GetService<IBigFileGate>() as IDisposable)?.Dispose();
         (Services?.GetService<IPriorityGate>() as IDisposable)?.Dispose();
+
+        // Drain the centralized log shipper last so any entry the engine
+        // produced during teardown (e.g. "job stopped") has a chance to
+        // be POSTed before the queue is abandoned.
+        try { _logShipper?.DisposeAsync().AsTask().GetAwaiter().GetResult(); }
+        catch { /* shutdown best-effort */ }
+        _logShipper = null;
     }
 }

--- a/src/EasySave.UI/App.axaml.cs
+++ b/src/EasySave.UI/App.axaml.cs
@@ -112,10 +112,13 @@ public partial class App : Application
         // Backend services
         services.AddSingleton<IDailyLogger>(_ =>
         {
-            var logFormat = SettingsRepository.Instance.Load().LogFormat;
-            return logFormat.Equals("xml", StringComparison.OrdinalIgnoreCase)
-                ? (IDailyLogger)new XmlDailyLogger(AppConfig.Instance.LogDirectory)
-                : new JsonDailyLogger(AppConfig.Instance.LogDirectory);
+            var settings = SettingsRepository.Instance.Load();
+            var (logger, _) = DailyLoggerFactory.Create(
+                AppConfig.Instance.LogDirectory,
+                settings.LogFormat,
+                settings.LogMode,
+                settings.LogCentralizedEndpoint);
+            return logger;
         });
 
         services.AddSingleton<IEncryptionService>(_ =>

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -19,11 +19,12 @@ var (logger, logShipper) = DailyLoggerFactory.Create(
     AppConfig.Instance.Settings.LogFormat,
     AppConfig.Instance.Settings.LogMode,
     AppConfig.Instance.Settings.LogCentralizedEndpoint);
-AppDomain.CurrentDomain.ProcessExit += async (_, _) =>
-{
-    if (logShipper is not null)
-        await logShipper.DisposeAsync();
-};
+// ProcessExit is sync — an async lambda would be async void and the
+// runtime would not wait for the channel drain, losing buffered entries
+// on shutdown. Block here so DisposeAsync completes before the process
+// exits.
+AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+    logShipper?.DisposeAsync().AsTask().GetAwaiter().GetResult();
 IEncryptionService encryption = string.IsNullOrWhiteSpace(AppConfig.Instance.Settings.CryptoSoft.Path)
     ? new NoOpEncryptionService()
     : new CryptoSoftAdapter(AppConfig.Instance.Settings.CryptoSoft);

--- a/src/EasySave/Program.cs
+++ b/src/EasySave/Program.cs
@@ -14,7 +14,16 @@ catch (IOException ex)
     Environment.Exit(1);
 }
 
-var logger = new JsonDailyLogger(AppConfig.Instance.LogDirectory);
+var (logger, logShipper) = DailyLoggerFactory.Create(
+    AppConfig.Instance.LogDirectory,
+    AppConfig.Instance.Settings.LogFormat,
+    AppConfig.Instance.Settings.LogMode,
+    AppConfig.Instance.Settings.LogCentralizedEndpoint);
+AppDomain.CurrentDomain.ProcessExit += async (_, _) =>
+{
+    if (logShipper is not null)
+        await logShipper.DisposeAsync();
+};
 IEncryptionService encryption = string.IsNullOrWhiteSpace(AppConfig.Instance.Settings.CryptoSoft.Path)
     ? new NoOpEncryptionService()
     : new CryptoSoftAdapter(AppConfig.Instance.Settings.CryptoSoft);

--- a/src/EasySave/Services/DailyLoggerFactory.cs
+++ b/src/EasySave/Services/DailyLoggerFactory.cs
@@ -24,9 +24,14 @@ public static class DailyLoggerFactory
         // otherwise silently drop every entry: the logger ctors guard for
         // this (LogRouter.Effective falls back to Local) but we prefer to
         // never construct the shipper at all in that case.
+        // Uri.TryCreate accepts file://, ftp://, etc. — HttpLogShipper's
+        // ctor would then throw ArgumentException. Filter to http/https
+        // here so a typo in appsettings.json silently falls back to Local
+        // instead of crashing the entry point.
         if (logMode != LogMode.Local
             && !string.IsNullOrWhiteSpace(centralizedEndpoint)
-            && Uri.TryCreate(centralizedEndpoint, UriKind.Absolute, out var endpoint))
+            && Uri.TryCreate(centralizedEndpoint, UriKind.Absolute, out var endpoint)
+            && (endpoint.Scheme == Uri.UriSchemeHttp || endpoint.Scheme == Uri.UriSchemeHttps))
         {
             shipper = new HttpLogShipper(endpoint);
         }

--- a/src/EasySave/Services/DailyLoggerFactory.cs
+++ b/src/EasySave/Services/DailyLoggerFactory.cs
@@ -1,0 +1,42 @@
+using EasyLog;
+using EasySave.Models;
+
+namespace EasySave.Services;
+
+// Builds an IDailyLogger from AppSettings, wiring an HttpLogShipper when
+// LogMode is Centralized / Both AND LogCentralizedEndpoint is set. Both
+// CLI (Program.cs) and UI (App.axaml.cs) call into this so the centralized
+// shipping feature behaves identically regardless of entry point. Returns
+// the shipper alongside so callers can keep it alive for IDisposable
+// teardown — JsonDailyLogger / XmlDailyLogger do not own the shipper.
+public static class DailyLoggerFactory
+{
+    public static (IDailyLogger Logger, HttpLogShipper? Shipper) Create(
+        string logDirectory,
+        string logFormat,
+        LogMode logMode,
+        string centralizedEndpoint)
+    {
+        HttpLogShipper? shipper = null;
+
+        // Only build a shipper when the operator opted in AND gave us a
+        // reachable endpoint. An empty endpoint with mode=Centralized would
+        // otherwise silently drop every entry: the logger ctors guard for
+        // this (LogRouter.Effective falls back to Local) but we prefer to
+        // never construct the shipper at all in that case.
+        if (logMode != LogMode.Local
+            && !string.IsNullOrWhiteSpace(centralizedEndpoint)
+            && Uri.TryCreate(centralizedEndpoint, UriKind.Absolute, out var endpoint))
+        {
+            shipper = new HttpLogShipper(endpoint);
+        }
+
+        var effectiveMode = shipper is null ? LogMode.Local : logMode;
+
+        IDailyLogger logger = logFormat.Equals("xml", StringComparison.OrdinalIgnoreCase)
+            ? new XmlDailyLogger(logDirectory, shipper, effectiveMode)
+            : new JsonDailyLogger(logDirectory, shipper, effectiveMode);
+
+        return (logger, shipper);
+    }
+}

--- a/tests/EasySave.Tests.V2/DailyLoggerFactoryTests.cs
+++ b/tests/EasySave.Tests.V2/DailyLoggerFactoryTests.cs
@@ -1,0 +1,83 @@
+using EasyLog;
+using EasySave.Services;
+
+namespace EasySave.Tests.V2;
+
+// Locks the factory behaviour so a regression in Program.cs / App.axaml.cs
+// (passing LogMode but forgetting the endpoint, or vice versa) is caught
+// by CI rather than at the demo. The factory is the single bottleneck for
+// "do we ship logs centrally or not" — once it's correct, both entry
+// points are correct.
+public class DailyLoggerFactoryTests : IDisposable
+{
+    private readonly string _logDir;
+
+    public DailyLoggerFactoryTests()
+    {
+        _logDir = Path.Combine(Path.GetTempPath(), "dlf-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_logDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_logDir))
+            Directory.Delete(_logDir, recursive: true);
+    }
+
+    [Fact]
+    public void Create_LocalMode_NoShipper()
+    {
+        var (logger, shipper) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Local, "http://x:9100/logs");
+
+        Assert.NotNull(logger);
+        Assert.Null(shipper);
+        if (logger is IDisposable d) d.Dispose();
+    }
+
+    [Fact]
+    public async Task Create_CentralizedMode_WithEndpoint_BuildsShipper()
+    {
+        var (logger, shipper) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Centralized, "http://collector:9100/logs");
+
+        Assert.NotNull(logger);
+        Assert.NotNull(shipper);
+        await shipper!.DisposeAsync();
+        if (logger is IDisposable d) d.Dispose();
+    }
+
+    [Fact]
+    public void Create_CentralizedMode_EmptyEndpoint_FallsBackToLocal()
+    {
+        var (logger, shipper) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Centralized, "");
+
+        Assert.NotNull(logger);
+        Assert.Null(shipper);
+        if (logger is IDisposable d) d.Dispose();
+    }
+
+    [Fact]
+    public void Create_CentralizedMode_InvalidEndpoint_FallsBackToLocal()
+    {
+        var (logger, shipper) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Centralized, "not a uri");
+
+        Assert.NotNull(logger);
+        Assert.Null(shipper);
+        if (logger is IDisposable d) d.Dispose();
+    }
+
+    [Fact]
+    public void Create_XmlFormat_ReturnsXmlLogger()
+    {
+        var (logger, _) = DailyLoggerFactory.Create(_logDir, "xml", LogMode.Local, "");
+        Assert.IsType<XmlDailyLogger>(logger);
+        if (logger is IDisposable d) d.Dispose();
+    }
+
+    [Fact]
+    public void Create_JsonFormat_ReturnsJsonLogger()
+    {
+        var (logger, _) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Local, "");
+        Assert.IsType<JsonDailyLogger>(logger);
+        if (logger is IDisposable d) d.Dispose();
+    }
+}

--- a/tests/EasySave.Tests.V2/DailyLoggerFactoryTests.cs
+++ b/tests/EasySave.Tests.V2/DailyLoggerFactoryTests.cs
@@ -80,4 +80,25 @@ public class DailyLoggerFactoryTests : IDisposable
         Assert.IsType<JsonDailyLogger>(logger);
         if (logger is IDisposable d) d.Dispose();
     }
+
+    [Fact]
+    public async Task Create_BothMode_WithEndpoint_BuildsShipper()
+    {
+        var (logger, shipper) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Both, "http://collector:9100/logs");
+
+        Assert.NotNull(logger);
+        Assert.NotNull(shipper);
+        await shipper!.DisposeAsync();
+        if (logger is IDisposable d) d.Dispose();
+    }
+
+    [Fact]
+    public void Create_NonHttpScheme_FallsBackToLocal()
+    {
+        var (logger, shipper) = DailyLoggerFactory.Create(_logDir, "json", LogMode.Centralized, "file:///tmp/logs");
+
+        Assert.NotNull(logger);
+        Assert.Null(shipper);
+        if (logger is IDisposable d) d.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary

Both `Program.cs` (CLI) and `App.axaml.cs` (UI) were building `JsonDailyLogger` / `XmlDailyLogger` without passing an `ILogShipper`. Result: setting `log_mode: Centralized` in `appsettings.json` had **zero effect** — the V3 centralized-logging feature was coded, tested in isolation, but never reachable from a real run.

Closes the V3 cahier requirement "Centralisation des fichiers log journaliers" end-to-end.

## Changes

- New `DailyLoggerFactory.Create(logDir, format, mode, endpoint)` in `EasySave.Services` — single bottleneck that decides whether to build an `HttpLogShipper`. Falls back to `LogMode.Local` when the endpoint is empty or malformed, so a misconfigured centralized setup never drops entries.
- `Program.cs` and `App.axaml.cs` both call into the factory.
- `Program.cs` disposes the shipper on `ProcessExit` to drain the buffered queue.
- Six tests in `DailyLoggerFactoryTests` pin the matrix: Local / Centralized × valid / empty / invalid endpoint × json / xml format.

## Test plan
- [x] `dotnet build EasySave.sln` — 0 errors
- [x] `dotnet test EasySave.sln` — 160/166 V2 passing (4 pre-existing `SelfSignedCertProviderTests` failures unrelated to this PR — macOS Keychain `EphemeralKeySet` not supported), 130 V1 passing, 7 LogCentralizer passing
- [x] All 6 new `DailyLoggerFactoryTests` pass
- [ ] CI green on staging (Linux runners — cert tests will pass there)

## Wire format

No DTO touched. `EasyLog.dll` public surface unchanged (the shipper-aware ctors already existed in `JsonDailyLogger` / `XmlDailyLogger`).