### PR TITLE
fix(ui): pause/resume orchestrator jobs via PauseGate (no restart)

### DIFF
--- a/src/EasySave.UI/ViewModels/JobsViewModel.cs
+++ b/src/EasySave.UI/ViewModels/JobsViewModel.cs
@@ -20,22 +20,10 @@ public sealed partial class JobsViewModel : ViewModelBase
     private readonly IParallelBackupOrchestrator? _orchestrator;
     // Tracks jobs paused by the watcher (distinct from user-initiated pauses).
     private readonly HashSet<string> _watcherPausedJobs = new();
-    // Subset of _watcherPausedJobs: jobs stopped via the orchestrator (Run All
-    // path). Needed to route the resume back through orchestrator.RunAsync
-    // instead of _backup.ResumeJob, which is a no-op for orchestrator-tracked jobs.
-    private readonly HashSet<string> _watcherOrchestratorStoppedJobs = new();
     // Names currently executing inside the orchestrator (added at RunAllAsync start,
-    // removed in its finally). Used by OnBusinessSoftwareDetected to distinguish
-    // orchestrator-tracked from adapter-tracked jobs — only the former must be
-    // recorded in _watcherOrchestratorStoppedJobs to avoid double-starting.
+    // removed in its finally). Used to route Pause/Resume to the orchestrator's
+    // PauseGate instead of the adapter, which doesn't know about Run-All jobs.
     private readonly HashSet<string> _orchestratorTrackedJobs = new();
-    // User-paused jobs from the orchestrator path. Resume restarts them via
-    // orchestrator.RunAsync (the adapter doesn't know them). Restart is from
-    // file 0 until PR #180 wires resumeAfterPath into BackupManagerJobRunner.
-    private readonly HashSet<string> _orchestratorPausedJobs = new();
-    // Resume catch-up floor: holds the bar at the paused value while the
-    // engine re-walks the file list; cleared once entry.Progress >= floor.
-    private readonly Dictionary<string, int> _orchestratorResumeProgressFloor = new();
 
     // Set by MainWindowViewModel after construction.
     public Action<BackupJob?>? RequestOpenJobEdit { get; set; }
@@ -98,30 +86,13 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             var vm = Jobs.FirstOrDefault(j => j.Name == entry.Name);
             if (vm is null) return;
-            // orchestrator.Stop flushes an Inactive snapshot with
-            // FilesRemaining=0 → Progress=100; without this guard the bar
-            // would jump to 100 % under a Paused badge. Same race for Failed:
-            // the queued snapshot arrives after the run-loop finally has
-            // stamped Failed + Progress=0.
+            // Paused / Failed badges are owned by the UI controller (Pause click,
+            // exception path). Don't let a queued backend snapshot clobber them:
+            // on Pause the engine writes state=Paused but FilesRemaining is
+            // preserved, so vm.Progress stays accurate from the previous Active tick.
             if (vm.UiState is not (UiJobState.Paused or UiJobState.Failed))
             {
-                int reported = (int)entry.Progress;
-                if (_orchestratorResumeProgressFloor.TryGetValue(entry.Name, out var floor))
-                {
-                    if (reported >= floor)
-                    {
-                        _orchestratorResumeProgressFloor.Remove(entry.Name);
-                        vm.Progress = reported;
-                    }
-                    else
-                    {
-                        vm.Progress = floor;
-                    }
-                }
-                else
-                {
-                    vm.Progress = reported;
-                }
+                vm.Progress = (int)entry.Progress;
                 vm.CurrentFile = entry.CurrentSource;
                 vm.FilesRemaining = entry.FilesRemaining;
             }
@@ -131,17 +102,11 @@ public sealed partial class JobsViewModel : ViewModelBase
                 if (vm.UiState is UiJobState.Idle or UiJobState.Completed or UiJobState.Failed)
                     vm.UiState = UiJobState.Running;
             }
