### PR TITLE
fix(ui): surface job errors + pause/resume buttons + stable resume progress

### DIFF
--- a/src/EasySave.UI/Assets/i18n/en.json
+++ b/src/EasySave.UI/Assets/i18n/en.json
@@ -19,6 +19,7 @@
   "jobs.state.paused": "Paused",
   "jobs.state.idle": "Idle",
   "jobs.state.done": "Done",
+  "jobs.state.failed": "Failed",
   "settings.title": "Settings",
   "settings.save": "Save",
   "settings.log_format": "Log Format",

--- a/src/EasySave.UI/Assets/i18n/fr.json
+++ b/src/EasySave.UI/Assets/i18n/fr.json
@@ -19,6 +19,7 @@
   "jobs.state.paused": "En pause",
   "jobs.state.idle": "Prêt",
   "jobs.state.done": "Fait",
+  "jobs.state.failed": "Erreur",
   "settings.title": "Paramètres",
   "settings.save": "Enregistrer",
   "settings.log_format": "Format des logs",

--- a/src/EasySave.UI/Converters/StateToColorConverter.cs
+++ b/src/EasySave.UI/Converters/StateToColorConverter.cs
@@ -13,6 +13,7 @@ public sealed class StateToColorConverter : IValueConverter
             UiJobState.Running => new SolidColorBrush(Color.Parse("#3B82F6")),    // blue
             UiJobState.Paused => new SolidColorBrush(Color.Parse("#FF6B35")),     // orange
             UiJobState.Completed => new SolidColorBrush(Color.Parse("#22C55E")),  // green
+            UiJobState.Failed => new SolidColorBrush(Color.Parse("#EF4444")),     // red
             _ => new SolidColorBrush(Color.Parse("#6B7280")),                     // gray (idle)
         };
 

--- a/src/EasySave.UI/ViewModels/BackupJobVM.cs
+++ b/src/EasySave.UI/ViewModels/BackupJobVM.cs
@@ -28,6 +28,12 @@ public sealed partial class BackupJobVM : ObservableObject, IDisposable
     [ObservableProperty] private string _currentFile = string.Empty;
     [ObservableProperty] private int _filesRemaining;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasError))]
+    private string _lastError = string.Empty;
+
+    public bool HasError => !string.IsNullOrEmpty(LastError);
+
     public bool IsRunning => UiState == UiJobState.Running;
     public bool IsPaused => UiState == UiJobState.Paused;
 
@@ -42,6 +48,7 @@ public sealed partial class BackupJobVM : ObservableObject, IDisposable
         UiJobState.Running => TranslationSource.Instance["jobs.state.active"],
         UiJobState.Paused => TranslationSource.Instance["jobs.state.paused"],
         UiJobState.Completed => TranslationSource.Instance["jobs.state.done"],
+        UiJobState.Failed => TranslationSource.Instance["jobs.state.failed"],
         _ => TranslationSource.Instance["jobs.state.idle"],
     };
 

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -29,6 +29,19 @@ public sealed partial class JobsViewModel : ViewModelBase
     // orchestrator-tracked from adapter-tracked jobs — only the former must be
     // recorded in _watcherOrchestratorStoppedJobs to avoid double-starting.
     private readonly HashSet<string> _orchestratorTrackedJobs = new();
+    // Jobs paused by the user while running under the orchestrator. Resume on
+    // these must restart via orchestrator.RunAsync because _backup.ResumeJob
+    // is a no-op for orchestrator-tracked jobs (the adapter never tracked them).
+    // Limitation: orchestrator restart is from the beginning of the job until
+    // BackupManagerJobRunner honours resumeAfterPath (tracked in PR #180).
+    private readonly HashSet<string> _orchestratorPausedJobs = new();
+    // Progress floor per job currently catching up after a resume-from-pause
+    // restart. The engine re-walks the whole file list (no resumeAfterPath
+    // support yet), so its early Active snapshots report a Progress lower
+    // than what the user saw at pause time. Without a floor the bar would
+    // snap back to 0 % and crawl up, which the user reads as a regression.
+    // The entry is dropped from the dict once the engine catches up.
+    private readonly Dictionary<string, int> _orchestratorResumeProgressFloor = new();
 
     // Set by MainWindowViewModel after construction.
     public Action<BackupJob?>? RequestOpenJobEdit { get; set; }
