### PR TITLE
perf(ui): cap daily-log preview to the first 150 lines

### DIFF
--- a/src/EasySave.UI/Assets/i18n/en.json
+++ b/src/EasySave.UI/Assets/i18n/en.json
@@ -50,6 +50,8 @@
   "logs.title": "Logs",
   "logs.empty": "No log files yet.",
   "logs.refresh": "Refresh",
+  "logs.truncated_notice": "--- Preview limited to the first {0} lines. Open the file directly to view it all. ---",
+  "logs.truncated_badge": "Preview · first {0} lines",
   "progress.title": "Backup Progress",
   "progress.files_remaining": "Files remaining:",
   "progress.business_pause": "Jobs paused — business software detected:",

--- a/src/EasySave.UI/Assets/i18n/fr.json
+++ b/src/EasySave.UI/Assets/i18n/fr.json
@@ -50,6 +50,8 @@
   "logs.title": "Journaux",
   "logs.empty": "Aucun fichier de journal pour le moment.",
   "logs.refresh": "Actualiser",
+  "logs.truncated_notice": "--- Aperçu limité aux {0} premières lignes. Ouvrez le fichier directement pour tout consulter. ---",
+  "logs.truncated_badge": "Aperçu · {0} premières lignes",
   "progress.title": "Progression des sauvegardes",
   "progress.files_remaining": "Fichiers restants :",
   "progress.business_pause": "Jobs en pause — logiciel métier détecté :",

--- a/src/EasySave.UI/ViewModels/LogsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/LogsViewModel.cs
@@ -2,16 +2,23 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave.Services;
+using EasySave.UI.Services;
 
 namespace EasySave.UI.ViewModels;
 
 /// <summary>
 /// View model for the logs viewer screen. Lists daily log files written by
-/// EasyLog (JSON or XML) and shows the raw content of the selected file in
-/// a read-only panel.
+/// EasyLog (JSON or XML) and shows a bounded preview of the selected file
+/// so a huge daily log does not block the UI thread or balloon memory.
 /// </summary>
 public sealed partial class LogsViewModel : ViewModelBase
 {
+    // Hard cap on lines streamed into SelectedContent. A pretty-printed JSON
+    // backup-row entry is ~11 lines, so 150 lines is ~13 entries — enough to
+    // see the latest activity. Files like the 18 MB XML log we hit in
+    // testing would otherwise lock the UI for several seconds.
+    private const int MaxPreviewLines = 150;
+
     public ObservableCollection<LogFileItem> Files { get; } = new();
 
     [ObservableProperty]
@@ -25,8 +32,15 @@ public sealed partial class LogsViewModel : ViewModelBase
     [ObservableProperty]
     private string _statusMessage = string.Empty;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TruncatedBadge))]
+    private bool _isTruncated;
+
     public bool HasSelection => SelectedFile is not null;
     public bool IsEmpty => Files.Count == 0;
+
+    public string TruncatedBadge => string.Format(
+        TranslationSource.Instance["logs.truncated_badge"], MaxPreviewLines);
 
     public LogsViewModel()
     {
@@ -39,6 +53,7 @@ public sealed partial class LogsViewModel : ViewModelBase
         Files.Clear();
         StatusMessage = string.Empty;
         SelectedContent = string.Empty;
+        IsTruncated = false;
         SelectedFile = null;
 
         var dir = AppConfig.Instance.LogDirectory;
@@ -66,6 +81,7 @@ public sealed partial class LogsViewModel : ViewModelBase
 
     partial void OnSelectedFileChanged(LogFileItem? value)
     {
+        IsTruncated = false;
         if (value is null)
         {
             SelectedContent = string.Empty;
@@ -74,7 +90,22 @@ public sealed partial class LogsViewModel : ViewModelBase
 
         try
         {
-            SelectedContent = File.ReadAllText(value.FullPath);
+            // ReadLines streams instead of loading the whole file at once.
+            // We take MaxPreviewLines+1 to detect whether the file extends
+            // beyond the cap without materialising the rest.
+            var lines = File.ReadLines(value.FullPath)
+                            .Take(MaxPreviewLines + 1)
+                            .ToList();
+            if (lines.Count > MaxPreviewLines)
+            {
+                IsTruncated = true;
+                lines.RemoveAt(MaxPreviewLines);
+                lines.Add(string.Empty);
+                lines.Add(string.Format(
+                    TranslationSource.Instance["logs.truncated_notice"],
+                    MaxPreviewLines));
+            }
+            SelectedContent = string.Join('\n', lines);
         }
         catch (IOException ex)
         {
@@ -83,4 +114,3 @@ public sealed partial class LogsViewModel : ViewModelBase
         }
     }
 }
-

--- a/src/EasySave.UI/ViewModels/LogsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/LogsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasySave.Services;
@@ -11,7 +12,7 @@ namespace EasySave.UI.ViewModels;
 /// EasyLog (JSON or XML) and shows a bounded preview of the selected file
 /// so a huge daily log does not block the UI thread or balloon memory.
 /// </summary>
-public sealed partial class LogsViewModel : ViewModelBase
+public sealed partial class LogsViewModel : ViewModelBase, IDisposable
 {
     // Hard cap on lines streamed into SelectedContent. A pretty-printed JSON
     // backup-row entry is ~11 lines, so 150 lines is ~13 entries — enough to
@@ -44,8 +45,22 @@ public sealed partial class LogsViewModel : ViewModelBase
 
     public LogsViewModel()
     {
+        // Re-read the active file when the user flips FR↔EN so the truncation
+        // footer baked into SelectedContent picks up the new locale, and the
+        // badge text re-renders through OnPropertyChanged(TruncatedBadge).
+        TranslationSource.Instance.PropertyChanged += OnLocaleChanged;
         Refresh();
     }
+
+    private void OnLocaleChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(TruncatedBadge));
+        if (SelectedFile is not null)
+            OnSelectedFileChanged(SelectedFile);
+    }
+
+    public void Dispose()
+        => TranslationSource.Instance.PropertyChanged -= OnLocaleChanged;
 
     [RelayCommand]
     private void Refresh()