-            else
+            else if (entry.State == JobState.Inactive)
             {
-                // Backend finished (Inactive): mark Completed when the job ran to
-                // its end (no remaining files), otherwise fall back to Idle so a
-                // job that exited via pause/cancel doesn't claim success.
-                // Skip when the run-loop already stamped Failed or Paused — those
-                // badges are owned by the UI controller (exception path / Pause
-                // button) and the backend's Inactive snapshot must not clobber
-                // them. Pause on the Run-All path triggers orchestrator.Stop()
-                // which immediately flushes Inactive; without this guard the
-                // badge flashed from Paused to Idle/Completed within one tick.
+                // Backend finished: mark Completed when the job ran to its end,
+                // otherwise Idle. Skip when the run-loop already stamped Failed
+                // or Paused — those badges are owned by the UI controller.
                 if (vm.UiState is not (UiJobState.Failed or UiJobState.Paused))
                 {
                     vm.UiState = entry.FilesRemaining == 0 && entry.TotalFilesEligible > 0
@@ -149,10 +114,6 @@ public sealed partial class JobsViewModel : ViewModelBase
                         : UiJobState.Idle;
                 }
                 _watcherPausedJobs.Remove(vm.Name);
-                _watcherOrchestratorStoppedJobs.Remove(vm.Name);
-                // _orchestratorPausedJobs is owned by Pause/Resume — clearing
-                // it here would happen on the post-Stop Inactive snapshot and
-                // break the next Resume.
             }
         });
     }
@@ -167,17 +128,13 @@ public sealed partial class JobsViewModel : ViewModelBase
         {
             _watcherPausedJobs.Add(job.Name);
             job.UiState = UiJobState.Paused;
+            // Adapter PauseJob: no-op for orchestrator-tracked jobs, real pause for
+            // single-run jobs. Orchestrator.Pause resets the per-job PauseGate so
+            // Run-All-launched jobs stall at the next file boundary without giving up
+            // their slot — Resume continues from the same offset, no restart.
             _backup.PauseJob(job.Name, $"BusinessSoftwareDetected: {name}");
-            // Mirror the wiring already in place for the manual Pause button:
-            // jobs launched by Run All are tracked in the orchestrator, not in
-            // the adapter, so PauseJob above is a no-op for them. Stop() cancels
-            // the per-job CTS and halts the worker at the next file boundary.
-            if (_orchestrator is not null)
-            {
-                _orchestrator.Stop(job.Name);
-                if (_orchestratorTrackedJobs.Contains(job.Name))
-                    _watcherOrchestratorStoppedJobs.Add(job.Name);
-            }
+            if (_orchestrator is not null && _orchestratorTrackedJobs.Contains(job.Name))
+                _orchestrator.Pause(job.Name);
         }
     }
 
@@ -189,60 +146,15 @@ public sealed partial class JobsViewModel : ViewModelBase
         var toResume = Jobs
             .Where(j => j.UiState == UiJobState.Paused && _watcherPausedJobs.Contains(j.Name))
             .ToList();
-        var orchestratorRestart = toResume
-            .Where(j => _watcherOrchestratorStoppedJobs.Contains(j.Name))
-            .Select(j => j.Name)
-            .ToList();
         foreach (var job in toResume)
         {
             _watcherPausedJobs.Remove(job.Name);
-            _watcherOrchestratorStoppedJobs.Remove(job.Name);
             job.UiState = UiJobState.Running;
-            // Resumes adapter-tracked jobs (single-run path); no-op for orchestrator-tracked.
+            // Adapter ResumeJob handles single-run jobs; for orchestrator-tracked
+            // jobs the adapter is a no-op and the PauseGate signal does the work.
             _backup.ResumeJob(job.Name);
-        }
-        // Orchestrator-tracked jobs were stopped (one-way). Restart them.
-        // Limitation: restarts from the beginning of the job (resumeAfterPath is
-        // not propagated by BackupManagerJobRunner in this iteration — see PR #180).
-        // CS4014: intentional fire-and-forget; errors surface via StatusMessage.
-        if (orchestratorRestart.Count > 0)
-#pragma warning disable CS4014
-            RunWatcherOrchestratorJobsAsync(orchestratorRestart);
-#pragma warning restore CS4014
-    }
-
-    private async Task RunWatcherOrchestratorJobsAsync(IReadOnlyList<string> jobNames)
-    {
-        // Register the jobs as orchestrator-tracked so a subsequent user Pause
-        // click correctly routes through orchestrator.Stop and adds the job to
-        // _orchestratorPausedJobs. Without this, a Pause→Resume cycle launched
-        // by ResumeJob would leave the second Pause invisible to the engine —
-        // the badge would flip to Paused while the engine kept copying files.
-        foreach (var name in jobNames) _orchestratorTrackedJobs.Add(name);
-        try
-        {
-            await _orchestrator!.RunAsync(jobNames, CancellationToken.None).ConfigureAwait(true);
-        }
-        catch (Exception ex)
-        {
-            StatusMessage = ex.Message;
-        }
-        finally
-        {
-            foreach (var name in jobNames)
-            {
-                _orchestratorTrackedJobs.Remove(name);
-                var vm = Jobs.FirstOrDefault(j => j.Name == name);
-                if (vm?.UiState == UiJobState.Running)
-                {
-                    // If we end up here while still Running, the orchestrator
-                    // threw before publishing the final state. Drop the floor
-                    // so a future fresh Run is not clamped by it.
-                    _orchestratorResumeProgressFloor.Remove(name);
-                    vm.UiState = UiJobState.Idle;
-                    vm.Progress = 0;
-                }
-            }
+            if (_orchestrator is not null && _orchestratorTrackedJobs.Contains(job.Name))
+                _orchestrator.Resume(job.Name);
         }
     }
 