@@ -91,13 +104,39 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             var vm = Jobs.FirstOrDefault(j => j.Name == entry.Name);
             if (vm is null) return;
-            vm.Progress = (int)entry.Progress;
-            vm.CurrentFile = entry.CurrentSource;
-            vm.FilesRemaining = entry.FilesRemaining;
+            // When the user has paused a Run-All job, the backend's final
+            // Inactive snapshot zeroes FilesRemaining/SizeRemaining (the
+            // BackupManager finally branch treats orchestrator.Stop as a
+            // normal end), which makes the derived Progress jump to 100.
+            // Freeze the progress fields so the bar stays where the user
+            // paused — Resume will reset them to 0 (the orchestrator restart
+            // path) or keep them (adapter resume from offset).
+            if (vm.UiState != UiJobState.Paused)
+            {
+                int reported = (int)entry.Progress;
+                if (_orchestratorResumeProgressFloor.TryGetValue(entry.Name, out var floor))
+                {
+                    if (reported >= floor)
+                    {
+                        _orchestratorResumeProgressFloor.Remove(entry.Name);
+                        vm.Progress = reported;
+                    }
+                    else
+                    {
+                        vm.Progress = floor;
+                    }
+                }
+                else
+                {
+                    vm.Progress = reported;
+                }
+                vm.CurrentFile = entry.CurrentSource;
+                vm.FilesRemaining = entry.FilesRemaining;
+            }
             if (entry.State == JobState.Active)
             {
-                // Promote Idle/Completed → Running on a new run; don't touch a user-paused job.
-                if (vm.UiState is UiJobState.Idle or UiJobState.Completed)
+                // Promote Idle/Completed/Failed → Running on a new run; don't touch a user-paused job.
+                if (vm.UiState is UiJobState.Idle or UiJobState.Completed or UiJobState.Failed)
                     vm.UiState = UiJobState.Running;
             }
             else
@@ -105,11 +144,27 @@ public sealed partial class JobsViewModel : ViewModelBase
                 // Backend finished (Inactive): mark Completed when the job ran to
                 // its end (no remaining files), otherwise fall back to Idle so a
                 // job that exited via pause/cancel doesn't claim success.
-                vm.UiState = entry.FilesRemaining == 0 && entry.TotalFilesEligible > 0
-                    ? UiJobState.Completed
-                    : UiJobState.Idle;
+                // Skip when the run-loop already stamped Failed or Paused — those
+                // badges are owned by the UI controller (exception path / Pause
+                // button) and the backend's Inactive snapshot must not clobber
+                // them. Pause on the Run-All path triggers orchestrator.Stop()
+                // which immediately flushes Inactive; without this guard the
+                // badge flashed from Paused to Idle/Completed within one tick.
+                if (vm.UiState is not (UiJobState.Failed or UiJobState.Paused))
+                {
+                    vm.UiState = entry.FilesRemaining == 0 && entry.TotalFilesEligible > 0
+                        ? UiJobState.Completed
+                        : UiJobState.Idle;
+                }
                 _watcherPausedJobs.Remove(vm.Name);
                 _watcherOrchestratorStoppedJobs.Remove(vm.Name);
+                // _orchestratorPausedJobs is owned by Pause/Resume and must
+                // NOT be cleared here — the backend's Inactive snapshot fires
+                // immediately after orchestrator.Stop(), while the user is
+                // still in the Paused state waiting to click Resume. Clearing
+                // it here would make the subsequent Resume route to the
+                // adapter's no-op ResumeJob path and the job would never
+                // restart.
             }
         });
     }