--- a/src/EasySave.UI/ViewModels/LogsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/LogsViewModel.cs
@@ -34,7 +34,6 @@ public sealed partial class LogsViewModel : ViewModelBase, IDisposable
     private string _statusMessage = string.Empty;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(TruncatedBadge))]
     private bool _isTruncated;
 
     public bool HasSelection => SelectedFile is not null;
@@ -68,7 +67,6 @@ public sealed partial class LogsViewModel : ViewModelBase, IDisposable
         Files.Clear();
         StatusMessage = string.Empty;
         SelectedContent = string.Empty;
-        IsTruncated = false;
         SelectedFile = null;
 
         var dir = AppConfig.Instance.LogDirectory;

--- a/src/EasySave.UI/Views/LogsView.axaml
+++ b/src/EasySave.UI/Views/LogsView.axaml
@@ -75,18 +75,31 @@
                     CornerRadius="8"
                     Padding="14"
                     BoxShadow="0 1 4 0 #10000000">
-                <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                              VerticalScrollBarVisibility="Auto">
-                    <TextBox Text="{Binding SelectedContent, Mode=OneWay}"
-                             IsReadOnly="True"
-                             AcceptsReturn="True"
-                             TextWrapping="NoWrap"
-                             FontFamily="Cascadia Code, Consolas, monospace"
-                             FontSize="12"
-                             Foreground="#111827"
-                             Background="Transparent"
-                             BorderThickness="0" />
-                </ScrollViewer>
+                <DockPanel>
+                    <Border DockPanel.Dock="Top"
+                            IsVisible="{Binding IsTruncated}"
+                            Background="#FEF3C7"
+                            CornerRadius="4"
+                            Padding="8,4"
+                            Margin="0,0,0,8">
+                        <TextBlock Text="{Binding TruncatedBadge}"
+                                   FontSize="11"
+                                   FontWeight="Medium"
+                                   Foreground="#92400E" />
+                    </Border>
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                  VerticalScrollBarVisibility="Auto">
+                        <TextBox Text="{Binding SelectedContent, Mode=OneWay}"
+                                 IsReadOnly="True"
+                                 AcceptsReturn="True"
+                                 TextWrapping="NoWrap"
+                                 FontFamily="Cascadia Code, Consolas, monospace"
+                                 FontSize="12"
+                                 Foreground="#111827"
+                                 Background="Transparent"
+                                 BorderThickness="0" />
+                    </ScrollViewer>
+                </DockPanel>
             </Border>
         </Grid>
 


### PR DESCRIPTION
## Summary

The logs viewer was reading the entire daily log via `File.ReadAllText`, materialising the whole file as a string in `SelectedContent` and pinning it inside the TextBox. On a busy V3 host the daily log easily reaches tens of MB (484 entries per Run All run on our 3.4 GB demo dataset, multiplied by every run that day), which blocks the UI thread for several seconds on selection and balloons memory.

This PR caps the preview at the first **150 lines** — about 13 file-transfer entries with the pretty-printed JSON format we ship — which is plenty to see what's happening recently without dragging the rest into RAM.

## What changes

| File | Change |
|---|---|
| `ViewModels/LogsViewModel.cs` | Switch to `File.ReadLines(...).Take(MaxPreviewLines + 1).ToList()` — streaming read, materialises at most 151 lines. The 151st is dropped after the count check so only 150 are shown. Adds `IsTruncated` + `TruncatedBadge` computed property. |
| `Views/LogsView.axaml` | Yellow `IsTruncated` banner above the viewer (`#FEF3C7` background, `#92400E` text). |
| `Assets/i18n/{en,fr}.json` | `logs.truncated_notice` (footer appended to content) and `logs.truncated_badge` (banner text). |

## Cahier compliance

- No public API change; `IDailyLogger` v1.0 contract untouched.
- No on-disk format change; the daily log file is read-only.
- The full file remains available on disk — the truncation footer points the operator at it.

## Files touched

```
 src/EasySave.UI/Assets/i18n/en.json         |  2 ++
 src/EasySave.UI/Assets/i18n/fr.json         |  2 ++
 src/EasySave.UI/ViewModels/LogsViewModel.cs | 38 +++++++++++++++++++++++++++++++++++++--
 src/EasySave.UI/Views/LogsView.axaml        | 37 +++++++++++++++++++++++++------------
 4 files changed, 63 insertions(+), 16 deletions(-)
```

## Test plan

- [x] `dotnet build src/EasySave.UI/EasySave.UI.csproj` — 0 errors, 0 warnings.
- [x] EN ↔ FR locale parity: `diff` of `logs.*` keys returns empty.
- [ ] Select `<today>.xml` after a Run All on the 3.4 GB demo (~500 entries, ~70 KB) → yellow banner visible, content ends with the truncation footer, view stays responsive.
- [ ] Select a small log (< 150 lines) → no banner, no footer, content shown in full.
- [ ] Toggle FR/EN in the sidebar → static labels flip; the badge re-renders next time a file is selected (acceptable trade-off — documented behaviour).