### PR TITLE
fix(ui): route business-watcher pause/resume through orchestrator

### DIFF
--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -12,7 +12,7 @@ namespace EasySave.UI.ViewModels;
 public sealed partial class JobsViewModel : ViewModelBase
 {
     private readonly IBackupManagerAdapter _backup;
-    private readonly BusinessWatcherService _watcher;
+    private readonly IBusinessSoftwareSignals _watcher;
     // V3 parallel orchestrator. Used by RunAllAsync to launch jobs in
     // parallel bounded by max_parallel_jobs. Single-job Run/Pause/Resume
     // still goes through _backup (the adapter) — Pause/Resume routes to
@@ -20,6 +20,10 @@ public sealed partial class JobsViewModel : ViewModelBase
     private readonly IParallelBackupOrchestrator? _orchestrator;
     // Tracks jobs paused by the watcher (distinct from user-initiated pauses).
     private readonly HashSet<string> _watcherPausedJobs = new();
+    // Subset of _watcherPausedJobs: jobs stopped via the orchestrator (Run All
+    // path). Needed to route the resume back through orchestrator.RunAsync
+    // instead of _backup.ResumeJob, which is a no-op for orchestrator-tracked jobs.
+    private readonly HashSet<string> _watcherOrchestratorStoppedJobs = new();
 
     // Set by MainWindowViewModel after construction.
     public Action<BackupJob?>? RequestOpenJobEdit { get; set; }
@@ -35,7 +39,7 @@ public sealed partial class JobsViewModel : ViewModelBase
 
     public JobsViewModel(
         IBackupManagerAdapter backup,
-        BusinessWatcherService watcher,
+        IBusinessSoftwareSignals watcher,
         IParallelBackupOrchestrator? orchestrator = null)
     {
         _backup = backup;
@@ -46,7 +50,6 @@ public sealed partial class JobsViewModel : ViewModelBase
         _backup.StateUpdated += OnStateUpdated;
         _watcher.BusinessSoftwareDetected += OnBusinessSoftwareDetected;
         _watcher.BusinessSoftwareGone += OnBusinessSoftwareGone;
-        _watcher.Start();
     }
 
     private void LoadJobs()
@@ -116,20 +119,66 @@ public sealed partial class JobsViewModel : ViewModelBase
             _watcherPausedJobs.Add(job.Name);
             job.UiState = UiJobState.Paused;
             _backup.PauseJob(job.Name, $"BusinessSoftwareDetected: {name}");
+            // Mirror the wiring already in place for the manual Pause button:
+            // jobs launched by Run All are tracked in the orchestrator, not in
+            // the adapter, so PauseJob above is a no-op for them. Stop() cancels
+            // the per-job CTS and halts the worker at the next file boundary.
+            if (_orchestrator is not null)
+            {
+                _orchestrator.Stop(job.Name);
+                _watcherOrchestratorStoppedJobs.Add(job.Name);
+            }
         }
     }
 
