### PR TITLE
chore(ui): bump sidebar version label to v3.0

### DIFF
--- a/src/EasySave.UI/Assets/i18n/en.json
+++ b/src/EasySave.UI/Assets/i18n/en.json
@@ -31,7 +31,7 @@
   "settings.saved": "Settings saved.",
   "settings.save_failed": "Could not save settings. Check disk access and try again.",
   "about.title": "About",
-  "about.version": "Version 2.0.0",
+  "about.version": "Version 3.0.0",
   "about.authors": "Authors: EasySave Team — CESI PGE A3 FISE INFO",
   "about.description": "Backup software developed as part of the software engineering project.",
   "edit.title_create": "New Backup Job",

--- a/src/EasySave.UI/Assets/i18n/fr.json
+++ b/src/EasySave.UI/Assets/i18n/fr.json
@@ -31,7 +31,7 @@
   "settings.saved": "Paramètres enregistrés.",
   "settings.save_failed": "Impossible d'enregistrer les paramètres. Vérifiez l'accès au disque et réessayez.",
   "about.title": "À propos",
-  "about.version": "Version 2.0.0",
+  "about.version": "Version 3.0.0",
   "about.authors": "Auteurs : Équipe EasySave — CESI PGE A3 FISE INFO",
   "about.description": "Logiciel de sauvegarde développé dans le cadre du projet de génie logiciel.",
   "edit.title_create": "Nouvelle sauvegarde",

--- a/src/EasySave.UI/Views/MainWindow.axaml
+++ b/src/EasySave.UI/Views/MainWindow.axaml
@@ -30,7 +30,7 @@
                                    Foreground="White"
                                    FontSize="20"
                                    FontWeight="SemiBold" />
-                        <TextBlock Text="v3.0"
+                        <TextBlock Text="{markup:T Key=about.version}"
                                    Foreground="#6B7280"
                                    FontSize="12" />
                     </StackPanel>

--- a/src/EasySave.UI/Views/MainWindow.axaml
+++ b/src/EasySave.UI/Views/MainWindow.axaml
@@ -30,7 +30,7 @@
                                    Foreground="White"
                                    FontSize="20"
                                    FontWeight="SemiBold" />
-                        <TextBlock Text="v2.0"
+                        <TextBlock Text="v3.0"
                                    Foreground="#6B7280"
                                    FontSize="12" />
                     </StackPanel>


### PR DESCRIPTION
## Summary

- Sidebar in `MainWindow.axaml:33` was still hard-coded to `v2.0`. Bump to `v3.0` to match the released cycle.

## Test plan

- [ ] Launch `EasySave.UI`, confirm the sidebar shows `v3.0` under the EasySave title.