@@ -306,9 +218,6 @@ public sealed partial class JobsViewModel : ViewModelBase
             else if (vm.UiState == UiJobState.Running)
             {
                 vm.UiState = UiJobState.Idle;
-                // The job exited mid-flight (exception or external cancel) — wipe
-                // the leftover progress so the bar doesn't stay at e.g. 47% with
-                // an Idle badge until the next run starts.
                 vm.Progress = 0;
             }
             vm.CurrentFile = string.Empty;
@@ -339,10 +248,6 @@ public sealed partial class JobsViewModel : ViewModelBase
 
         // V3 path: when the parallel orchestrator is wired (GUI host), run
         // every eligible job concurrently bounded by max_parallel_jobs.
-        // Progress updates still flow through StateTracker → adapter
-        // .StateUpdated → OnStateUpdated, so the cards refresh as usual.
-        // Fallback (no orchestrator injected — e.g. unit tests of this
-        // ViewModel) keeps the original Task.WhenAll loop via the adapter.
         if (_orchestrator is not null)
         {
             foreach (var vm in eligible) _orchestratorTrackedJobs.Add(vm.Name);
@@ -352,9 +257,6 @@ public sealed partial class JobsViewModel : ViewModelBase
                     eligible.Select(j => j.Name),
                     CancellationToken.None).ConfigureAwait(true);
 