-    private void OnBusinessSoftwareGone(object? sender, EventArgs _)
+    private void OnBusinessSoftwareGone(object? sender, EventArgs e)
     {
         IsBusinessSoftwareDetected = false;
         DetectedSoftwareName = string.Empty;
         // Only resume jobs that the watcher itself paused; leave user-paused jobs alone.
-        foreach (var job in Jobs.Where(j => j.UiState == UiJobState.Paused
-                                         && _watcherPausedJobs.Contains(j.Name)).ToList())
+        var toResume = Jobs
+            .Where(j => j.UiState == UiJobState.Paused && _watcherPausedJobs.Contains(j.Name))
+            .ToList();
+        var orchestratorRestart = toResume
+            .Where(j => _watcherOrchestratorStoppedJobs.Contains(j.Name))
+            .Select(j => j.Name)
+            .ToList();
+        foreach (var job in toResume)
         {
             _watcherPausedJobs.Remove(job.Name);
+            _watcherOrchestratorStoppedJobs.Remove(job.Name);
             job.UiState = UiJobState.Running;
+            // Resumes adapter-tracked jobs (single-run path); no-op for orchestrator-tracked.
             _backup.ResumeJob(job.Name);
+        }
+        // Orchestrator-tracked jobs were stopped (one-way). Restart them.
+        // Limitation: restarts from the beginning of the job (resumeAfterPath is
+        // not propagated by BackupManagerJobRunner in this iteration — see PR #180).
+        if (orchestratorRestart.Count > 0)
+            _ = RunWatcherOrchestratorJobsAsync(orchestratorRestart);
+    }
+
+    private async Task RunWatcherOrchestratorJobsAsync(IReadOnlyList<string> jobNames)
+    {
+        try
+        {
+            await _orchestrator!.RunAsync(jobNames, CancellationToken.None).ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = ex.Message;
+        }
+        finally
+        {
+            foreach (var name in jobNames)
+            {
+                var vm = Jobs.FirstOrDefault(j => j.Name == name);
+                if (vm?.UiState == UiJobState.Running)
+                {
+                    vm.UiState = UiJobState.Idle;
+                    vm.Progress = 0;
+                }
+            }
         }
     }
 

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -24,6 +24,11 @@ public sealed partial class JobsViewModel : ViewModelBase
     // path). Needed to route the resume back through orchestrator.RunAsync
     // instead of _backup.ResumeJob, which is a no-op for orchestrator-tracked jobs.
     private readonly HashSet<string> _watcherOrchestratorStoppedJobs = new();
+    // Names currently executing inside the orchestrator (added at RunAllAsync start,
+    // removed in its finally). Used by OnBusinessSoftwareDetected to distinguish
+    // orchestrator-tracked from adapter-tracked jobs — only the former must be
+    // recorded in _watcherOrchestratorStoppedJobs to avoid double-starting.
+    private readonly HashSet<string> _orchestratorTrackedJobs = new();
 
     // Set by MainWindowViewModel after construction.
     public Action<BackupJob?>? RequestOpenJobEdit { get; set; }
@@ -104,6 +109,7 @@ public sealed partial class JobsViewModel : ViewModelBase
                     ? UiJobState.Completed
                     : UiJobState.Idle;
                 _watcherPausedJobs.Remove(vm.Name);
+                _watcherOrchestratorStoppedJobs.Remove(vm.Name);
             }
         });
     }
@@ -126,12 +132,13 @@ public sealed partial class JobsViewModel : ViewModelBase
             if (_orchestrator is not null)
             {
                 _orchestrator.Stop(job.Name);
-                _watcherOrchestratorStoppedJobs.Add(job.Name);
+                if (_orchestratorTrackedJobs.Contains(job.Name))
+                    _watcherOrchestratorStoppedJobs.Add(job.Name);
             }
         }
     }
 
-    private void OnBusinessSoftwareGone(object? sender, EventArgs e)
+    private void OnBusinessSoftwareGone(object? sender, EventArgs _)
     {
         IsBusinessSoftwareDetected = false;
         DetectedSoftwareName = string.Empty;
@@ -154,8 +161,11 @@ public sealed partial class JobsViewModel : ViewModelBase
         // Orchestrator-tracked jobs were stopped (one-way). Restart them.
         // Limitation: restarts from the beginning of the job (resumeAfterPath is
         // not propagated by BackupManagerJobRunner in this iteration — see PR #180).
+        // CS4014: intentional fire-and-forget; errors surface via StatusMessage.
         if (orchestratorRestart.Count > 0)
-            _ = RunWatcherOrchestratorJobsAsync(orchestratorRestart);
+#pragma warning disable CS4014
+            RunWatcherOrchestratorJobsAsync(orchestratorRestart);
+#pragma warning restore CS4014
     }
 
     private async Task RunWatcherOrchestratorJobsAsync(IReadOnlyList<string> jobNames)