@@ -170,6 +225,12 @@ public sealed partial class JobsViewModel : ViewModelBase
 
     private async Task RunWatcherOrchestratorJobsAsync(IReadOnlyList<string> jobNames)
     {
+        // Register the jobs as orchestrator-tracked so a subsequent user Pause
+        // click correctly routes through orchestrator.Stop and adds the job to
+        // _orchestratorPausedJobs. Without this, a Pause→Resume cycle launched
+        // by ResumeJob would leave the second Pause invisible to the engine —
+        // the badge would flip to Paused while the engine kept copying files.
+        foreach (var name in jobNames) _orchestratorTrackedJobs.Add(name);
         try
         {
             await _orchestrator!.RunAsync(jobNames, CancellationToken.None).ConfigureAwait(true);
@@ -182,6 +243,7 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             foreach (var name in jobNames)
             {
+                _orchestratorTrackedJobs.Remove(name);
                 var vm = Jobs.FirstOrDefault(j => j.Name == name);
                 if (vm?.UiState == UiJobState.Running)
                 {
@@ -221,14 +283,19 @@ public sealed partial class JobsViewModel : ViewModelBase
     {
         if (IsBusinessSoftwareDetected
             || vm.UiState is UiJobState.Running or UiJobState.Paused) return;
+        vm.LastError = string.Empty;
+        StatusMessage = string.Empty;
         vm.UiState = UiJobState.Running;
         RequestShowProgress?.Invoke();
+        var failed = false;
         try
         {
             await _backup.RunJobAsync(vm.Name).ConfigureAwait(true);
         }
         catch (Exception ex)
         {
+            failed = true;
+            vm.LastError = ex.Message;
             StatusMessage = ex.Message;
         }
         finally
@@ -237,7 +304,14 @@ public sealed partial class JobsViewModel : ViewModelBase
             // backend writes its last Inactive snapshot. Leave the UiState alone
             // here so we don't overwrite Completed → Idle. Only clean up the
             // transient progress fields that have no meaning between runs.
-            if (vm.UiState == UiJobState.Running)
+            // Failure path overrides the backend state to Failed so the badge
+            // reflects the exception that was swallowed at the adapter boundary.
+            if (failed)
+            {
+                vm.UiState = UiJobState.Failed;
+                vm.Progress = 0;
+            }
+            else if (vm.UiState == UiJobState.Running)
             {
                 vm.UiState = UiJobState.Idle;
                 // The job exited mid-flight (exception or external cancel) — wipe
@@ -254,17 +328,22 @@ public sealed partial class JobsViewModel : ViewModelBase
     private async Task RunAllAsync()
     {
         if (IsBusinessSoftwareDetected) return;
+        StatusMessage = string.Empty;
         RequestShowProgress?.Invoke();
 
         // Include Completed jobs so a second click after a successful run
         // re-launches every job; only Running and Paused are skipped to avoid
         // double-starting an active or user-paused backup.
         var eligible = Jobs
-            .Where(j => j.UiState is UiJobState.Idle or UiJobState.Completed)
+            .Where(j => j.UiState is UiJobState.Idle or UiJobState.Completed or UiJobState.Failed)
             .ToList();
         if (eligible.Count == 0) return;
 
-        foreach (var vm in eligible) vm.UiState = UiJobState.Running;
+        foreach (var vm in eligible)
+        {
+            vm.LastError = string.Empty;
+            vm.UiState = UiJobState.Running;
+        }
 
         // V3 path: when the parallel orchestrator is wired (GUI host), run
         // every eligible job concurrently bounded by max_parallel_jobs.
@@ -277,9 +356,29 @@ public sealed partial class JobsViewModel : ViewModelBase
             foreach (var vm in eligible) _orchestratorTrackedJobs.Add(vm.Name);
             try
             {
-                await _orchestrator.RunAsync(
+                var results = await _orchestrator.RunAsync(
                     eligible.Select(j => j.Name),
                     CancellationToken.None).ConfigureAwait(true);
+
+                // Per-job results: stamp Failed/Cancelled messages on the
+                // matching card so the user sees which job failed and why
+                // even while the progress view is still open.
+                var resultByName = results.ToDictionary(r => r.JobName, StringComparer.Ordinal);
+                foreach (var vm in eligible)
+                {
+                    if (resultByName.TryGetValue(vm.Name, out var result)
+                        && result.Outcome == JobOutcome.Failed)
+                    {
+                        if (!string.IsNullOrEmpty(result.Message))
+                            vm.LastError = result.Message;
+                        vm.UiState = UiJobState.Failed;
+                        vm.Progress = 0;
+                    }
+                }
+                var firstFailure = results.FirstOrDefault(r =>
+                    r.Outcome == JobOutcome.Failed && !string.IsNullOrEmpty(r.Message));
+                if (firstFailure is not null)
+                    StatusMessage = $"{firstFailure.JobName}: {firstFailure.Message}";
             }
             catch (Exception ex)
             {
@@ -315,18 +414,22 @@ public sealed partial class JobsViewModel : ViewModelBase
     private void PauseJob(BackupJobVM vm)
     {
         vm.UiState = UiJobState.Paused;
+        // Run-All jobs (in the orchestrator): the v3 BackupManagerJobRunner
+        // does not honor ctx.PauseGate today, so orchestrator.Pause() would
+        // be a no-op. Use orchestrator.Stop() which cancels the per-job CTS
+        // and stops the worker at the next file boundary. Resume on the
+        // same card restarts from the beginning of the job via the
+        // orchestrator (see ResumeJob).
+        if (_orchestrator is not null && _orchestratorTrackedJobs.Contains(vm.Name))
+        {
+            _orchestratorPausedJobs.Add(vm.Name);
+            _orchestrator.Stop(vm.Name);
+            return;
+        }
         // Single-Run jobs (in the adapter): a real pause that stops the
         // worker at the next file boundary and persists "Paused" in
         // state.json, ready to be resumed from the same offset.
         _backup.PauseJob(vm.Name);
-        // Run-All jobs (in the orchestrator): the v3 BackupManagerJobRunner
-        // does not honor ctx.PauseGate today, so orchestrator.Pause() would
-        // be a no-op. Use orchestrator.Stop() which cancels the per-job CTS
-        // and stops the worker at the next file boundary. Effective result:
-        // the job halts and shows Inactive — it cannot be resumed from the
-        // same offset on this path (Resume button is a no-op for Run-All
-        // jobs in this iteration). Documented limitation.
-        _orchestrator?.Stop(vm.Name);
     }
 
     [RelayCommand]
@@ -334,36 +437,53 @@ public sealed partial class JobsViewModel : ViewModelBase
     {
         if (IsBusinessSoftwareDetected) return;
         vm.UiState = UiJobState.Running;
-        // Only the adapter knows how to resume from a saved offset. For
-        // Run-All-launched jobs, Pause acted as Stop above; Resume is a
-        // visual no-op until the user clicks Run on the card again.
+        // Run-All-launched jobs: Pause was actually a Stop on the orchestrator
+        // (one-way), so Resume cannot continue from the saved offset. Restart
+        // the job from scratch via the orchestrator — same pattern as the
+        // business-software watcher resume path. Limitation: progress restarts
+        // at 0 until BackupManagerJobRunner honours resumeAfterPath (PR #180).
+        if (_orchestrator is not null && _orchestratorPausedJobs.Remove(vm.Name))
+        {
+            // Hold the bar at the paused-value while the engine re-copies
+            // up to that file. OnStateUpdated lifts the floor once
+            // entry.Progress catches up.
+            _orchestratorResumeProgressFloor[vm.Name] = vm.Progress;
+            vm.LastError = string.Empty;
+#pragma warning disable CS4014
+            RunWatcherOrchestratorJobsAsync(new[] { vm.Name });
+#pragma warning restore CS4014
+            return;
+        }
+        // Single-Run-launched jobs: the adapter holds the pause offset.
         _backup.ResumeJob(vm.Name);
     }
 
     // Used by RunAllAsync to run a job without navigating (navigation is done once before the loop).
     private async Task RunJobInternal(BackupJobVM vm)
     {
+        vm.LastError = string.Empty;
         vm.UiState = UiJobState.Running;
+        var failed = false;
         try
         {
             await _backup.RunJobAsync(vm.Name).ConfigureAwait(true);
         }
         catch (Exception ex)
         {
+            failed = true;
+            vm.LastError = ex.Message;
             StatusMessage = ex.Message;
         }
         finally
         {
-            // Final state (Completed vs Idle) is set by OnStateUpdated when the
-            // backend writes its last Inactive snapshot. Leave the UiState alone
-            // here so we don't overwrite Completed → Idle. Only clean up the
-            // transient progress fields that have no meaning between runs.
-            if (vm.UiState == UiJobState.Running)
+            if (failed)
+            {
+                vm.UiState = UiJobState.Failed;
+                vm.Progress = 0;
+            }
+            else if (vm.UiState == UiJobState.Running)
             {
                 vm.UiState = UiJobState.Idle;
-                // The job exited mid-flight (exception or external cancel) — wipe
-                // the leftover progress so the bar doesn't stay at e.g. 47% with
-                // an Idle badge until the next run starts.
                 vm.Progress = 0;
             }
             vm.CurrentFile = string.Empty;

--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -29,18 +29,12 @@ public sealed partial class JobsViewModel : ViewModelBase
     // orchestrator-tracked from adapter-tracked jobs — only the former must be
     // recorded in _watcherOrchestratorStoppedJobs to avoid double-starting.
     private readonly HashSet<string> _orchestratorTrackedJobs = new();
-    // Jobs paused by the user while running under the orchestrator. Resume on
-    // these must restart via orchestrator.RunAsync because _backup.ResumeJob
-    // is a no-op for orchestrator-tracked jobs (the adapter never tracked them).
-    // Limitation: orchestrator restart is from the beginning of the job until
-    // BackupManagerJobRunner honours resumeAfterPath (tracked in PR #180).
+    // User-paused jobs from the orchestrator path. Resume restarts them via
+    // orchestrator.RunAsync (the adapter doesn't know them). Restart is from
+    // file 0 until PR #180 wires resumeAfterPath into BackupManagerJobRunner.
     private readonly HashSet<string> _orchestratorPausedJobs = new();
-    // Progress floor per job currently catching up after a resume-from-pause
-    // restart. The engine re-walks the whole file list (no resumeAfterPath
-    // support yet), so its early Active snapshots report a Progress lower
-    // than what the user saw at pause time. Without a floor the bar would
-    // snap back to 0 % and crawl up, which the user reads as a regression.
-    // The entry is dropped from the dict once the engine catches up.
+    // Resume catch-up floor: holds the bar at the paused value while the
+    // engine re-walks the file list; cleared once entry.Progress >= floor.
     private readonly Dictionary<string, int> _orchestratorResumeProgressFloor = new();
 
     // Set by MainWindowViewModel after construction.
@@ -104,14 +98,12 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             var vm = Jobs.FirstOrDefault(j => j.Name == entry.Name);
             if (vm is null) return;
-            // When the user has paused a Run-All job, the backend's final
-            // Inactive snapshot zeroes FilesRemaining/SizeRemaining (the
-            // BackupManager finally branch treats orchestrator.Stop as a
-            // normal end), which makes the derived Progress jump to 100.
-            // Freeze the progress fields so the bar stays where the user
-            // paused — Resume will reset them to 0 (the orchestrator restart
-            // path) or keep them (adapter resume from offset).
-            if (vm.UiState != UiJobState.Paused)
+            // orchestrator.Stop flushes an Inactive snapshot with
+            // FilesRemaining=0 → Progress=100; without this guard the bar
+            // would jump to 100 % under a Paused badge. Same race for Failed:
+            // the queued snapshot arrives after the run-loop finally has
+            // stamped Failed + Progress=0.
+            if (vm.UiState is not (UiJobState.Paused or UiJobState.Failed))
             {
                 int reported = (int)entry.Progress;
                 if (_orchestratorResumeProgressFloor.TryGetValue(entry.Name, out var floor))
@@ -158,13 +150,9 @@ public sealed partial class JobsViewModel : ViewModelBase
                 }
                 _watcherPausedJobs.Remove(vm.Name);
                 _watcherOrchestratorStoppedJobs.Remove(vm.Name);
-                // _orchestratorPausedJobs is owned by Pause/Resume and must
-                // NOT be cleared here — the backend's Inactive snapshot fires
-                // immediately after orchestrator.Stop(), while the user is
-                // still in the Paused state waiting to click Resume. Clearing
-                // it here would make the subsequent Resume route to the
-                // adapter's no-op ResumeJob path and the job would never
-                // restart.
+                // _orchestratorPausedJobs is owned by Pause/Resume — clearing
+                // it here would happen on the post-Stop Inactive snapshot and
+                // break the next Resume.
             }
         });
     }
@@ -247,6 +235,10 @@ public sealed partial class JobsViewModel : ViewModelBase
                 var vm = Jobs.FirstOrDefault(j => j.Name == name);
                 if (vm?.UiState == UiJobState.Running)
                 {
+                    // If we end up here while still Running, the orchestrator
+                    // threw before publishing the final state. Drop the floor
+                    // so a future fresh Run is not clamped by it.
+                    _orchestratorResumeProgressFloor.Remove(name);
                     vm.UiState = UiJobState.Idle;
                     vm.Progress = 0;
                 }
@@ -371,6 +363,7 @@ public sealed partial class JobsViewModel : ViewModelBase
                     {
                         if (!string.IsNullOrEmpty(result.Message))
                             vm.LastError = result.Message;
+                        _orchestratorResumeProgressFloor.Remove(vm.Name);
                         vm.UiState = UiJobState.Failed;
                         vm.Progress = 0;
                     }

--- a/src/EasySave.UI/ViewModels/RunProgressViewModel.cs
+++ b/src/EasySave.UI/ViewModels/RunProgressViewModel.cs
@@ -11,8 +11,13 @@ public sealed partial class RunProgressViewModel : ViewModelBase, IDisposable
 
     public ObservableCollection<BackupJobVM> Jobs => _jobsVm.Jobs;
 
+    // Exposed so the progress view's per-card buttons can bind directly to
+    // JobsViewModel's Pause/Resume commands without duplicating them here.
+    public JobsViewModel JobsVm => _jobsVm;
+
     public bool IsBusinessSoftwareDetected => _jobsVm.IsBusinessSoftwareDetected;
     public string DetectedSoftwareName => _jobsVm.DetectedSoftwareName;
+    public string StatusMessage => _jobsVm.StatusMessage;
 
     // Set by MainWindowViewModel so this VM can trigger navigation back.
     public Action? CloseRequested { get; set; }
@@ -29,6 +34,8 @@ public sealed partial class RunProgressViewModel : ViewModelBase, IDisposable
             OnPropertyChanged(nameof(IsBusinessSoftwareDetected));
         if (e.PropertyName is nameof(JobsViewModel.DetectedSoftwareName))
             OnPropertyChanged(nameof(DetectedSoftwareName));
+        if (e.PropertyName is nameof(JobsViewModel.StatusMessage))
+            OnPropertyChanged(nameof(StatusMessage));
     }
 
     [RelayCommand]

--- a/src/EasySave.UI/ViewModels/UiJobState.cs
+++ b/src/EasySave.UI/ViewModels/UiJobState.cs
@@ -1,3 +1,3 @@
 namespace EasySave.UI.ViewModels;
 
-public enum UiJobState { Idle, Running, Paused, Completed }
+public enum UiJobState { Idle, Running, Paused, Completed, Failed }

--- a/src/EasySave.UI/Views/JobsView.axaml
+++ b/src/EasySave.UI/Views/JobsView.axaml
@@ -176,6 +176,17 @@
                                                Foreground="{StaticResource MutedTextBrush}"
                                                IsVisible="{Binding IsRunning}" />
 
+                                    <!-- Per-card error pill -->
+                                    <Border IsVisible="{Binding HasError}"
+                                            Background="#FEE2E2"
+                                            CornerRadius="4"
+                                            Padding="8,4">
+                                        <TextBlock Text="{Binding LastError}"
+                                                   Foreground="#B91C1C"
+                                                   FontSize="11"
+                                                   TextWrapping="Wrap" />
+                                    </Border>
+
                                 </StackPanel>
                             </Border>
                         </DataTemplate>

--- a/src/EasySave.UI/Views/RunProgressView.axaml
+++ b/src/EasySave.UI/Views/RunProgressView.axaml
@@ -30,6 +30,20 @@
             </TextBlock>
         </Border>
 
+        <!-- Error banner (shows the first job failure surfaced by JobsViewModel) -->
+        <Border DockPanel.Dock="Top"
+                IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                Background="#FEE2E2"
+                CornerRadius="6"
+                Padding="14,10"
+                Margin="0,0,0,12">
+            <TextBlock Text="{Binding StatusMessage}"
+                       Foreground="#B91C1C"
+                       FontSize="13"
+                       TextWrapping="Wrap"
+                       VerticalAlignment="Center" />
+        </Border>
+
         <!-- Close button -->
         <Button DockPanel.Dock="Bottom"
                 Command="{Binding CloseProgressCommand}"
@@ -50,15 +64,38 @@
                                 BoxShadow="0 1 4 0 #15000000">
                             <StackPanel Spacing="8">
 
-                                <!-- Job name + state badge -->
-                                <Grid ColumnDefinitions="*,Auto">
+                                <!-- Job name + action buttons + state badge -->
+                                <Grid ColumnDefinitions="*,Auto,Auto,Auto">
                                     <TextBlock Grid.Column="0"
                                                Text="{Binding Name}"
                                                FontSize="15"
                                                FontWeight="SemiBold"
                                                Foreground="#111827"
                                                VerticalAlignment="Center" />
-                                    <Border Grid.Column="1"
+
+                                    <Button Grid.Column="1"
+                                            Command="{Binding $parent[UserControl].DataContext.JobsVm.PauseJobCommand}"
+                                            CommandParameter="{Binding}"
+                                            Padding="10,5"
+                                            FontSize="12"
+                                            Margin="0,0,6,0"
+                                            VerticalAlignment="Center"
+                                            IsVisible="{Binding IsRunning}">
+                                        <TextBlock Text="{markup:T Key=jobs.pause}" />
+                                    </Button>
+
+                                    <Button Grid.Column="2"
+                                            Command="{Binding $parent[UserControl].DataContext.JobsVm.ResumeJobCommand}"
+                                            CommandParameter="{Binding}"
+                                            Padding="10,5"
+                                            FontSize="12"
+                                            Margin="0,0,10,0"
+                                            VerticalAlignment="Center"
+                                            IsVisible="{Binding IsPaused}">
+                                        <TextBlock Text="{markup:T Key=jobs.resume}" />
+                                    </Button>
+
+                                    <Border Grid.Column="3"
                                             CornerRadius="12"
                                             Padding="10,4">
                                         <Border.Background>
@@ -103,6 +140,17 @@
                                                FontSize="11"
                                                Foreground="{StaticResource MutedTextBrush}" />
                                 </StackPanel>
+
+                                <!-- Per-card error pill -->
+                                <Border IsVisible="{Binding HasError}"
+                                        Background="#FEE2E2"
+                                        CornerRadius="4"
+                                        Padding="8,4">
+                                    <TextBlock Text="{Binding LastError}"
+                                               Foreground="#B91C1C"
+                                               FontSize="11"
+                                               TextWrapping="Wrap" />
+                                </Border>
 
                             </StackPanel>
                         </Border>


### PR DESCRIPTION
## Summary

Five UX gaps on the Run All / RunProgressView flow surfaced while testing the V3 demo dataset (3.4 GB, 484 files, 4 big files ≥ 4 MB).

### 1. Failed jobs were invisible while RunProgressView was open

Exceptions from `_backup.RunJobAsync` were caught and dropped into `StatusMessage`, but `StatusMessage` was only bound in `JobsView`. From the progress view, the badge flipped silently back to `Idle` with no clue why.

Now:
- New `UiJobState.Failed` (+ `jobs.state.failed` i18n EN/FR, red color in `StateToColorConverter`).
- `BackupJobVM.LastError` + `HasError` on each card.
- `RunProgressViewModel` bridges `JobsViewModel.StatusMessage`.
- Both `JobsView` and `RunProgressView` render a red banner + per-card error pill.
- `RunAllAsync` iterates the orchestrator's `JobResult[]` and stamps `vm.LastError` + `vm.UiState = Failed` on Failed outcomes.

### 2. No Pause / Resume buttons in RunProgressView

Where the operator spends time during Run All, no controls were visible — they had to navigate back to JobsView. Pause / Resume buttons are now wired per-card in RunProgressView, bound through a new `JobsVm` proxy on `RunProgressViewModel`.

### 3. Paused badge was clobbered when orchestrator.Stop flushed Inactive

`orchestrator.Stop` triggers `BackupManager.ExecuteJob`'s `paused = pauseGate is null` branch with `pauseGate` set, so it falls through to the normal-end finally: `FilesRemaining = 0` → derived `Progress = 100`. `OnStateUpdated` then promoted the badge to `Completed`.

`OnStateUpdated` now guards Progress, CurrentFile, FilesRemaining and the badge transition against a `Paused` state.

### 4. Resume on Run-All-launched jobs was a silent no-op

Pause routed to `orchestrator.Stop` (one-way), but Resume still called `_backup.ResumeJob` which knows nothing about orchestrator-tracked jobs. The badge flipped to `Running` and the bar stayed put while nothing actually ran.

- `PauseJob` records the job in `_orchestratorPausedJobs`.
- `ResumeJob` restarts via `RunWatcherOrchestratorJobsAsync` (same path the business-software watcher uses).
- Cleanup that used to fire on Inactive snapshot was wrong — the snapshot fires immediately after `Stop`, while the user is still in `Paused` waiting to click Resume. That cleanup was removed; the set is owned by Pause / Resume only.

Documented limitation: orchestrator restart starts from the beginning of the job until PR #180 wires `resumeAfterPath` into `BackupManagerJobRunner`.

### 5. Spamming Pause / Resume produced phantom runs

`RunWatcherOrchestratorJobsAsync` (the resume path) did not register the restarted job in `_orchestratorTrackedJobs`. The next `PauseJob.Contains` returned false → routed to the adapter no-op → badge flipped to `Paused` while the engine kept copying in the background. The function now adds / removes from the tracked set, matching `RunAllAsync`'s bookkeeping.

### 6. Progress snapped back to 0 on every Resume

The orchestrator restart re-walks the whole file list, so its early Active snapshots report a Progress lower than the user's paused value. The bar dropped to 0 and crawled up — the operator reads that as a regression.

`ResumeJob` stores the paused value in a per-job floor; `OnStateUpdated` clamps the bar to that floor until the engine catches up, then drops the floor entry. Pause / Resume cycles can be repeated freely.

## Files

| File | Change |
|---|---|
| `ViewModels/UiJobState.cs` | Add `Failed` |
| `ViewModels/BackupJobVM.cs` | Add `LastError`, `HasError`, Failed in `StateDisplayName` |
| `ViewModels/JobsViewModel.cs` | Pause / Resume routing, error stamping, Paused guard, resume floor |
| `ViewModels/RunProgressViewModel.cs` | Expose `JobsVm` proxy + bridge `StatusMessage` |
| `Views/JobsView.axaml` | Per-card error pill |
| `Views/RunProgressView.axaml` | Error banner, per-card pill, Pause / Resume buttons |
| `Converters/StateToColorConverter.cs` | Failed → red |
| `Assets/i18n/{en,fr}.json` | `jobs.state.failed` |

## Test plan

- [x] `dotnet build` clean (0 errors, 0 warnings).
- [x] Smoke tested locally on a 3.4 GB / 484-file demo dataset with `max_parallel_jobs = 2`.
- [ ] Run All → both jobs run in parallel, badges update correctly, current-file label visible.
- [ ] Point a job source to a non-existent folder → click Run → red banner + red `Erreur` badge + red pill with the exception message. Bar stays at 0 %.
- [ ] Run All → Pause at 50 % → bar freezes at 50 %, badge `Paused`. Click Resume → bar holds at 50 % while the engine catches up, then progresses to 100 %.
- [ ] Spam Pause / Resume several times → badge always reflects the actual state, bar never goes backward.