### PR TITLE
docs(v3): add v3.0.0 release notes + refresh one-page user manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,146 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] — 2026-05-13
+
+Major release. EasySave moves from sequential to parallel backups, introduces a
+remote operator console over TCP, a Docker-based daily-log centralizer, a global
+big-file gate, cross-job priority extensions, CryptoSoft mono-instance
+enforcement, and automatic pause / resume on business-software detection.
+`EasyLog.dll` reaches v1.2 with optional `MachineName` / `UserName` / `EventType`
+fields — additive only; the v1.0 public surface and on-disk JSON / XML shape
+stay frozen for existing consumers.
+
+### Added
+
+- **Parallel backup engine** (`IParallelBackupOrchestrator` /
+  `ParallelBackupOrchestrator`): jobs selected via Run All execute concurrently
+  bounded by `max_parallel_jobs` (default 4). Per-job
+  `JobExecutionContext` (CTS + PauseGate) isolates Pause / Stop so one job
+  cannot freeze another. The legacy sequential path is gone.
+- **Big-file gate** (`IBigFileGate` / `BigFileGate`): files ≥
+  `large_file_threshold_kb` (default 4096) traverse a global `SemaphoreSlim`
+  N=1 — only one large transfer in flight across every job. Small files keep
+  running fully parallel.
+- **Priority extensions cross-job gate** (`IPriorityGate` / `PriorityGate`):
+  no non-priority file starts on any job while a priority extension is still
+  pending on any other job. Extensions configured via the new
+  `priority_extensions` setting.
+- **Pause / Play / Stop on every job and globally**: per-card buttons in the
+  Avalonia GUI and identical commands from the remote console. Pause stops
+  at the next file boundary; Stop cancels immediately; Play resumes from the
+  saved offset (Full) or re-scans (Differential).
+- **Business-software auto-pause/auto-resume** (V3 semantics): when a process
+  in `business_software` is detected, every running job pauses at its next
+  file boundary; when the process exits, the watcher resumes them
+  automatically. Replaces the V2 "refuse to launch" rule. The event is
+  consigned in the daily log.
+- **CryptoSoft mono-instance**: a named system mutex
+  (`Global\ProSoft.CryptoSoft`) guarantees only one CryptoSoft process runs
+  at a time on the machine; concurrent encrypt requests serialize transparently.
+- **Daily-log centralizer** (`src/LogCentralizer`): ASP.NET Core minimal API
+  shipped as a Docker image (`docker-compose.yml`). Receives `LogEntry`
+  rows from every workstation and writes a single daily file per host or per
+  fleet, demultiplexed by the new `MachineName` / `UserName` fields.
+- **`LogMode` routing** (`Local` / `Centralized` / `Both`): `JsonDailyLogger`
+  and `XmlDailyLogger` accept an `ILogShipper`; `HttpLogShipper` posts to
+  `log_centralizer_url` with retry + bounded buffer. Local writes preserved
+  in `Both` mode, dropped in `Centralized`.
+- **Remote operator console** (`EasySave.RemoteConsole`): standalone Avalonia
+  client that connects to `TcpRemoteConsoleServer` over newline-delimited
+  JSON / TCP. Live job board (progress, state, current file) and Pause / Play /
+  Stop commands. Optional TLS via self-signed certificate + TOFU
+  `known_hosts`. Multi-console broadcast (`CommandReceived` event audits
+  which console issued which command). Auto-reconnect 1 s → 2 s → 5 s → 10 s.
+- **Thread-safe `IStateRepository`** (`StateTracker`): atomic per-job updates
+  for the concurrent V3 multi-job runs; `state.json` no longer corrupts under
+  parallel writes.
+- **`StateEntry.FailedFilesCount`**: surfaces the number of files that failed
+  during a job so the GUI / state.json reflect a partial-success outcome
+  instead of presenting an all-or-nothing result.
+- **`EasyLog` v1.2 fields** (additive, all nullable): `MachineName`,
+  `UserName`, and `EventType` (`LogEvent` enum covering V3 events —
+  `RemoteConsoleConnected`, `ParallelJobStarted`, `BigFileEnqueued`,
+  `JobPaused`, `BusinessSoftwareAutoPaused`, etc.). Omitted from output when
+  null so v1 / v2 consumers see the same JSON / XML shape they always have.
+- **V3 settings** in `appsettings.json`: `max_parallel_jobs`,
+  `large_file_threshold_kb`, `priority_extensions`, `log_mode`,
+  `log_centralizer_url`, `remote_console_enabled`, `remote_console_port`,
+  `remote_console_tls`.
+
+### Changed
+
+- `JsonDailyLogger` switches to a single-writer **`Channel<T>`** consumer.
+  Concurrent `Append` calls from N parallel jobs no longer trigger N file
+  rewrites — the writer batches them and writes once per drain (4 jobs ×
+  1000 entries = a handful of writes instead of 4000). `Append` stays
+  synchronous and durable: it blocks until the entry is on disk.
+- `XmlDailyLogger` adopts the same `LogRouter.Normalize` helper as the JSON
+  writer for host-field stamping, so both formats produce identical
+  `MachineName` / `UserName` semantics.
+- `BackupManagerAdapter.PauseJob` and `ResumeJob` route through the new
+  `IJobController` contract; `JobsViewModel.PauseJob` calls both the adapter
+  and the orchestrator so Run-All-launched jobs honor the manual Pause / Stop
+  buttons.
+- Sidebar version label promoted from `v2.0` to `v3.0`.
+- `CryptoSoft` CLI exits with a documented error code when the mono-instance
+  mutex is already held — callers retry transparently within
+  `crypto_soft.timeout_ms`.
+
+### Fixed
+
+- **`JsonDailyLogger.ReadExisting`** survives a transient `IOException` on
+  the day file (writer-task no longer dies, closes #155).
+- **`TcpRemoteConsoleServer`** clean-up race on brutal client disconnect:
+  the connection state is published exactly once even when `BroadcastAsync`
+  and the client `HandleClient` finally block race.
+- **`TcpRemoteConsoleClient.ConnectAsync`** publishes the `Error` state when
+  the initial connect throws — the UI no longer shows "connecting…" forever.
+- **Read-line guard** in the remote protocol caps inbound payloads at 64 KB
+  to prevent OOM on a hostile / malformed client.
+- **State cache** (`StateTracker`) clears `_cacheDirty` after a successful
+  write and guards the timer callback against re-entrancy on Dispose.
+- **LogCentralizer Docker image** runs as a non-root user with correct write
+  permissions on the mounted journal volume.
+- **HttpLogShipper** order-preserving retry: entries published in order A, B,
+  C arrive in order A, B, C even when A's first POST fails and is retried.
+
+### Documentation
+
+- V3 UML diagrams (`docs/diagrams/`): Class · Activity · Deployment ·
+  Sequence (Parallel + BigFileGate) · Sequence (Play-Pause-Stop) ·
+  Sequence (Remote Console).
+- V3 acceptance recettes (`docs/recettes/`): parallelism, pause / resume on
+  Run All, priority extensions, business-software auto-pause, CryptoSoft
+  mono-instance, remote console, backward compatibility with v1 / v2.
+- V3 user manual (one page) generated by `docs/generate-manuel.js` —
+  sections updated to cover parallelism, priority files, big-file gate,
+  pause / play / stop, business-software auto-pause, CryptoSoft mono-instance,
+  log centralization, JSON / XML format switch.
+- `docs/v3-log-centralizer-admin.md` — administrator handbook for the Docker
+  centralizer (deployment, retention, troubleshooting).
+- `docs/v3-remote-console-tls.md` — TLS configuration handbook.
+- `src/EasySave/Services/README.md` — taxonomy of the five concurrency
+  primitives used in V3 (`Channel<T>`, `SemaphoreSlim`, named `Mutex`,
+  `ManualResetEventSlim`, `CancellationTokenSource`) and when each applies.
+
+### Tests
+
+- `ParallelBackupOrchestratorTests`: deterministic concurrency tests on the
+  `max_parallel_jobs` cap, Pause / Resume / Stop isolation, and faulted-job
+  containment.
+- `BigFileGateTests`, `PriorityGateTests`: semaphore-N=1 contract and
+  cross-job priority ordering.
+- `TcpRemoteConsoleServerTests`: brutal-disconnect cleanup and the
+  `BroadcastAsync` / `HandleClient` finally race.
+- `HttpLogShipperTests`: retry order, zero-loss, throughput.
+- `LogCentralizerE2ETests`: Testcontainers end-to-end round-trip of a
+  `LogEntry` from the shipper to the centralized daily file.
+- `StateTrackerConcurrencyTests`: N-writer race on `state.json`.
+- `ChannelEventBusTests`: faulted-handler isolation between subscribers.
+
+[3.0.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v2.1.0...v3.0.0
+
 ## [2.1.0] — 2026-05-05
 
 Maintenance release on `release/v2.x` rolling up the fixes and small UX
@@ -144,7 +284,7 @@ the v1.x console and `EasyLog.dll` contracts fully intact.
   as paused — the job now stops at the next file boundary (no partial writes).
 - Resuming a paused Full-backup job no longer re-copies already-transferred files.
 
-[Unreleased]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v3.0.0...HEAD
 [2.1.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v1.0.1...v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ stay frozen for existing consumers.
   fleet, demultiplexed by the new `MachineName` / `UserName` fields.
 - **`LogMode` routing** (`Local` / `Centralized` / `Both`): `JsonDailyLogger`
   and `XmlDailyLogger` accept an `ILogShipper`; `HttpLogShipper` posts to
-  `log_centralizer_url` with retry + bounded buffer. Local writes preserved
+  `log_centralized_endpoint` with retry + bounded buffer. Local writes preserved
   in `Both` mode, dropped in `Centralized`.
 - **Remote operator console** (`EasySave.RemoteConsole`): standalone Avalonia
   client that connects to `TcpRemoteConsoleServer` over newline-delimited
@@ -70,8 +70,8 @@ stay frozen for existing consumers.
   null so v1 / v2 consumers see the same JSON / XML shape they always have.
 - **V3 settings** in `appsettings.json`: `max_parallel_jobs`,
   `large_file_threshold_kb`, `priority_extensions`, `log_mode`,
-  `log_centralizer_url`, `remote_console_enabled`, `remote_console_port`,
-  `remote_console_tls`.
+  `log_centralized_endpoint`, `remote_console_enabled`, `remote_console_port`,
+  `remote_console_tls_enabled`.
 
 ### Changed
 
@@ -143,8 +143,6 @@ stay frozen for existing consumers.
   `LogEntry` from the shipper to the centralized daily file.
 - `StateTrackerConcurrencyTests`: N-writer race on `state.json`.
 - `ChannelEventBusTests`: faulted-handler isolation between subscribers.
-
-[3.0.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v2.1.0...v3.0.0
 
 ## [2.1.0] — 2026-05-05
 
@@ -285,6 +283,7 @@ the v1.x console and `EasyLog.dll` contracts fully intact.
 - Resuming a paused Full-backup job no longer re-copies already-transferred files.
 
 [Unreleased]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/JulianKerignard/Genie_Logiciel_Groupe4/compare/v1.0.1...v2.0.0
 

--- a/docs/sections/section1.js
+++ b/docs/sections/section1.js
@@ -4,26 +4,19 @@ const { h1, body, bullet } = require("../helpers");
 
 module.exports = function section1() {
   return [
-    h1("1. Introduction"),
+    h1("1. Présentation"),
     body(
-      "EasySave est un outil de sauvegarde de fichiers ProSoft (.NET 8). " +
-      "Il permet de définir jusqu'à 5 tâches de sauvegarde (jobs) et de les exécuter " +
-      "vers des destinations locales, externes ou réseau."
+      "EasySave V3.0 est l'outil de sauvegarde ProSoft (.NET 8). Interface graphique " +
+      "Avalonia (FR / EN), nombre de jobs illimité, types Complète ou Différentielle, " +
+      "sources et cibles locales / externes / réseau."
     ),
-    body("Prérequis : .NET 8 Runtime · Systèmes : Windows, macOS, Linux."),
-    body("Nouveautés V3 :"),
-    bullet(
-      "Parallélisme : plusieurs jobs s'exécutent simultanément " +
-      "(max_parallel_jobs, défaut 4) ; erreurs isolées par job."
-    ),
-    bullet(
-      "BigFileGate : les fichiers dont la taille est >= large_file_threshold_kb " +
-      "(défaut 4 096 Ko) passent par un sémaphore N=1 — un seul gros transfert actif " +
-      "à la fois. Les petits fichiers ne sont pas concernés."
-    ),
-    bullet(
-      "Console déportée TCP (port 9000 par défaut) : supervision et contrôle " +
-      "des jobs à distance via une application Avalonia autonome."
-    ),
+    body("Nouveautés V3 par rapport à la V2 :"),
+    bullet("Sauvegardes parallèles (le mode séquentiel est abandonné)."),
+    bullet("Fichiers prioritaires : aucun fichier non prioritaire ne démarre tant qu'une extension prioritaire est en attente sur un job."),
+    bullet("Gros fichiers : un seul transfert > seuil paramétrable à la fois (anti-saturation bande passante)."),
+    bullet("Pause / Play / Stop par job ou en masse, en local ou depuis la console déportée."),
+    bullet("Pause auto si logiciel métier détecté ; reprise auto à sa fermeture."),
+    bullet("CryptoSoft mono-instance (une seule exécution simultanée sur la machine)."),
+    bullet("Centralisation des journaux via service Docker (mode Local, Centralisé ou Both)."),
   ];
 };

--- a/docs/sections/section2.js
+++ b/docs/sections/section2.js
@@ -5,17 +5,12 @@ const { h1, body, bullet, code } = require("../helpers");
 module.exports = function section2() {
   return [
     h1("2. Installation et lancement"),
-    body("Application principale — lancer depuis la racine du projet :"),
-    code("cd src/EasySave && dotnet run"),
-    body(
-      "Sans argument : menu interactif. " +
-      "Avec argument : exécution directe des jobs sélectionnés (indices base 1)."
-    ),
-    code("dotnet run -- 1        # job 1"),
-    code("dotnet run -- 1-3      # jobs 1, 2, 3"),
-    code("dotnet run -- 1;3;5    # jobs 1, 3, 5"),
-    body("Fichiers de données (jobs.json · state.json · Logs/) :"),
-    bullet("Windows  : %AppData%\\ProSoft\\EasySave\\"),
-    bullet("Linux/macOS : ~/.config/ProSoft/EasySave/"),
+    body("Interface graphique (mode nominal) :"),
+    code("cd src/EasySave.UI && dotnet run"),
+    body("Console déportée (poste opérateur distant) :"),
+    code("cd EasySave.RemoteConsole && dotnet run"),
+    body("Données utilisateur (jobs.json · state.json · Logs/) :"),
+    bullet("Windows : %AppData%\\ProSoft\\EasySave\\"),
+    bullet("Linux / macOS : ~/.config/ProSoft/EasySave/"),
   ];
 };

--- a/docs/sections/section3.js
+++ b/docs/sections/section3.js
@@ -4,23 +4,17 @@ const { h1, body, bullet } = require("../helpers");
 
 module.exports = function section3() {
   return [
-    h1("3. Gestion des jobs"),
-    body("Maximum 5 jobs. Types : Full (copie totale récursive) · Differential (nouveaux fichiers ou modifiés uniquement)."),
-    body("Menu interactif :"),
-    bullet("1 — Créer un job : nom (unique, insensible à la casse), source, destination, type"),
-    bullet("2 — Supprimer un job"),
-    bullet("3 — Lister les jobs"),
-    bullet("4 — Exécuter un ou plusieurs jobs"),
-    bullet("5 — Changer la langue (en / fr)"),
+    h1("3. Sauvegardes"),
     body(
-      "Parallélisme : les jobs sélectionnés s'exécutent en parallèle dans la limite de " +
-      "max_parallel_jobs (défaut 4). Une erreur dans un job n'interrompt pas les autres."
+      "Onglet Jobs : créer / éditer / supprimer un job (nom unique, source, destination, " +
+      "type Complète ou Différentielle). Boutons Run par job ou Run All en masse. Chaque " +
+      "card affiche un badge d'état (Idle / Running / Paused / Done), une barre de " +
+      "progression et le fichier en cours."
     ),
-    body(
-      "BigFileGate : les fichiers dont la taille est >= large_file_threshold_kb " +
-      "(défaut 4 096 Ko) sont soumis à un sémaphore N=1 — un seul gros fichier est " +
-      "transféré à la fois sur l'ensemble des jobs. Les petits fichiers sont traités " +
-      "en parallèle sans restriction."
-    ),
+    bullet("Parallélisme : max_parallel_jobs (défaut 4) ; une erreur n'interrompt pas les autres."),
+    bullet("Prioritaires : tant qu'une extension de priority_extensions reste à copier sur un job, les fichiers non prioritaires des autres jobs attendent."),
+    bullet("Gros fichiers : les fichiers >= large_file_threshold_kb traversent un sémaphore N=1 commun à tous les jobs ; les petits fichiers passent en parallèle sans restriction."),
+    bullet("Pause (au prochain fichier) · Play (reprise depuis l'offset courant) · Stop (annulation immédiate) sur chaque card et globalement."),
+    bullet("Logiciel métier : si business_software est détecté, tous les jobs en cours passent automatiquement en pause ; reprise auto dès qu'il est fermé. L'événement est consigné dans le journal."),
   ];
 };

--- a/docs/sections/section4.js
+++ b/docs/sections/section4.js
@@ -1,22 +1,22 @@
 "use strict";
 
-const { h1, body, bullet, code } = require("../helpers");
+const { h1, body, bullet } = require("../helpers");
 
 module.exports = function section4() {
   return [
-    h1("4. Console déportée (EasySave.RemoteConsole)"),
+    h1("4. Console déportée et journaux"),
     body(
-      "Application Avalonia autonome. Se connecte à EasySave via TCP pour afficher " +
-      "en temps réel la progression de chaque job et envoyer des commandes à distance."
+      "EasySave.RemoteConsole se connecte à EasySave en TCP (Host + Port). Elle affiche " +
+      "en temps réel l'état de tous les jobs et envoie les commandes Pause / Play / Stop. " +
+      "Reconnexion automatique (1 s → 2 s → 5 s → 10 s). TLS optionnel via " +
+      "remote_console_tls."
     ),
-    body("Activation côté serveur : définir remote_console_enabled: true dans appsettings.json."),
-    body("Lancement :"),
-    code("cd EasySave.RemoteConsole && dotnet run"),
-    body("Interface :"),
-    bullet("Barre de connexion : champs Host (défaut 127.0.0.1) et Port (défaut 9000), boutons Connexion / Déconnexion, indicateur d'état."),
-    bullet("Liste des jobs : nom · barre de progression · statut (Running / Paused / Done) · boutons Pause, Play, Stop."),
-    body("Connexion : saisir l'IP de la machine hébergeant EasySave, vérifier le port, cliquer Connexion."),
-    body("Commandes : Pause (suspend au prochain fichier) · Play (reprend ou démarre) · Stop (annule)."),
-    body("Reconnexion automatique en cas de coupure : 1 s → 2 s → 5 s → 10 s (boucle)."),
+    body(
+      "Journaux : un fichier par jour (yyyy-MM-dd.json ou .xml) ; format paramétrable. " +
+      "Le mode log_mode contrôle la destination :"
+    ),
+    bullet("Local : journaux uniquement sur le poste de l'utilisateur (défaut)."),
+    bullet("Centralized : envoi HTTP au service Docker LogCentralizer ; journal unique pour toute la flotte (différentiation par MachineName + UserName)."),
+    bullet("Both : écriture locale ET envoi au centralisateur."),
   ];
 };

--- a/docs/sections/section4.js
+++ b/docs/sections/section4.js
@@ -9,7 +9,7 @@ module.exports = function section4() {
       "EasySave.RemoteConsole se connecte à EasySave en TCP (Host + Port). Elle affiche " +
       "en temps réel l'état de tous les jobs et envoie les commandes Pause / Play / Stop. " +
       "Reconnexion automatique (1 s → 2 s → 5 s → 10 s). TLS optionnel via " +
-      "remote_console_tls."
+      "remote_console_tls_enabled."
     ),
     body(
       "Journaux : un fichier par jour (yyyy-MM-dd.json ou .xml) ; format paramétrable. " +

--- a/docs/sections/section5.js
+++ b/docs/sections/section5.js
@@ -3,18 +3,20 @@
 const { h1, body, empty, configTable } = require("../helpers");
 
 const CONFIG_ROWS = [
-  ["language",                "string",   "\"en\"",          "Langue de l'interface : \"en\" ou \"fr\"."],
-  ["log_format",              "string",   "\"json\"",        "Format des journaux : \"json\" ou \"xml\"."],
-  ["log_mode",                "string",   "\"Local\"",       "Routage des journaux : Local · Centralized · Both."],
-  ["log_centralizer_url",     "string",   "\"\"",            "URL du service Docker LogCentralizer (modes Centralized / Both)."],
-  ["encrypted_extensions",    "string[]", "[]",              "Extensions chiffrées via CryptoSoft (ex. [\".pdf\", \".docx\"])."],
-  ["priority_extensions",     "string[]", "[]",              "Extensions prioritaires (copiées avant tout fichier non prioritaire)."],
-  ["business_software",       "string[]", "[]",              "Exécutables métier : pause auto des jobs si l'un est lancé."],
-  ["crypto_soft.path",        "string",   "\"\"",            "Chemin vers CryptoSoft (mono-instance). Vide = pas de chiffrement."],
-  ["large_file_threshold_kb", "int",      "4096",            "Seuil (Ko) au-delà duquel les fichiers passent par le sémaphore N=1."],
-  ["max_parallel_jobs",       "int",      "4",               "Nombre max de jobs s'exécutant en parallèle."],
-  ["remote_console_enabled",  "bool",     "false",           "Active le serveur TCP de la console déportée."],
-  ["remote_console_port",     "int",      "9000",            "Port TCP du serveur de console déportée."],
+  ["language",                  "string",   "\"en\"",    "Langue de l'interface : \"en\" ou \"fr\"."],
+  ["log_format",                "string",   "\"json\"",  "Format des journaux : \"json\" ou \"xml\"."],
+  ["log_mode",                  "string",   "\"Local\"", "Routage des journaux : Local · Centralized · Both."],
+  ["log_centralized_endpoint",  "string",   "\"\"",      "URL du service Docker LogCentralizer (modes Centralized / Both)."],
+  ["encrypted_extensions",      "string[]", "[]",        "Extensions chiffrées via CryptoSoft (ex. [\".pdf\", \".docx\"])."],
+  ["priority_extensions",       "string[]", "[]",        "Extensions prioritaires (copiées avant tout fichier non prioritaire)."],
+  ["business_software",         "string[]", "[]",        "Exécutables métier : pause auto des jobs si l'un est lancé."],
+  ["crypto_soft.path",          "string",   "\"\"",      "Chemin vers CryptoSoft (mono-instance). Vide = pas de chiffrement."],
+  ["crypto_soft.timeout_ms",    "int",      "30000",     "Délai max (ms) avant kill du processus CryptoSoft sur un fichier."],
+  ["large_file_threshold_kb",   "int",      "4096",      "Seuil (Ko) au-delà duquel les fichiers passent par le sémaphore N=1."],
+  ["max_parallel_jobs",         "int",      "4",         "Nombre max de jobs s'exécutant en parallèle."],
+  ["remote_console_enabled",    "bool",     "false",     "Active le serveur TCP de la console déportée."],
+  ["remote_console_port",       "int",      "9000",      "Port TCP du serveur de console déportée."],
+  ["remote_console_tls_enabled","bool",     "false",     "Wrappe le socket de la console déportée dans TLS (cert auto-signé)."],
 ];
 
 module.exports = function section5() {

--- a/docs/sections/section5.js
+++ b/docs/sections/section5.js
@@ -3,25 +3,25 @@
 const { h1, body, empty, configTable } = require("../helpers");
 
 const CONFIG_ROWS = [
-  ["language",                "string",   "\"en\"",   "Langue de l'interface : \"en\" (anglais) ou \"fr\" (français)."],
-  ["encrypted_extensions",    "string[]", "[]",       "Extensions chiffrées via CryptoSoft lors de la copie (ex. [\".pdf\"])."],
-  ["business_software",       "string[]", "[]",       "Exécutables métier : les jobs sont mis en pause automatiquement s'ils sont actifs."],
-  ["log_format",              "string",   "\"json\"", "Format des journaux de transfert. Valeur : \"json\"."],
-  ["crypto_soft.path",        "string",   "\"\"",     "Chemin vers CryptoSoft. Laisser vide pour désactiver le chiffrement."],
-  ["crypto_soft.timeout_ms",  "int",      "30000",    "Délai max pour une opération CryptoSoft (ms)."],
-  ["large_file_threshold_kb", "int",      "4096",     "Seuil BigFileGate (Ko). Fichiers >= seuil → sémaphore N=1."],
-  ["remote_console_enabled",  "bool",     "false",    "Active le serveur TCP de la console déportée."],
-  ["remote_console_port",     "int",      "9000",     "Port TCP d'écoute du serveur de console déportée."],
-  ["max_parallel_jobs",       "int",      "4",        "Nombre max de jobs s'exécutant en parallèle."],
+  ["language",                "string",   "\"en\"",          "Langue de l'interface : \"en\" ou \"fr\"."],
+  ["log_format",              "string",   "\"json\"",        "Format des journaux : \"json\" ou \"xml\"."],
+  ["log_mode",                "string",   "\"Local\"",       "Routage des journaux : Local · Centralized · Both."],
+  ["log_centralizer_url",     "string",   "\"\"",            "URL du service Docker LogCentralizer (modes Centralized / Both)."],
+  ["encrypted_extensions",    "string[]", "[]",              "Extensions chiffrées via CryptoSoft (ex. [\".pdf\", \".docx\"])."],
+  ["priority_extensions",     "string[]", "[]",              "Extensions prioritaires (copiées avant tout fichier non prioritaire)."],
+  ["business_software",       "string[]", "[]",              "Exécutables métier : pause auto des jobs si l'un est lancé."],
+  ["crypto_soft.path",        "string",   "\"\"",            "Chemin vers CryptoSoft (mono-instance). Vide = pas de chiffrement."],
+  ["large_file_threshold_kb", "int",      "4096",            "Seuil (Ko) au-delà duquel les fichiers passent par le sémaphore N=1."],
+  ["max_parallel_jobs",       "int",      "4",               "Nombre max de jobs s'exécutant en parallèle."],
+  ["remote_console_enabled",  "bool",     "false",           "Active le serveur TCP de la console déportée."],
+  ["remote_console_port",     "int",      "9000",            "Port TCP du serveur de console déportée."],
 ];
 
 module.exports = function section5() {
   return [
     h1("5. Configuration (appsettings.json)"),
-    body("Fichier : src/EasySave/appsettings.json. Relancez l'application après modification."),
+    body("Fichier : src/EasySave/appsettings.json. Redémarrer l'application après modification."),
     empty(),
     configTable(CONFIG_ROWS),
-    empty(),
-    body("La langue peut aussi être changée à chaud via l'option 5 du menu interactif."),
   ];
 };

--- a/docs/sections/section6.js
+++ b/docs/sections/section6.js
@@ -5,22 +5,9 @@ const { h1, bullet } = require("../helpers");
 module.exports = function section6() {
   return [
     h1("6. Dépannage"),
-    bullet(
-      "Console non connectée : vérifier qu'EasySave est lancé avec " +
-      "remote_console_enabled: true, que le port est identique des deux côtés " +
-      "et que le pare-feu autorise le trafic TCP sur ce port."
-    ),
-    bullet(
-      "Job bloqué en Pause : cliquer Play depuis la console déportée, " +
-      "ou redémarrer EasySave."
-    ),
-    bullet(
-      "Erreur au démarrage : vérifier .NET 8 (dotnet --version) " +
-      "et la validité du JSON dans appsettings.json."
-    ),
-    bullet(
-      "Fichiers de log absents : vérifier les droits d'écriture " +
-      "sur le répertoire de données utilisateur (§2)."
-    ),
+    bullet("Console déportée injoignable : vérifier remote_console_enabled, le port identique des deux côtés et l'autorisation TCP du pare-feu."),
+    bullet("Job bloqué en Pause : cliquer Play depuis la card ou la console déportée ; vérifier qu'aucun logiciel métier n'est lancé."),
+    bullet("Journaux centralisés vides : vérifier log_centralizer_url et que le conteneur Docker LogCentralizer est démarré."),
+    bullet("Erreur au démarrage : vérifier .NET 8 (dotnet --version) et la validité du JSON dans appsettings.json."),
   ];
 };


### PR DESCRIPTION
## Summary

Two V3 livrables prepared for the soutenance:

1. **Release notes** — new `[3.0.0] — 2026-05-13` section in `CHANGELOG.md` covering every cahier-V3 feature (parallel engine, big-file gate, priority extensions, pause / play / stop, business-software auto-pause, CryptoSoft mono-instance, log centralizer + `LogMode` routing, remote console, `EasyLog` v1.2 additive fields, state-tracker concurrency) plus the V3 doc and test deliverables.
2. **One-page user manual** — `docs/sections/*.js` rewritten to match the V3 cahier within the one-page constraint (GUI is primary, unlimited jobs, priority extensions, big-file gate, business-software auto-pause + auto-resume, CryptoSoft mono-instance, JSON / XML logs, log centralizer modes Local / Centralized / Both). Regenerated locally via `node docs/generate-manuel.js` → `docs/ManuelUtilisateur_EasySave_V3.docx` (gitignored by design — script is the source of truth).

The `[Unreleased]` compare link now points to `v3.0.0...HEAD` so the next maintenance entries land after V3.

## Test plan

- [ ] `node docs/generate-manuel.js` generates `ManuelUtilisateur_EasySave_V3.docx` without error.
- [ ] The generated docx fits on a single A4 page.
- [ ] Open the `[3.0.0]` section in `CHANGELOG.md` and skim: every cahier-V3 feature is mentioned at least once under Added / Changed / Tests / Documentation.
- [ ] No `EasyLog.dll` v1.0 contract drift — additive fields only.