### PR TITLE
fix(easylog): drop entry on permanent 4xx instead of retrying forever

### DIFF
--- a/src/EasyLog/HttpLogShipper.cs
+++ b/src/EasyLog/HttpLogShipper.cs
@@ -121,17 +121,30 @@ public sealed class HttpLogShipper : ILogShipper
         }
     }
 
-    // Retries a single entry with exponential backoff until POST succeeds
-    // or shutdown is requested. Order is preserved — we never advance to
-    // the next queued entry while the current one is still pending.
+    // Retries a single entry with exponential backoff until POST succeeds,
+    // a permanent error is observed, or shutdown is requested. Order is
+    // preserved — we never advance to the next queued entry while the
+    // current one is still pending a transient retry.
     private async Task ProcessSingleEntryAsync(LogEntry entry, CancellationToken ct)
     {
         int backoffIndex = 0;
         while (!ct.IsCancellationRequested)
         {
-            if (await TrySendAsync(entry, ct).ConfigureAwait(false))
+            var outcome = await TrySendAsync(entry, ct).ConfigureAwait(false);
+            switch (outcome)
             {
-                return;
+                case SendOutcome.Success:
+                    return;
+                case SendOutcome.DropPermanent:
+                    // 4xx: collector rejected the entry (schema mismatch,
+                    // auth, wrong route, payload too large, …). Retrying
+                    // can never succeed — drop the entry, trace it for
+                    // operators, and advance to the next queued one so
+                    // the channel does not grow unbounded behind it.
+                    return;
+                case SendOutcome.RetryTransient:
+                default:
+                    break;
             }
 
             TimeSpan delay = BackoffSchedule[Math.Min(backoffIndex, BackoffSchedule.Length - 1)];
@@ -147,28 +160,49 @@ public sealed class HttpLogShipper : ILogShipper
         }
     }
 
-    private async Task<bool> TrySendAsync(LogEntry entry, CancellationToken ct)
+    // Classifies the POST attempt into one of three buckets so
+    // ProcessSingleEntryAsync can decide between retry, drop, and advance.
+    // 2xx → Success; 5xx / network → RetryTransient; 4xx → DropPermanent.
+    private async Task<SendOutcome> TrySendAsync(LogEntry entry, CancellationToken ct)
     {
         try
         {
             using var content = JsonContent.Create(entry, options: PayloadOptions);
             using var response = await _http.PostAsync(_endpoint, content, ct).ConfigureAwait(false);
-            return response.IsSuccessStatusCode;
+            if (response.IsSuccessStatusCode) return SendOutcome.Success;
+            int status = (int)response.StatusCode;
+            if (status >= 500)
+            {
+                return SendOutcome.RetryTransient;
+            }
+            // 4xx (and any other non-2xx, non-5xx): permanent reject.
+            Trace.TraceError(
+                $"[EasyLog] HttpLogShipper dropping entry (job='{entry.JobName}', " +
+                $"source='{entry.SourceFile}'): collector returned {status} {response.ReasonPhrase}. " +
+                $"Retrying would not succeed — fix the endpoint, payload shape, or auth.");
+            return SendOutcome.DropPermanent;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            return false;
+            return SendOutcome.RetryTransient;
         }
         catch (HttpRequestException)
         {
-            return false;
+            return SendOutcome.RetryTransient;
         }
         catch (TaskCanceledException)
         {
             // Per-request timeout from HttpClient.Timeout — same handling
             // as a network failure.
-            return false;
+            return SendOutcome.RetryTransient;
         }
+    }
+
+    private enum SendOutcome
+    {
+        Success,
+        RetryTransient,
+        DropPermanent,
     }
 
     /// <inheritdoc />

--- a/tests/EasySave.Tests.V2/HttpLogShipperTests.cs
+++ b/tests/EasySave.Tests.V2/HttpLogShipperTests.cs
@@ -357,6 +357,77 @@ public class HttpLogShipperTests : IDisposable
             $"(observed {sw.ElapsedMilliseconds} ms for {totalEntries} calls; target >= 1000/s).");
     }
 