-                // Per-job results: stamp Failed/Cancelled messages on the
-                // matching card so the user sees which job failed and why
-                // even while the progress view is still open.
                 var resultByName = results.ToDictionary(r => r.JobName, StringComparer.Ordinal);
                 foreach (var vm in eligible)
                 {
@@ -363,7 +265,6 @@ public sealed partial class JobsViewModel : ViewModelBase
                     {
                         if (!string.IsNullOrEmpty(result.Message))
                             vm.LastError = result.Message;
-                        _orchestratorResumeProgressFloor.Remove(vm.Name);
                         vm.UiState = UiJobState.Failed;
                         vm.Progress = 0;
                     }
@@ -379,13 +280,6 @@ public sealed partial class JobsViewModel : ViewModelBase
             }
             finally
             {
-                // If the orchestrator threw (ObjectDisposedException on
-                // shutdown, ArgumentException on duplicate names) before
-                // the engine could publish its final state, the cards we
-                // promoted to Running above would otherwise stay stuck
-                // there. Reset only the cards we touched and only if they
-                // are still Running — leave cards the engine has already
-                // moved to Paused / Completed alone.
                 foreach (var vm in eligible)
                 {
                     _orchestratorTrackedJobs.Remove(vm.Name);
@@ -407,16 +301,12 @@ public sealed partial class JobsViewModel : ViewModelBase
     private void PauseJob(BackupJobVM vm)
     {
         vm.UiState = UiJobState.Paused;
-        // Run-All jobs (in the orchestrator): the v3 BackupManagerJobRunner
-        // does not honor ctx.PauseGate today, so orchestrator.Pause() would
-        // be a no-op. Use orchestrator.Stop() which cancels the per-job CTS
-        // and stops the worker at the next file boundary. Resume on the
-        // same card restarts from the beginning of the job via the
-        // orchestrator (see ResumeJob).
+        // Run-All jobs (in the orchestrator): resetting the PauseGate stalls the
+        // worker at the next file boundary without releasing its slot, so Resume
+        // continues from the same offset — no restart, no progress floor needed.
         if (_orchestrator is not null && _orchestratorTrackedJobs.Contains(vm.Name))
         {
-            _orchestratorPausedJobs.Add(vm.Name);
-            _orchestrator.Stop(vm.Name);
+            _orchestrator.Pause(vm.Name);
             return;
         }
         // Single-Run jobs (in the adapter): a real pause that stops the
@@ -430,21 +320,12 @@ public sealed partial class JobsViewModel : ViewModelBase
     {
         if (IsBusinessSoftwareDetected) return;
         vm.UiState = UiJobState.Running;
-        // Run-All-launched jobs: Pause was actually a Stop on the orchestrator
-        // (one-way), so Resume cannot continue from the saved offset. Restart
-        // the job from scratch via the orchestrator — same pattern as the
-        // business-software watcher resume path. Limitation: progress restarts
-        // at 0 until BackupManagerJobRunner honours resumeAfterPath (PR #180).
-        if (_orchestrator is not null && _orchestratorPausedJobs.Remove(vm.Name))
+        // Run-All-launched jobs: signal the PauseGate so the worker thread
+        // (still parked at its file boundary) continues from where it stopped.
+        if (_orchestrator is not null && _orchestratorTrackedJobs.Contains(vm.Name))
         {
-            // Hold the bar at the paused-value while the engine re-copies
-            // up to that file. OnStateUpdated lifts the floor once
-            // entry.Progress catches up.
-            _orchestratorResumeProgressFloor[vm.Name] = vm.Progress;
             vm.LastError = string.Empty;
-#pragma warning disable CS4014
-            RunWatcherOrchestratorJobsAsync(new[] { vm.Name });
-#pragma warning restore CS4014
+            _orchestrator.Resume(vm.Name);
             return;
         }
         // Single-Run-launched jobs: the adapter holds the pause offset.

--- a/tests/EasySave.Tests.V2/JobsViewModelWatcherIntegrationTests.cs
+++ b/tests/EasySave.Tests.V2/JobsViewModelWatcherIntegrationTests.cs
@@ -42,9 +42,11 @@ public class JobsViewModelWatcherIntegrationTests
         public void Dispose() { }
     }
 
-    // Returns immediately — used for tests that only inspect Stop calls.
+    // Returns immediately — used for tests that only inspect Pause/Resume calls.
     private sealed class RecordingOrchestrator : IParallelBackupOrchestrator
     {
+        public List<string> PausedJobs { get; } = new();
+        public List<string> ResumedJobs { get; } = new();
         public List<string> StoppedJobs { get; } = new();
         public List<IReadOnlyList<string>> RunAsyncCalls { get; } = new();
 
@@ -56,8 +58,8 @@ public class JobsViewModelWatcherIntegrationTests
             return Task.FromResult<IReadOnlyList<JobResult>>(Array.Empty<JobResult>());
         }
 
-        public void Pause(string jobName) { }
-        public void Resume(string jobName) { }
+        public void Pause(string jobName) => PausedJobs.Add(jobName);
+        public void Resume(string jobName) => ResumedJobs.Add(jobName);
         public void Stop(string jobName) => StoppedJobs.Add(jobName);
         public void PauseAll() { }
         public void ResumeAll() { }
@@ -71,6 +73,8 @@ public class JobsViewModelWatcherIntegrationTests
     private sealed class BlockingOrchestrator : IParallelBackupOrchestrator
     {
         private readonly Task<IReadOnlyList<JobResult>> _runResult;
+        public List<string> PausedJobs { get; } = new();
+        public List<string> ResumedJobs { get; } = new();
         public List<string> StoppedJobs { get; } = new();
         public List<IReadOnlyList<string>> RunAsyncCalls { get; } = new();
 
@@ -86,8 +90,8 @@ public class JobsViewModelWatcherIntegrationTests
         }
 
         public void Stop(string jobName) => StoppedJobs.Add(jobName);
-        public void Pause(string jobName) { }
-        public void Resume(string jobName) { }
+        public void Pause(string jobName) => PausedJobs.Add(jobName);
+        public void Resume(string jobName) => ResumedJobs.Add(jobName);
         public void PauseAll() { }
         public void ResumeAll() { }
         public void StopAll() { }
@@ -104,69 +108,74 @@ public class JobsViewModelWatcherIntegrationTests
     // ── Tests ─────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void OnBusinessSoftwareDetected_StopsRunAllJobsViaOrchestrator()
+    public async Task OnBusinessSoftwareDetected_PausesRunAllJobsViaOrchestratorPauseGate()
     {
-        var signals = new StubSignals();
-        var adapter = new RecordingAdapter();
-        var orchestrator = new RecordingOrchestrator();
-        var sut = new JobsViewModel(adapter, signals, orchestrator);
-
-        var job1 = MakeVm("Job1", UiJobState.Running);
-        var job2 = MakeVm("Job2", UiJobState.Running);
-        sut.Jobs.Add(job1);
-        sut.Jobs.Add(job2);
-
-        signals.RaiseDetected("calc");
-
-        Assert.Contains("Job1", orchestrator.StoppedJobs);
-        Assert.Contains("Job2", orchestrator.StoppedJobs);
-        Assert.Equal(UiJobState.Paused, job1.UiState);
-        Assert.Equal(UiJobState.Paused, job2.UiState);
-        // Adapter PauseJob is also called (covers single-run jobs on the same path).
-        Assert.Contains("Job1", adapter.PausedJobs);
-        Assert.Contains("Job2", adapter.PausedJobs);
-    }
-
-    [Fact]
-    public async Task OnBusinessSoftwareGone_ResumesPreviouslyPausedOrchestratorJobs()
-    {
-        // Use a blocking orchestrator so that RunAllAsync is still in flight
-        // (and _orchestratorTrackedJobs is populated) when the watcher fires.
+        // V3.1: orchestrator-tracked jobs are paused via orchestrator.Pause
+        // (resets the PauseGate) rather than Stop+restart. The worker thread
+        // parks at the next file boundary and resumes from the same offset.
         var tcs = new TaskCompletionSource<IReadOnlyList<JobResult>>();
         var signals = new StubSignals();
         var adapter = new RecordingAdapter();
         var orchestrator = new BlockingOrchestrator(tcs.Task);
         var sut = new JobsViewModel(adapter, signals, orchestrator);
 
-        // Jobs start Idle so Run All picks them up.
         var job1 = MakeVm("Job1", UiJobState.Idle);
         var job2 = MakeVm("Job2", UiJobState.Idle);
         sut.Jobs.Add(job1);
         sut.Jobs.Add(job2);
 
-        // Run All executes synchronously up to "await _orchestrator.RunAsync()",
-        // registering Job1 and Job2 in _orchestratorTrackedJobs before yielding.
+        // RunAll registers both jobs in _orchestratorTrackedJobs and then blocks.
         var runAll = sut.RunAllCommand.ExecuteAsync(null);
 
-        // While the orchestrator is blocking: fire the watcher.
         signals.RaiseDetected("calc");
 
-        // Complete the orchestrator run so RunAll's finally clears _orchestratorTrackedJobs.
+        Assert.Contains("Job1", orchestrator.PausedJobs);
+        Assert.Contains("Job2", orchestrator.PausedJobs);
+        // Stop must NOT be called — the whole point is to keep the worker
+        // parked on the PauseGate so Resume picks up at the same file.
+        Assert.Empty(orchestrator.StoppedJobs);
+        Assert.Equal(UiJobState.Paused, job1.UiState);
+        Assert.Equal(UiJobState.Paused, job2.UiState);
+        // Adapter PauseJob is also called (covers single-run jobs on the same path).
+        Assert.Contains("Job1", adapter.PausedJobs);
+        Assert.Contains("Job2", adapter.PausedJobs);
+
         tcs.SetResult(Array.Empty<JobResult>());
         await runAll;
+    }
 
-        // Gone: orchestrator-tracked jobs must be restarted via RunAsync.
+    [Fact]
+    public async Task OnBusinessSoftwareGone_ResumesOrchestratorJobsViaPauseGate_NoRestart()
+    {
+        // V3.1: orchestrator-tracked jobs resume by signaling the PauseGate
+        // through orchestrator.Resume. The original RunAsync stays in flight
+        // (no second RunAsync call) — the worker thread continues from the
+        // paused file boundary.
+        var tcs = new TaskCompletionSource<IReadOnlyList<JobResult>>();
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new BlockingOrchestrator(tcs.Task);
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        var job1 = MakeVm("Job1", UiJobState.Idle);
+        var job2 = MakeVm("Job2", UiJobState.Idle);
+        sut.Jobs.Add(job1);
+        sut.Jobs.Add(job2);
+
+        var runAll = sut.RunAllCommand.ExecuteAsync(null);
+
+        signals.RaiseDetected("calc");
         signals.RaiseGone();
 
-        // Two RunAsync calls total: 1 for Run All, 1 for watcher restart.
-        Assert.Equal(2, orchestrator.RunAsyncCalls.Count);
-        var restarted = orchestrator.RunAsyncCalls[1];
-        Assert.Contains("Job1", restarted);
-        Assert.Contains("Job2", restarted);
-        // Jobs are not Paused after the restart (either Running while the
-        // fake orchestrator runs, or Idle once it completes immediately).
+        Assert.Contains("Job1", orchestrator.ResumedJobs);
+        Assert.Contains("Job2", orchestrator.ResumedJobs);
+        // Only one RunAsync — the original Run All. No restart was needed.
+        Assert.Single(orchestrator.RunAsyncCalls);
         Assert.NotEqual(UiJobState.Paused, job1.UiState);
         Assert.NotEqual(UiJobState.Paused, job2.UiState);
+
+        tcs.SetResult(Array.Empty<JobResult>());
+        await runAll;
     }
 
     [Fact]
@@ -184,22 +193,19 @@ public class JobsViewModelWatcherIntegrationTests
 
         signals.RaiseDetected("calc");
 
-        // Only the Running job should be stopped.
-        Assert.Equal(new[] { "Job1" }, orchestrator.StoppedJobs);
+        // Only the Running job should be paused.
         Assert.Equal(UiJobState.Paused, running.UiState);
-        // User-paused job must not be touched.
-        Assert.DoesNotContain("Job2", orchestrator.StoppedJobs);
+        Assert.DoesNotContain("Job2", orchestrator.PausedJobs);
         Assert.DoesNotContain("Job2", adapter.PausedJobs);
         Assert.Equal(UiJobState.Paused, userPaused.UiState);
     }
 
     [Fact]
-    public void OnBusinessSoftwareGone_AdapterTrackedJob_ResumesViaAdapterOnly_NoOrchestratorRestart()
+    public void OnBusinessSoftwareGone_AdapterTrackedJob_ResumesViaAdapterOnly_NoOrchestratorResume()
     {
-        // Regression guard for the double-start bug: a job started via the
-        // single-job Run card is adapter-tracked, not orchestrator-tracked.
-        // Even when an orchestrator is injected, Gone must NOT dispatch a
-        // second orchestrator.RunAsync for that job.
+        // Regression guard: a job started via the single-job Run card is
+        // adapter-tracked, not orchestrator-tracked. Even when an orchestrator
+        // is injected, Gone must NOT dispatch orchestrator.Resume for that job.
         var signals = new StubSignals();
         var adapter = new RecordingAdapter();
         var orchestrator = new RecordingOrchestrator();
@@ -215,7 +221,64 @@ public class JobsViewModelWatcherIntegrationTests
 
         // Adapter-side resume must have been called.
         Assert.Contains("Job1", adapter.ResumedJobs);
-        // Orchestrator must NOT have been asked to restart the job.
+        // Orchestrator must NOT have been asked to resume the job.
+        Assert.Empty(orchestrator.ResumedJobs);
         Assert.Empty(orchestrator.RunAsyncCalls);
+    }
+
+    [Fact]
+    public async Task PauseCommand_OrchestratorTrackedJob_CallsOrchestratorPause_NotStop()
+    {
+        // V3.1: a user click on the Pause button for a Run-All-launched job must
+        // route through orchestrator.Pause (PauseGate) so Resume picks up at
+        // the same offset. Stop+restart is the legacy behaviour we removed.
+        var tcs = new TaskCompletionSource<IReadOnlyList<JobResult>>();
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new BlockingOrchestrator(tcs.Task);
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        var job1 = MakeVm("Job1", UiJobState.Idle);
+        sut.Jobs.Add(job1);
+
+        var runAll = sut.RunAllCommand.ExecuteAsync(null);
+
+        sut.PauseJobCommand.Execute(job1);
+
+        Assert.Equal(UiJobState.Paused, job1.UiState);
+        Assert.Contains("Job1", orchestrator.PausedJobs);
+        Assert.Empty(orchestrator.StoppedJobs);
+
+        tcs.SetResult(Array.Empty<JobResult>());
+        await runAll;
+    }
+
+    [Fact]
+    public async Task ResumeCommand_OrchestratorTrackedJob_CallsOrchestratorResume_NoSecondRunAsync()
+    {
+        // V3.1: Resume of an orchestrator-tracked job signals the PauseGate
+        // — the worker thread continues from the paused file boundary.
+        // No second RunAsync is fired, no progress floor is needed.
+        var tcs = new TaskCompletionSource<IReadOnlyList<JobResult>>();
+        var signals = new StubSignals();
+        var adapter = new RecordingAdapter();
+        var orchestrator = new BlockingOrchestrator(tcs.Task);
+        var sut = new JobsViewModel(adapter, signals, orchestrator);
+
+        var job1 = MakeVm("Job1", UiJobState.Idle);
+        sut.Jobs.Add(job1);
+
+        var runAll = sut.RunAllCommand.ExecuteAsync(null);
+
+        sut.PauseJobCommand.Execute(job1);
+        sut.ResumeJobCommand.Execute(job1);
+
+        Assert.Equal(UiJobState.Running, job1.UiState);
+        Assert.Contains("Job1", orchestrator.ResumedJobs);
+        // Only the original Run All — no restart.
+        Assert.Single(orchestrator.RunAsyncCalls);
+
+        tcs.SetResult(Array.Empty<JobResult>());
+        await runAll;
     }
 }


### PR DESCRIPTION
## Summary

- Route Pause/Resume on Run-All-launched jobs through `orchestrator.Pause/Resume` (PauseGate) instead of `orchestrator.Stop` + restart.
- The worker thread parks at the next file boundary and resumes from the same offset — no rescan, no re-copy of already-transferred files.
- Drops the `_orchestratorResumeProgressFloor` / `_orchestratorPausedJobs` / `_watcherOrchestratorStoppedJobs` / `RunWatcherOrchestratorJobsAsync` workaround. `JobsViewModel` goes from 486 → 367 lines.

## Context

`BackupManagerJobRunner` already forwards `context.PauseGate` to `BackupManager.ExecuteJob`, and `BackupManager.RunJob` stalls on the gate at every file boundary (see `BackupManager.cs:268-299` and the existing `ExecuteJob_PauseGateReset_StateBecomesPausedThenResumes` test). The stale `// v3 BackupManagerJobRunner does not honor ctx.PauseGate today` comment in `JobsViewModel.PauseJob` was wrong — the runner does honor it. The UI was just calling `Stop` instead of `Pause`.

## What this fixes (user-visible)

1. **No more restart from file 0.** Resume continues at the exact file where Pause stopped.
2. **No more progress bar drop to 0% on Resume.** The bar stays at its paused value and progresses naturally.
3. **One run = one JobStarted entry in the daily log.** Pause/Resume produce `JobPaused` / `JobResumed` events between the two, not a fresh JobStarted.
4. Same fix applies when the business-software watcher (Calculator, Notepad, …) auto-pauses jobs — the job no longer loses its offset when the software closes.

## Test plan

- [x] `JobsViewModelWatcherIntegrationTests` (6 tests, 2 new): asserts PauseCommand/ResumeCommand on orchestrator-tracked jobs call `Pause/Resume` (not `Stop`), and that no second `RunAsync` is fired on Resume.
- [x] `BackupManagerPauseResumeTests.ExecuteJob_PauseGateReset_StateBecomesPausedThenResumes` still green (PauseGate path unchanged at the engine level).
- [x] Full test suite green except 4 pre-existing `SelfSignedCertProviderTests` failures (X509 PFX on macOS, unrelated).
- [ ] Manual smoke: Run All on 3 jobs, click Pause mid-run, verify progress holds; click Resume, verify the bar continues from the same value and no files are re-copied (check daily log + state.json `CurrentSource`).