@@ -264,6 +274,7 @@ public sealed partial class JobsViewModel : ViewModelBase
         // ViewModel) keeps the original Task.WhenAll loop via the adapter.
         if (_orchestrator is not null)
         {
+            foreach (var vm in eligible) _orchestratorTrackedJobs.Add(vm.Name);
             try
             {
                 await _orchestrator.RunAsync(
@@ -285,6 +296,7 @@ public sealed partial class JobsViewModel : ViewModelBase
                 // moved to Paused / Completed alone.
                 foreach (var vm in eligible)
                 {
+                    _orchestratorTrackedJobs.Remove(vm.Name);
                     if (vm.UiState == UiJobState.Running)
                     {
                         vm.UiState = UiJobState.Idle;

--- a/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/EasySave.UI/ViewModels/MainWindowViewModel.cs
@@ -117,6 +117,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         _jobsVm = new JobsViewModel(_backup, _watcher, _orchestrator);
         _jobsVm.RequestOpenJobEdit = job => ShowJobEdit(job);
         _jobsVm.RequestShowProgress = () => ShowRunProgress();
+        _watcher.Start();
         return _jobsVm;
     }
 }

--- a/tests/EasySave.Tests.V2/JobsViewModelWatcherIntegrationTests.cs
+++ b/tests/EasySave.Tests.V2/JobsViewModelWatcherIntegrationTests.cs
@@ -1,0 +1,153 @@
+using EasySave.Models;
+using EasySave.Services;
+using EasySave.Shared;
+using EasySave.UI.Services;
+using EasySave.UI.ViewModels;
+
+namespace EasySave.Tests.V2;
+
+public class JobsViewModelWatcherIntegrationTests
+{
+    // Triggers watcher appear/gone events synchronously without a real polling loop.
+    private sealed class StubSignals : IBusinessSoftwareSignals
+    {
+        public event EventHandler<string>? BusinessSoftwareDetected;
+        public event EventHandler? BusinessSoftwareGone;
+
+        public void RaiseDetected(string name) =>
+            BusinessSoftwareDetected?.Invoke(this, name);
+
+        public void RaiseGone() =>
+            BusinessSoftwareGone?.Invoke(this, EventArgs.Empty);
+    }
+
+    // Records PauseJob / ResumeJob calls; returns no jobs from GetJobs so
+    // LoadJobs leaves Jobs empty and tests can add VMs manually.
+    private sealed class RecordingAdapter : IBackupManagerAdapter
+    {
+        public List<string> PausedJobs { get; } = new();
+        public List<string> ResumedJobs { get; } = new();
+
+        public event EventHandler<StateEntry>? StateUpdated { add { } remove { } }
+
+        public IReadOnlyList<BackupJob> GetJobs() => Array.Empty<BackupJob>();
+        public void AddJob(BackupJob job) { }
+        public void RemoveJob(string name) { }
+        public Task RunJobAsync(string jobName, string? resumeAfterPath = null, CancellationToken ct = default)
+            => Task.CompletedTask;
+        public void PauseJob(string jobName, string reason = "UserRequested")
+            => PausedJobs.Add(jobName);
+        public void ResumeJob(string jobName) => ResumedJobs.Add(jobName);
+        public bool IsJobRunning(string jobName) => false;
+        public void Dispose() { }
+    }
+
+    // Records Stop calls and RunAsync invocations.
+    private sealed class RecordingOrchestrator : IParallelBackupOrchestrator
+    {
+        public List<string> StoppedJobs { get; } = new();
+        public List<IReadOnlyList<string>> RunAsyncCalls { get; } = new();
+
+        public event Action<JobProgressDto> ProgressChanged = static _ => { };
+
+        public Task<IReadOnlyList<JobResult>> RunAsync(IEnumerable<string> jobNames, CancellationToken ct)
+        {
+            RunAsyncCalls.Add(jobNames.ToList());
+            return Task.FromResult<IReadOnlyList<JobResult>>(Array.Empty<JobResult>());
+        }
+
+        public void Pause(string jobName) { }
+        public void Resume(string jobName) { }
+        public void Stop(string jobName) => StoppedJobs.Add(jobName);
+        public void PauseAll() { }
+        public void ResumeAll() { }
+        public void StopAll() { }
+        public void Dispose() { }
+    }
+
+    private static BackupJobVM MakeVm(string name, UiJobState state)
+    {
+        var vm = new BackupJobVM(new BackupJob { Name = name });
+        vm.UiState = state;
+        return vm;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OnBusinessSoftwareDetected_StopsRunAllJobsViaOrchestrator()
+    {
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new RecordingOrchestrator();
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        var job1 = MakeVm("Job1", UiJobState.Running);
+        var job2 = MakeVm("Job2", UiJobState.Running);
+        sut.Jobs.Add(job1);
+        sut.Jobs.Add(job2);
+
+        signals.RaiseDetected("calc");
+
+        Assert.Contains("Job1", orchestrator.StoppedJobs);
+        Assert.Contains("Job2", orchestrator.StoppedJobs);
+        Assert.Equal(UiJobState.Paused, job1.UiState);
+        Assert.Equal(UiJobState.Paused, job2.UiState);
+        // Adapter PauseJob is also called (covers single-run jobs on the same path).
+        Assert.Contains("Job1", adapter.PausedJobs);
+        Assert.Contains("Job2", adapter.PausedJobs);
+    }
+
+    [Fact]
+    public void OnBusinessSoftwareGone_ResumesPreviouslyPausedJobs()
+    {
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new RecordingOrchestrator();
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        var job1 = MakeVm("Job1", UiJobState.Running);
+        var job2 = MakeVm("Job2", UiJobState.Running);
+        sut.Jobs.Add(job1);
+        sut.Jobs.Add(job2);
+
+        // Detected registers them in _watcherPausedJobs + _watcherOrchestratorStoppedJobs.
+        signals.RaiseDetected("calc");
+        // Gone should restart them via the orchestrator.
+        signals.RaiseGone();
+
+        var restarted = Assert.Single(orchestrator.RunAsyncCalls);
+        Assert.Contains("Job1", restarted);
+        Assert.Contains("Job2", restarted);
+        // The fake orchestrator returns immediately so the finally block in
+        // RunWatcherOrchestratorJobsAsync resets the cards to Idle — that is
+        // correct end-state behaviour.  What matters here is that RunAsync
+        // was called with both job names (the restart was dispatched).
+        Assert.NotEqual(UiJobState.Paused, job1.UiState);
+        Assert.NotEqual(UiJobState.Paused, job2.UiState);
+    }
+
+    [Fact]
+    public void OnBusinessSoftwareDetected_DoesNotPauseUserPausedJobs()
+    {
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new RecordingOrchestrator();
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        var running = MakeVm("Job1", UiJobState.Running);
+        var userPaused = MakeVm("Job2", UiJobState.Paused);
+        sut.Jobs.Add(running);
+        sut.Jobs.Add(userPaused);
+
+        signals.RaiseDetected("calc");
+
+        // Only the Running job should be stopped.
+        Assert.Equal(new[] { "Job1" }, orchestrator.StoppedJobs);
+        Assert.Equal(UiJobState.Paused, running.UiState);
+        // User-paused job must not be touched.
+        Assert.DoesNotContain("Job2", orchestrator.StoppedJobs);
+        Assert.DoesNotContain("Job2", adapter.PausedJobs);
+        Assert.Equal(UiJobState.Paused, userPaused.UiState);
+    }
+}

--- a/tests/EasySave.Tests.V2/JobsViewModelWatcherIntegrationTests.cs
+++ b/tests/EasySave.Tests.V2/JobsViewModelWatcherIntegrationTests.cs
@@ -42,7 +42,7 @@ public class JobsViewModelWatcherIntegrationTests
         public void Dispose() { }
     }
 
-    // Records Stop calls and RunAsync invocations.
+    // Returns immediately — used for tests that only inspect Stop calls.
     private sealed class RecordingOrchestrator : IParallelBackupOrchestrator
     {
         public List<string> StoppedJobs { get; } = new();
@@ -59,6 +59,35 @@ public class JobsViewModelWatcherIntegrationTests
         public void Pause(string jobName) { }
         public void Resume(string jobName) { }
         public void Stop(string jobName) => StoppedJobs.Add(jobName);
+        public void PauseAll() { }
+        public void ResumeAll() { }
+        public void StopAll() { }
+        public void Dispose() { }
+    }
+
+    // Blocks RunAsync until the caller resolves the TCS, then immediately for
+    // any subsequent calls (TCS task is permanently complete after SetResult).
+    // Used to simulate a Run All that is in flight while the watcher fires.
+    private sealed class BlockingOrchestrator : IParallelBackupOrchestrator
+    {
+        private readonly Task<IReadOnlyList<JobResult>> _runResult;
+        public List<string> StoppedJobs { get; } = new();
+        public List<IReadOnlyList<string>> RunAsyncCalls { get; } = new();
+
+        public BlockingOrchestrator(Task<IReadOnlyList<JobResult>> runResult)
+            => _runResult = runResult;
+
+        public event Action<JobProgressDto> ProgressChanged = static _ => { };
+
+        public Task<IReadOnlyList<JobResult>> RunAsync(IEnumerable<string> jobNames, CancellationToken ct)
+        {
+            RunAsyncCalls.Add(jobNames.ToList());
+            return _runResult;
+        }
+
+        public void Stop(string jobName) => StoppedJobs.Add(jobName);
+        public void Pause(string jobName) { }
+        public void Resume(string jobName) { }
         public void PauseAll() { }
         public void ResumeAll() { }
         public void StopAll() { }
@@ -99,30 +128,43 @@ public class JobsViewModelWatcherIntegrationTests
     }
 
     [Fact]
-    public void OnBusinessSoftwareGone_ResumesPreviouslyPausedJobs()
+    public async Task OnBusinessSoftwareGone_ResumesPreviouslyPausedOrchestratorJobs()
     {
+        // Use a blocking orchestrator so that RunAllAsync is still in flight
+        // (and _orchestratorTrackedJobs is populated) when the watcher fires.
+        var tcs = new TaskCompletionSource<IReadOnlyList<JobResult>>();
         var signals = new StubSignals();
         var adapter = new RecordingAdapter();
-        var orchestrator = new RecordingOrchestrator();
+        var orchestrator = new BlockingOrchestrator(tcs.Task);
         var sut = new JobsViewModel(adapter, signals, orchestrator);
 
-        var job1 = MakeVm("Job1", UiJobState.Running);
-        var job2 = MakeVm("Job2", UiJobState.Running);
+        // Jobs start Idle so Run All picks them up.
+        var job1 = MakeVm("Job1", UiJobState.Idle);
+        var job2 = MakeVm("Job2", UiJobState.Idle);
         sut.Jobs.Add(job1);
         sut.Jobs.Add(job2);
 
-        // Detected registers them in _watcherPausedJobs + _watcherOrchestratorStoppedJobs.
+        // Run All executes synchronously up to "await _orchestrator.RunAsync()",
+        // registering Job1 and Job2 in _orchestratorTrackedJobs before yielding.
+        var runAll = sut.RunAllCommand.ExecuteAsync(null);
+
+        // While the orchestrator is blocking: fire the watcher.
         signals.RaiseDetected("calc");
-        // Gone should restart them via the orchestrator.
+
+        // Complete the orchestrator run so RunAll's finally clears _orchestratorTrackedJobs.
+        tcs.SetResult(Array.Empty<JobResult>());
+        await runAll;
+
+        // Gone: orchestrator-tracked jobs must be restarted via RunAsync.
         signals.RaiseGone();
 
-        var restarted = Assert.Single(orchestrator.RunAsyncCalls);
+        // Two RunAsync calls total: 1 for Run All, 1 for watcher restart.
+        Assert.Equal(2, orchestrator.RunAsyncCalls.Count);
+        var restarted = orchestrator.RunAsyncCalls[1];
         Assert.Contains("Job1", restarted);
         Assert.Contains("Job2", restarted);
-        // The fake orchestrator returns immediately so the finally block in
-        // RunWatcherOrchestratorJobsAsync resets the cards to Idle — that is
-        // correct end-state behaviour.  What matters here is that RunAsync
-        // was called with both job names (the restart was dispatched).
+        // Jobs are not Paused after the restart (either Running while the
+        // fake orchestrator runs, or Idle once it completes immediately).
         Assert.NotEqual(UiJobState.Paused, job1.UiState);
         Assert.NotEqual(UiJobState.Paused, job2.UiState);
     }
@@ -149,5 +191,31 @@ public class JobsViewModelWatcherIntegrationTests
         Assert.DoesNotContain("Job2", orchestrator.StoppedJobs);
         Assert.DoesNotContain("Job2", adapter.PausedJobs);
         Assert.Equal(UiJobState.Paused, userPaused.UiState);
+    }
+
+    [Fact]
+    public void OnBusinessSoftwareGone_AdapterTrackedJob_ResumesViaAdapterOnly_NoOrchestratorRestart()
+    {
+        // Regression guard for the double-start bug: a job started via the
+        // single-job Run card is adapter-tracked, not orchestrator-tracked.
+        // Even when an orchestrator is injected, Gone must NOT dispatch a
+        // second orchestrator.RunAsync for that job.
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new RecordingOrchestrator();
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        // Job1 is Running but was never registered in _orchestratorTrackedJobs
+        // because RunAllAsync was never called.
+        var job1 = MakeVm("Job1", UiJobState.Running);
+        sut.Jobs.Add(job1);
+
+        signals.RaiseDetected("calc");
+        signals.RaiseGone();
+
+        // Adapter-side resume must have been called.
+        Assert.Contains("Job1", adapter.ResumedJobs);
+        // Orchestrator must NOT have been asked to restart the job.
+        Assert.Empty(orchestrator.RunAsyncCalls);
     }
 }


### PR DESCRIPTION
OnBusinessSoftwareDetected now calls orchestrator.Stop() for each running job in addition to backup.PauseJob(), mirroring the existing wiring in the manual PauseJob command. Jobs launched by Run All are tracked in the orchestrator, not in BackupManagerAdapter, so the adapter call was a silent no-op causing jobs to keep running while the UI showed Paused badges.

OnBusinessSoftwareGone restarts orchestrator-stopped jobs via a restricted RunAsync call instead of backup.ResumeJob (which bails out immediately for jobs not in adapter._pausedByUs). A dedicated _watcherOrchestratorStoppedJobs set distinguishes orchestrator-tracked from adapter-tracked jobs to prevent double-starting. Limitation: restarts from the beginning of the job until PR #180 wires PauseGate into BackupManagerJobRunner.

JobsViewModel constructor now accepts IBusinessSoftwareSignals instead of the concrete BusinessWatcherService, enabling unit testing with a stub. Start() is moved to MainWindowViewModel.GetOrCreateJobsVm() where the concrete type is held.

Adds JobsViewModelWatcherIntegrationTests (3 tests):
- OnBusinessSoftwareDetected_StopsRunAllJobsViaOrchestrator
- OnBusinessSoftwareGone_ResumesPreviouslyPausedJobs
- OnBusinessSoftwareDetected_DoesNotPauseUserPausedJobs