+    [Fact]
+    public async Task Append_DropsEntry_OnPermanent4xx_AndDeliversFollowingEntries()
+    {
+        // Regression guard for issue #215: a 4xx (collector schema mismatch,
+        // auth, wrong route, payload too large, …) must not pin the writer
+        // task forever. The head entry is dropped, traced, and the next
+        // queued entry must reach the collector.
+        int call = 0;
+        var handler = new RecordingHandler(_ =>
+        {
+            int current = Interlocked.Increment(ref call);
+            return current == 1
+                ? new HttpResponseMessage(HttpStatusCode.BadRequest)
+                : new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        shipper.Append(new LogEntry { JobName = "rejected", Timestamp = "t" });
+        shipper.Append(new LogEntry { JobName = "delivered", Timestamp = "t" });
+
+        // Only two handler calls expected: the 400 (entry A dropped without
+        // retry) and the 204 (entry B delivered). If the bug regressed,
+        // entry A would still be retrying and entry B would never ship.
+        await handler.WaitForRequestsAsync(2);
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("rejected",
+            JsonDocument.Parse(handler.Requests[0].Body)
+                .RootElement.GetProperty("JobName").GetString());
+        Assert.Equal("delivered",
+            JsonDocument.Parse(handler.Requests[1].Body)
+                .RootElement.GetProperty("JobName").GetString());
+    }
+
+    [Fact]
+    public async Task Append_RetriesEntry_OnTransient5xx_UntilCollectorRecovers()
+    {
+        // 5xx is transient — the shipper must keep retrying the same entry
+        // with backoff until it succeeds. Two failures (1s + 2s = 3s) then
+        // success on the third attempt; cap the wait at the backoff replay
+        // deadline already used by the network-recovery test above.
+        int call = 0;
+        var handler = new RecordingHandler(_ =>
+        {
+            int current = Interlocked.Increment(ref call);
+            return current <= 2
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                : new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await using var shipper = new HttpLogShipper(
+            new Uri("http://collector.local/logs"),
+            new HttpClient(handler));
+
+        shipper.Append(new LogEntry { JobName = "retry-5xx", Timestamp = "t" });
+
+        await handler.WaitForRequestsAsync(3, BackoffReplayDeadline);
+
+        Assert.Equal(3, handler.Requests.Count);
+        // Every attempt carries the SAME entry — no advance until success.
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.Equal("retry-5xx",
+                JsonDocument.Parse(handler.Requests[i].Body)
+                    .RootElement.GetProperty("JobName").GetString());
+        }
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // Recording handler — captures outgoing requests so tests can assert
     // method, URI and JSON body without spinning a real HTTP listener.


### PR DESCRIPTION
## Summary

Closes #215.

- `TrySendAsync` now returns a `SendOutcome` (`Success` / `RetryTransient` / `DropPermanent`) instead of a bool.
- 2xx → `Success`, 5xx + network exceptions → `RetryTransient`, 4xx → `DropPermanent`.
- `ProcessSingleEntryAsync` drops + traces the entry on `DropPermanent` and advances to the next queued entry, instead of looping forever with exponential backoff.

## Why

Per issue #215, `HttpLogShipper.TrySendAsync` collapsed every non-2xx response into "not sent", so a permanent 4xx (collector schema mismatch, auth, wrong route, payload too large, …) pinned the writer task on the head entry and grew the unbounded channel behind it. In `LogMode.Centralized` (no local fallback) every subsequent `Append` was silently lost — the caller-side returned success but nothing reached the collector. #183 closed in 2026-05-12, but follow-up PR #195 was a behaviour-preserving refactor and never touched the retry decision.

## Test plan

- [x] New `Append_DropsEntry_OnPermanent4xx_AndDeliversFollowingEntries`: handler returns `400` on entry A then `204` on entry B → A is dropped without retry, B is delivered, writer task stays alive. Regressing the bug would block this assertion (entry B never observed).
- [x] New `Append_RetriesEntry_OnTransient5xx_UntilCollectorRecovers`: handler returns `500` twice then `204` → entry retries with backoff (1s + 2s) and succeeds on the third attempt. Asserts every observed request carries the same entry payload (no advance until success).
- [x] All 14 `HttpLogShipperTests` green (12 existing + 2 new).
- [x] Full suite green except 4 pre-existing `SelfSignedCertProviderTests` failures (X509 PFX on macOS, unrelated).

## Scope

- `src/EasyLog/HttpLogShipper.cs` + `tests/EasySave.Tests.V2/HttpLogShipperTests.cs`.
- `ILogShipper.Append` surface unchanged. `IDailyLogger` (frozen v1.0) untouched.
- No behavioural change for 2xx, 5xx, or network failure paths — only 4xx now drops instead of retrying.